### PR TITLE
Reactive consistency: global LSN + appointed leader (Phase 1)

### DIFF
--- a/docs/consistency-and-partial-sync-plan.md
+++ b/docs/consistency-and-partial-sync-plan.md
@@ -1,0 +1,586 @@
+# Ed: Consistency & Partial Sync — Design Course
+
+> Status: **draft / living document.** Plots a general course toward two large
+> features. We are not committing to build all of this, or any of it, now.
+> Supersedes the CRDT-leaning `DISTRIBUTED_CONSISTENCY_PLAN.md` on the old
+> `comprehensive-crdt-implementation` branch.
+
+## Goals
+
+Two features we want Ed to grow into:
+
+1. **Partial / lazy sync.** A context should only hold the objects it actually
+   uses. Referenced-but-unaccessed objects (e.g. the `EdTable`s inside an
+   `EdSeq[EdTable]`) should not exist in memory until accessed, materialize on
+   access, and stop syncing after a period of disuse (eviction).
+
+2. **Eventual consistency.** All clients converge on an agreed state. On
+   divergence, the authoritative value is assigned ("snap to correct value").
+   Time-travel/replay through history is desirable.
+
+## Headline decision: one foundation, not two features
+
+Both features are consumers of a single missing primitive:
+
+> **A totally-ordered, durable operation log produced by a single sequencer
+> (the host), where every operation carries a global monotonic sequence number
+> (LSN).**
+
+Ed already reifies every mutation as a `Message` (CREATE/ASSIGN/UNASSIGN/
+TOUCH/DESTROY). The messages are not *ordered* or *retained*. Add LSNs + a
+durable log and:
+
+- **Consistency** = apply ops in LSN order; on gap/divergence, replay and let
+  the authority's value win.
+- **Time-travel** = replay the log to LSN `T` (full replicas only — see below).
+- **Lazy/partial sync** = the log is the durable source you materialize *from*,
+  and the thing that makes eviction *safe* (you can always re-fetch).
+
+Feature 1 therefore **depends on** Feature 2's log: without a durable backing, an
+object nobody has touched gets evicted everywhere → data loss. **Build the
+ordered log first.**
+
+## Why not CRDTs
+
+The old `comprehensive-crdt-implementation` branch went all-in on Y-CRDT (Yrs)
+via futhark FFI: a 1.9 MB `libyrs.dylib`, ~8,300 lines, vector clocks. Its own
+plan doc admitted the costs: 2–4× memory, "no traditional transactions," and
+sequence CRDTs (RGA/Logoot) as a multi-month long pole. CRDTs buy *leaderless*
+convergence — which we don't need, because Enu has a host. Decision: **drop
+CRDTs.** Keep one cheap idea from that world — the **LWW register** — as the
+reconciliation rule for scalar values (below). Mine the old branch for ideas,
+not code.
+
+## Model: per-object authority + per-object mode
+
+Everything reduces to a little per-object metadata, alongside the existing
+`EdFlags`:
+
+```
+{ authority: peer_id,  mode: optimistic | confirmed }
+```
+
+### Authority
+
+- Each object has an **authority** peer that sequences/validates its writes.
+- **Today:** Enu has a single obvious host. For shared/world state, authority =
+  host. The host runs scripts, saves data, hosts the durable log + snapshots.
+- **Future (door left open, not built now):** per-object authority/ownership so
+  clients can own their own objects and the host stops being central. This is
+  the standard game-networking ownership model. Introducing `authority` as a
+  field now (even when it is always the host) keeps this path open.
+- **Handoff:** on authority disconnect, reassign deterministically (oldest
+  remaining connection / fall back to host). Cheap; not real consensus.
+
+### Mode (per object)
+
+- **Optimistic (default):** apply locally immediately, broadcast, let the
+  authority assign canonical order; if the local value drifts from canonical,
+  snap to it.
+- **Confirmed:** the local write stays tentative until the authority acks an
+  order, then commits. Reserve for the few things that must not double-count or
+  briefly show a wrong value.
+
+Reconciliation differs by data shape:
+
+- **`EdValue[T]` (register):** drift correction is a whole-value overwrite —
+  i.e. **last-writer-wins**. Cheap, no metadata. Can even resolve leaderless via
+  deterministic tiebreak `(timestamp, peer_id)`.
+- **`EdSeq`/`EdTable`/`EdSet` (deltas):** reconciliation is "re-apply ops in the
+  authority's canonical order." Commutative ops (two adds) don't care; add-vs-
+  remove of the same element does, and the authority decides.
+
+### Sequence ordering semantics (decided)
+
+> **`EdSeq` index positions are guaranteed only within a single tick. They may
+> change on the next tick.**
+
+Verified safe against Enu: `units` is an `EdSeq[Unit]` used almost entirely via
+iteration / `find_first`; the only positional access is `units[0]` ("first
+unit"). Tables are keyed by generated ids. Nothing depends on stable indices
+across ticks. This rule lets the authority reorder concurrent inserts freely.
+
+## The CAP reality (why election stays simple)
+
+You **cannot** have invisible + reliable + single-leader + stay-writable-during-
+a-partition. Real consensus (Raft/Paxos) avoids split-brain by *refusing writes
+in the minority partition* — for a game that means "you can't place a block
+until the network heals." That is the opposite of what Enu wants.
+
+**Enu wants AP:** stay available, tolerate divergence, reconcile on merge.
+Therefore:
+
+- Use **simple deterministic authority** (host today; "oldest connection /
+  lowest peer-id," bully-style re-election later). **Do not** build Raft — it
+  would actively hurt the "keep playing through a hiccup" goal.
+- Spend the "aim high" budget on the things that actually make p2p feel good:
+  1. **Seamless authority handoff** on disconnect.
+  2. **Good reconciliation** — auto-resolve where safe (LWW / op-replay),
+     escalate to a "pick the winner" prompt only for genuine conflicts on
+     `confirmed` objects.
+  3. **Per-object modes** so the rare critical object can be strict while the
+     world stays loose and fast.
+
+Tolerable: higher-than-average data loss; throwing an error / prompting "pick
+the winner" on an irreconcilable split.
+
+## Single stream vs per-object streams (decided)
+
+Keep **one logical order (one sequencer, global LSNs) with filtered delivery.**
+Each op carries its global LSN; a client subscribed to objects {A,B} receives
+only A's and B's ops, each still globally LSN-tagged, and tracks a *frontier*
+(highest LSN with complete coverage of its subscription set).
+
+| | single physical stream | per-object streams | **global order + filtered delivery** |
+|---|---|---|---|
+| Partial sync | no | yes | **yes** |
+| Transactions | trivial | hard (2PC / vector clocks) | **atomic LSN batch at authority** |
+| Global time-travel | yes | no common clock | **full replica only; scoped for partial clients** |
+
+Do **not** physically fragment into independent per-object logs — it makes
+transactions and global time-travel require vector clocks / distributed
+snapshots, sliding back toward CRDT-grade complexity.
+
+## What is impossible / reconsidered
+
+- **Full global time-travel on a thin client** is not a thing — you can only
+  replay history for objects you hold (or fetch). **Decision (accepted):**
+  global time-travel/replay is a **full-replica (host) capability** only.
+  Partial clients get scoped history at most.
+- **Leaderless + transactions + simple** can't coexist (CAP). Resolved by
+  choosing AP + host authority.
+
+## Serious tradeoffs to watch
+
+- **Optimistic flicker vs confirmed latency** — handled by per-object `mode`.
+- **Log growth** — needs snapshotting/compaction; time-travel depth bounded by
+  retention.
+- **Access-tracking overhead for eviction** — pervasive instrumentation on the
+  read hot path (`value` getter, `[]`, iteration). Needs measurement.
+- **Presence assertions are the #1 code obstacle.** `change_receiver` does
+  `assert object_id in self.ctx`; `process_message` requires resident objects.
+  Partial/lazy sync means an op can legitimately reference a non-resident
+  object. Every such site must become a **lazy-fetch-or-defer hook**.
+
+## Where the schema work fits
+
+The in-flight `TypeSchema` work was aimed at partial subscribers. Its real
+justification is **log durability / versioning**: a persisted log outlives the
+code that wrote it, so reading old entries whose types have since changed needs
+a schema. Re-aim it at the log format (Phase 2), not as a partial-subscriber
+band-aid.
+
+The **forwarding partial subscriber** stays useful as a Phase 0 relay primitive
+(a relay is the degenerate partial replica).
+
+## Path from single-host to per-object authority
+
+Single-host is a **degenerate case** of per-object authority, not a different
+architecture. The host plays four **separable** roles; per-object authority only
+decentralizes the first:
+
+| Role | Single-host today | Under per-object authority |
+|---|---|---|
+| (a) **Write authority** — owns/validates writes, decides conflicts | host, for everything | **per object** (the change) |
+| (b) **Sequencer** — assigns global LSNs / total order | host | *can stay host* |
+| (c) **Durable log + snapshots** | host | *can stay host* |
+| (d) **Script execution** | host | moves to clients later (Enu-specific) |
+
+Key insight: **(a) can decentralize while (b) and (c) stay central.** That
+intermediate stop — peers own their objects' *writes*, but ops still flow
+through the host for global ordering + durability — is **"federated," not pure
+p2p.** It keeps transactions + global time-travel working and is a far smaller
+step than full decentralization. It is almost certainly the right next stop for
+Enu, and probably far enough for a long time.
+
+**The fork you eventually hit** is whether global order survives:
+
+- **Federated (recommended next stop):** host stays sequencer + log forever — it
+  becomes "the timeline keeper," not "the decider." Peers get write authority;
+  ops still get a global LSN from the host. Transactions + global time-travel
+  survive. Small step.
+- **Fully decentralized (later, maybe never):** per-object LSN streams, no global
+  order. True p2p, but transactions + global time-travel degrade to scoped/
+  best-effort. Big step.
+
+**Four "cheap insurance" moves to bake into Phase 1** so the federated step is a
+loosened constraint, not a rewrite:
+
+1. **Model `authority` as per-object metadata from day one**, even though it is
+   always the host. Route writes through `authority_of(obj)` (currently returns
+   the host) — never hardcode "the host." Phase 6 = changing what that returns.
+2. **Make reconciliation deterministic**, not "host decides arbitrarily": LWW
+   with `(timestamp, peer_id)` tiebreak for values; canonical op-replay for
+   collections. Then it converges the same whether host or a peer decides.
+3. **Attribute ops to their authority** in the message/source layer, so trust is
+   "authorized by the object's authority," not "came from the host."
+4. **Keep the sequencer role and the authority role separate in code**, even
+   though one peer plays both now.
+
+## Host failover (host drops, ≥1 full replica)
+
+Semi-automatic failover is viable; surviving clients adopt the new host's state.
+
+- **Detection:** peers heartbeat the host; timeout ⇒ considered gone. Timeout
+  tuning trades failover speed against false positives (a slow host treated as
+  dead → split brain).
+- **Successor selection:** deterministic among full replicas. Tension between
+  *simplest* ("oldest connection / lowest peer-id") and *least data loss*
+  ("highest applied LSN"). Likely highest-LSN with id as tiebreak.
+- **State adoption + rollback wrinkle:** the new host's log is canonical. A
+  replica that optimistically applied ops *past* the new host's frontier (ops
+  the dead host sequenced but did not finish broadcasting) must **truncate/roll
+  back** to the new host's last LSN. So clients adopt the new host's state, with
+  possible loss of the last few in-flight ops (acceptable under our tolerance) —
+  but the rollback machinery must exist.
+- **Epoch/term (the one piece of consensus hygiene worth stealing):** bump a
+  monotonic `epoch` on every host change; tag every op with `(epoch, lsn)`;
+  higher epoch wins. Prevents a **zombie host** (slow host returns and resumes
+  sequencing) from corrupting everyone. Cheap now, painful to retrofit.
+
+### Failover & reconciliation policy (pluggable) — *decided*
+
+Resolution is **hookable**, with **auto-resolution by default** and a manual
+"pick the winner" prompt only as a **last resort** when no automatic winner can
+be determined — *not* on every network blip.
+
+- **Two hook points, one policy interface:**
+  - **Successor selection** (host dropped → choose new leader): usually no data
+    conflict, just pick who leads. (Subsumes the old "successor rule" question.)
+  - **Split-brain merge** (two diverged histories rejoin): real conflicting
+    writes — this is where "undecidable → escalate to user" lives.
+- **Canned policies:** oldest-connection-wins, most-activity/most-writes-wins,
+  highest-LSN / longest-log-wins (least data loss), lowest-peer-id (deterministic
+  tiebreak), and **escalate-to-user** as an explicit fallback a policy may return.
+- **Custom hook:** app supplies a resolver `(candidates) -> winner | undecidable`
+  over inputs like epoch, applied-LSN / log length, connection age, activity
+  metrics, peer id.
+- **Default:** auto-resolve; surface a prompt only when the resolver returns
+  *undecidable*.
+- **Open sub-decision — granularity:** does the winner decide **per partition**
+  (whole losing history discarded — simpler, loses more) or **per object**
+  (object-by-object merge — saves more, more undecidable cases)? The interface can
+  support either; we still need to pick a default. Plausibly per-object for
+  optimistic data, per-partition escalation only for `confirmed` objects.
+
+## Sync scopes — where consistency applies
+
+Correction to an earlier oversimplification: `SYNC_LOCAL` is **not** "outside
+consistency scope." The flags choose *which transports an object syncs over*, and
+**both** synced scopes need consistency:
+
+| Flags | Scope | Consistency? | Transport |
+|---|---|---|---|
+| neither | thread-local | **No** — the only exempt class | n/a (single thread) |
+| `SYNC_LOCAL` | cross-thread, intra-process | **Yes** — two threads can race the same object | reliable, ordered (channels); no partitions |
+| `SYNC_REMOTE` (usually + `SYNC_LOCAL`) | cross-network | **Yes** | lossy, reorderable, partitionable (netty) |
+
+Implications:
+
+- **Consistency machinery should be scope-agnostic** — the same LSN / log /
+  authority model applies whether "peers" are threads in a process or machines on
+  a network. A thread is just a peer with a cheaper, more reliable transport.
+- **CAP only bites at the network scope.** Cross-thread has ordered delivery and
+  no partitions, so it is the *easy* case — but still multi-writer, so it still
+  needs ordering + reconciliation.
+- **Authority generalizes to two levels.** *Decided (short term):* the local
+  authority is an **appointed leader thread**. For Enu the leader is the **worker
+  thread** (it runs the scripts that produce the authoritative simulation) and it
+  **wins conflicts**. The two levels compose: a `SYNC_REMOTE` object's global
+  authority is the **host's leader thread**; a `SYNC_LOCAL`-only object is
+  sequenced by the **local** leader thread. A write routes to that authority, gets
+  its LSN, then propagates out across threads and network from there.
+- **"Always appoint a leader thread" is a short-term simplification, not a model
+  constraint.** Other applications could have thread contexts as **true peers**
+  with no appointed leader. The design must keep this door open: treat *"does a
+  sequencer exist for this object's authority group?"* as the pivotal property,
+  resolved via `authority_of(obj)` — do **not** hardcode "local always has a
+  leader." A leaderless scope needs the same **convergence** primitives we already
+  plan (LWW-with-tiebreak, op-replay) but loses the single global LSN unless it
+  runs distributed ordering. So the peer-thread case is the **local-scope analog
+  of full p2p decentralization** — the same global-order-vs-per-object-convergence
+  fork. **Key relief:** even peer-threads **don't partition**, so they need
+  ordering/convergence but **not** partition tolerance / split-brain.
+- **Under the short-term assumption, election/failover is purely a network-scope
+  concern** — cross-thread has an appointed leader and no partitions, so all the
+  hard availability machinery stays on the network side. Treat this as an
+  implementation simplification we build first, with abstractions kept
+  **leader-agnostic** so a leaderless/peer scope can be added later.
+- **Implementation insight (de-risking):** Phase 1 (LSN + sequencer +
+  reconciliation) can be built and tested **entirely cross-thread first** —
+  deterministic, no netty — before adding the network's loss/partition
+  complications.
+
+## Consistency & durability levels (per object)
+
+These are **two different axes** we had been conflating:
+
+- **Consistency** = ordering/visibility/atomicity guarantees across replicas.
+- **Durability** = once acked, does the write survive a crash?
+
+Both become a per-object **ladder**, generalizing `mode` from a bool into a small
+enum:
+
+| Level | Consistency | Durability | Cost |
+|---|---|---|---|
+| 1. Optimistic, memory (default) | may snap back; flicker | lost if host crashes pre-save | fast, lossy |
+| 2. Confirmed | authority orders before ack; single-object linearizable, no flicker | loses uncommitted tail on crash | 1 round-trip |
+| 3. Confirmed + durable | as above | fsync before ack → survives host *restart* | + disk latency |
+| 4. Confirmed + replicated (quorum) | survives host *loss* with no data loss (**CP** for this object) | replicated to k replicas before ack | + round-trips, **blocks under partition** |
+
+Level 4 is **"AP by default, CP opt-in per object."** It also closes the failover
+data-loss gap: a quorum-replicated object loses nothing on host loss.
+
+**Reserve now:** make the **commit/ack point first-class** on the write path
+("ack after order" vs "after persist" vs "after replicate" = policy on one path),
+and make `mode` an extensible level, not a bool.
+
+## Data scenarios (grounded in Enu)
+
+| # | Scenario | Needs | Breaks under |
+|---|---|---|---|
+| A | Per-player avatar / my-bot edits | optimistic; authority = player | nothing |
+| B | Two players recolor the same block | LWW register + deterministic tiebreak | nothing (flicker ok) |
+| C | Two players add units to a shared `EdSeq` | op-replay in canonical order | stable-index assumptions (excluded) |
+| D | **Shared counter** (score, currency, resource count) | **serialized read-modify-write** at authority | plain LWW → **lost update** (10+1, 10+1 = 11) |
+| E | **Transfer** (item inventory A→B) | **atomic multi-object transaction** | non-atomic → item duplicated/vanishes |
+| F | **Claim a unique artifact / one-key door** | **serializable** (or single-object compare-and-set) | weaker → **write skew**: two players both claim |
+| G | **World invariant** (no two units per cell; total resources = N) | **serializable** transactions | weaker → invariant violated |
+| H | **A script reads many objects** (esp. once scripts move to clients) | **snapshot isolation** (consistent view as of one LSN) | weaker → script sees torn state |
+
+- **Requires serializable:** F and G (the **write-skew** anomaly — two txns each
+  individually valid, jointly violating a constraint). D needs serialized RMW,
+  not full serializability. E needs atomicity + isolation; **snapshot isolation**
+  usually suffices.
+- **H is the sleeper:** given the goal of clients running scripts, snapshot-
+  isolated reads matter — and they are *cheap* if you can reconstruct state as of
+  an LSN.
+- **Strategic insight:** with a single host sequencer, **serializable is nearly
+  free for the host-authoritative subset** (total order already exists). It gets
+  expensive only after authority decentralizes (cross-authority serializable
+  needs 2PC). ⇒ **Keep must-be-serializable objects (F, G) host-authoritative
+  even after per-object authority arrives.**
+- **Object exchange without transactions (the inventory case).** Model ownership
+  as a **single `owner` field on the owned object**, not as membership in two
+  separate inventory collections — inventories become *queries* ("items where
+  `owner == me`"). Then a one-way **give = a single-object authorized
+  compare-and-set on `owner`** — scenario **F**, not E: the item's authority
+  serializes it, so no duplication / double-spend and **no transaction**. Only a
+  true **atomic barter** (A↔B swap that must be both-or-neither) needs a real
+  transaction (two owner-flips committed together). Most exchange is one-way gives
+  or sequential accepts, so transactions stay *nice-to-have*, not required.
+
+### Enu object inventory (current — with caveats)
+
+Caveat: today's Enu is **not** representative of the target. Notably there is no
+in-game inventory yet (coming), and Ed is also intended as a **general data
+layer** beyond Enu (see next section). So this inventory validates the *model*
+but under-samples the harder scenarios (D/F/G), which arrive later.
+
+**Headline finding:** Enu **already event-sources its voxel world** —
+`voxels.nim` keeps `packed_chunks` (snapshots) + `chunk_deltas`
+(`EdTable[Vector3, EdSeq[DeltaUpdate]]`, an append-only delta log per chunk) and
+compacts to a new snapshot at `MAX_DELTAS_BEFORE_SNAPSHOT`. The global-log
+direction generalizes a pattern Enu already trusts. `chunk_deltas` is also a
+concrete **nested-Ed / lazy-materialization** case (table of seqs you don't want
+all resident).
+
+Classification of the reactive fields found:
+
+| Class | Examples (current) | Treatment |
+|---|---|---|
+| **Cross-thread only** (`SYNC_LOCAL`) | `Unit.collisions`, `Unit.sight_query`, `Unit.eval`, `*.local_flags`, `Player.block_log_entries`; likely the `net_*`/`voxel_tasks` telemetry | **still needs cross-thread consistency** — just not network sync. Truly exempt = objects with *neither* flag (see Sync scopes). |
+| **Plain optimistic LWW registers** (the fast-snap majority) | `Unit.{code,velocity,transform,glow,shared}`; `GameState.{player,open_unit,config,tool,open_sign,level_name,queued_action,status_message,...}`; `Player.input_direction` | optimistic, snap-to-correct. **This is most data.** |
+| **Collections** (op-replay, per-tick order) | `GameState.units : EdSeq[Unit]`; `console.log : EdSeq[string]`; `packed_chunks`/`chunk_deltas`; `*_flags` sets | op-replay in canonical order; id/position-keyed. `chunk_deltas` is the concurrency hotspot (two builders, same chunk → LWW per voxel cell). |
+| **Counters (D)** | none genuinely shared today (`voxel_tasks`/`net_*` look local/derived) | expect with inventory/economy (currency, scores, resource counts). |
+| **Unique-claim (F)** | `Unit.owner` / sign ownership (`players.nim`); `open_unit`/`open_sign` as an edit lock | host-arbitrated today; the F candidates. |
+| **Invariants (G)** | none hard today (voxel occupancy is LWW-per-cell, not a transaction) | expect with richer game/app rules. |
+| **Snapshot-iso reads (H)** | script execution (`worker.nim`, `host_bridge`) reads `units` + world state | the future-critical one once scripts move to clients. |
+
+Takeaways: (1) the **optimistic LWW + per-tick collections** model covers the
+overwhelming majority of *current* Enu state; (2) `SYNC_LOCAL` fields still need
+**cross-thread** consistency — only *no-flag* objects are exempt; (3) the genuinely
+hard scenarios (D/F/G) are mostly *future*, driven by inventory + the general-
+data-layer goal, not present today; (4) the voxel delta-log is both prior art for
+the global log and the first real concurrency hotspot.
+
+### Planned near-term features — first-pass classification
+
+All vague, all confirmed **not** transaction-hairy. Classification:
+
+| Feature | Data / writer | Trips | Treatment |
+|---|---|---|---|
+| **Script persistence** (0.3 course progress) — KV maps on a unit, one `SYNC_LOCAL` + one `SYNC_REMOTE` | per-unit KV; **single writer** (the unit's script on the leader thread) | none — even a `map["x"] += 1` is safe (single writer, no contention) | **optimistic, but durability-sensitive.** The real need is *don't lose progress* (durability), not consistency. First near-term feature that wants durable persistence. Maybe servable incrementally on Enu's **existing save path** + an `EdTable`, independent of the big refactor. Nested-Ed (table on a unit) → relevant to partial sync. |
+| **Games** (multiplayer tic-tac-toe, tetris) — host owns data; other scripts update but there is always a clear owner/winner | host-authoritative game state | **F** (claim a cell / spot), occasionally **D** (shared counters e.g. tetris garbage), all **host-serialized** | **host-authoritative optimistic + per-cell CAS.** This is exactly the single-authority model. "Clear owner/winner" = host arbitration → serializable-for-free. **First real use of `confirmed` mode = "make a move"** (don't render an unaccepted/illegal move). No transactions. |
+| **Action loops → AI agents / NPCs** (e.g. bot notified on script error, suggests a fix) | per-agent state-machine state (single writer); error/events (single producer, fan-out) | none typically; **F** if agents contend for a resource (owner-CAS) | **optimistic + reactive events** (the existing `track` mechanism). Reinforces **H** (snapshot reads) *once agents run off the leader thread*. No transactions. |
+| **(Long-term) Roblox-like ecosystem** — sell assets, publish worlds | balances, asset ownership, sales | **D + F + E** (real transactions) | the genuine future transaction driver (marketplace). Aligns with #11: **reserve, don't build.** ~20% of the way there. |
+
+**What this means for the design:**
+
+1. **No near-term feature needs transactions** — confirmed. They stay Phase 5+.
+2. **Durability, not consistency, is the first hard near-term requirement**
+   (script persistence): single-writer, optimistic, but must-not-lose. ⇒ the
+   **durability ladder + persistence (Phase 2)** earns near-term priority; the
+   conflict/reconciliation machinery is *less* urgent because near-term
+   contention is low and host-arbitrated. (Persistence may even land incrementally
+   on the existing save path, unblocking 0.3 without the full refactor.)
+3. **CAS-on-a-field (F) is the workhorse** for every "exactly one winner/owner"
+   case — game cells, item ownership, resource claims — not transactions.
+4. **`confirmed` mode's first concrete use is game moves.**
+5. **H (snapshot isolation) recurs**, always gated on compute moving *off* the
+   leader thread (agents/scripts on clients) — medium-term.
+
+## Ed beyond Enu (general data layer)
+
+Ed is intended to be a reasonable data layer for non-game apps too (eventually
+web apps), with — in the very distant future — a **read-only SQL interface** for
+visibility. Implications for *this* design:
+
+- **Multi-instance app servers map cleanly onto the model:** N app-server
+  instances = full replicas; the "host" generalizes to a **primary**. The
+  consistency/durability ladder and failover story carry over unchanged.
+- **Don't over-fit to game semantics.** General apps make D/F/G first-class:
+  shared counters (likes, balances), uniqueness constraints (usernames, slugs),
+  multi-object invariants. ⇒ **Transactions are a real eventual requirement, not
+  "maybe never"** — keep the Phase-5 framing reserved from the start.
+- **SQL read interface ⇒ two things we already want:** (a) **snapshot-isolated
+  reads** (a consistent view as of one LSN) — reinforces "state-as-of-LSN is
+  first-class"; (b) **runtime type/schema introspection** — a *third*
+  justification for the `TypeSchema` work (after partial-subscriber forwarding
+  and log versioning).
+
+## Optimistic write lifecycle & ack callback
+
+The two primary patterns are **fast local (optimistic, snap-to-correct)** for
+most data, and **slow fully-ack'd (confirmed)** for the few critical objects.
+For the fast pattern we also want to **know when an optimistic local write has
+been ack'd / become canonical** — a commit callback.
+
+Design notes:
+
+- This is distinct from the existing `track`/change callbacks (which fire on
+  *value change*). It fires on **commit outcome** for a specific write.
+- The outcome is richer than a bare ack — report **confirmed-as-is** vs
+  **corrected-to(X)** (your optimistic value held, vs it was superseded/snapped
+  to another value). That distinction is exactly what a UI wants ("saved" vs
+  "your edit was overridden").
+- **Reserve now:** every optimistic op carries a **client-generated op id**; the
+  authority echoes it back in the ordered/committed message so the originator can
+  correlate the ack and fire the callback. Correlation can also key off "the LSN
+  that subsumes my op reached my frontier." Cheap to add to the op/message format
+  now; annoying to retrofit.
+- API shape is open (a handle returned from the setter? `set(x, on_commit=...)`?
+  a per-object `track_commits`?) — see open questions.
+
+## CAP & database tradeoffs — reserve-now checklist
+
+The axes worth holding in mind, each with a now/later verdict:
+
+1. **CAP** — *decided:* AP default, CP opt-in per object. Reserve the mechanism
+   (epoch + future quorum); defer quorum itself.
+2. **PACELC** — even with no partition, stronger consistency costs **latency**.
+   Optimistic = "else latency," confirmed = "else consistency." Confirms the
+   per-object knob is the right shape.
+3. **Consistency model** (distinct from isolation): eventual → causal →
+   sequential → linearizable. Host-as-sequencer gives **sequential consistency
+   for free** on the ordered subset. *Now-relevant:* **causal delivery at the
+   partial boundary** — a partial replica could receive op B (references op A's
+   object) without A. *Reserve the rule:* never apply an op referencing state
+   past your LSN frontier; hold it pending.
+4. **Durability spectrum** — memory / fsync / quorum (the ladder above). *Now:*
+   first-class commit point.
+5. **Delivery semantics** — the LSN gives **idempotent-by-LSN apply** (re-applying
+   LSN N is a no-op), making replay-on-reconnect and failover-truncation safe.
+   *Now:* design every op idempotent under replay; record applied LSN.
+6. **Clocks** — wall-clock LWW tiebreak invites **clock-skew bugs**. *Now:* LSN
+   (logical order) is the **ordering truth**; wall-clock is only a tiebreak hint,
+   never the ordering authority. (HLC exists if wall-clock-meaningful causal
+   order is ever needed — likely never, with a sequencer.)
+7. **Membership / failure detection** — heartbeats + epochs. *Now:* epoch on host
+   identity (see Failover).
+8. **Compaction / snapshots** — bounds memory + time-travel depth. *Now:* design
+   the snapshot format alongside the log.
+9. **Schema evolution** — persisted log outlives code (the `TypeSchema` work's
+   real home).
+
+### Consolidated "reserve now" set (cheap now, expensive to retrofit)
+
+1. **`(epoch, lsn)` on every op and log entry** — failover hygiene + ordering truth.
+2. **First-class commit/ack point** (order → persist → replicate as policy on one
+   path); `mode` as an extensible level, not a bool.
+3. **Idempotent-by-LSN apply** — replay & rollback safety.
+4. **Log entry reserves `txn_id` + commit marker + schema version** — future
+   atomic transactions and schema evolution.
+5. **State-as-of-LSN reconstructable** — snapshot isolation, time-travel, and
+   failover truncation all need it.
+6. **LSN = ordering truth; wall-clock only a tiebreak hint.**
+7. **`authority_of(obj)` indirection**; keep must-be-serializable objects (F, G)
+   host-authoritative even post-decentralization.
+8. **Frontier rule:** never apply an op referencing state past your frontier
+   (causal safety at the partial boundary).
+9. **Client-generated op id on every op**, echoed back by the authority on
+   commit — enables the optimistic-write **ack/commit callback** (confirmed-as-is
+   vs corrected-to). Reuse for idempotent-by-LSN correlation.
+
+## Roadmap (order matters)
+
+- **Phase 0 — Plumbing (now, low risk).** Rebase `fix/changes-return-detection`
+  onto main (currently ~16 behind). Land forwarding partial subscriber. Defer /
+  re-aim the schema work.
+- **Phase 1 — Keystone: global LSN + sequencer.** Host stamps monotonic LSNs;
+  ordered in-memory log; gap-detection + replay request; reconciliation (LWW
+  snap for values, op-replay for collections). Add per-object `mode`
+  (optimistic/confirmed) and `authority` (always = host for now). Delivers
+  eventual consistency + "snap to correct value."
+- **Phase 2 — Durable log + snapshots.** Persist the ordered stream; snapshot
+  for compaction; schema-versioned log format. Full-replica time-travel/replay
+  falls out — prototype early as a debug/replay tool to validate the design.
+- **Phase 3 — Interest-based partial sync.** Subscribe to subsets; filtered,
+  LSN-tagged delivery; convert presence assertions → lazy-fetch hooks;
+  materialize-on-access.
+- **Phase 4 — Eviction.** Access tracking + TTL/LRU + unsubscribe. Safe only
+  because Phases 1–2 give a durable backing; re-access re-materializes.
+- **Phase 5 — Transactions (future).** Atomic LSN batches / commit records at
+  the authority; each client applies the slice touching its objects.
+- **Phase 6 — Per-object authority / p2p (future).** Generalize `authority`
+  beyond the host; ownership transfer; bully-style re-election. Opt-in
+  `confirmed`/transactional objects route through a coordinator when present.
+
+## Open questions / research
+
+1. **Optimistic vs confirmed boundary** — *near-term answer (resolved):*
+   optimistic-dominant. The only stricter near-term needs are (a) **durability**
+   for script persistence and (b) **`confirmed`/CAS** for game moves and
+   ownership. No transactions short-term. Revisit when features get concrete.
+   (See "Planned near-term features.")
+2. **Persistence/snapshot format + schema evolution** — the home for the schema
+   work.
+3. **Reference/causal integrity across the partial boundary** — exact semantics
+   for "op references an object I don't hold" (fetch? defer? drop?).
+4. **Access-tracking cost** — measure before committing to eviction design.
+5. **Authority handoff protocol** — detection + deterministic reassignment;
+   what state must transfer.
+
+### Decisions still needed from Scott (before/early in capture → build)
+
+6. **Split-brain merge policy** — *resolved:* pluggable policy, auto-resolve by
+   default, escalate to user only when undecidable (see Failover & reconciliation
+   policy). *Remaining:* per-object vs per-partition granularity + the default.
+7. **Failover UX (seamlessness)** — must failover be seamless (game keeps running,
+   needs tentative-state buffering) or is a brief "reconnecting…" pause
+   acceptable? (The *resolution* half is resolved; this *liveness* half is open.)
+8. **Concrete Enu object inventory** — *first pass done* (see "Planned near-term
+   features"): near-term work is optimistic + a little F/durability; D/G/E are
+   long-term (marketplace). *Remaining:* re-classify each feature as it gets
+   concrete, especially `confirmed` boundaries for games.
+9. **Successor selection rule** — *folded into* the pluggable policy (canned:
+   oldest / most-activity / highest-LSN / lowest-id). *Remaining:* pick the
+   default canned policy.
+10. **Ack/commit callback API shape** — handle returned from the setter vs
+    `set(x, on_commit = ...)` vs a per-object `track_commits`; and how it reports
+    confirmed-as-is vs corrected-to(X).
+11. **General-data-layer priorities** — *resolved:* far off / low priority. Do
+    **not** build transactions now; only avoid *precluding* them — keep the
+    reserve-now items (`txn_id` + commit record + schema version). Object exchange
+    (inventory) is handled by single-object `owner` CAS (scenario F), so no
+    short-term feature requires transactions. Stays Phase 5+.

--- a/docs/consistency-and-partial-sync-plan.md
+++ b/docs/consistency-and-partial-sync-plan.md
@@ -524,14 +524,21 @@ The axes worth holding in mind, each with a now/later verdict:
 
 ## Roadmap (order matters)
 
-- **Phase 0 — Plumbing (now, low risk).** Rebase `fix/changes-return-detection`
-  onto main (currently ~16 behind). Land forwarding partial subscriber. Defer /
-  re-aim the schema work.
-- **Phase 1 — Keystone: global LSN + sequencer.** Host stamps monotonic LSNs;
-  ordered in-memory log; gap-detection + replay request; reconciliation (LWW
-  snap for values, op-replay for collections). Add per-object `mode`
-  (optimistic/confirmed) and `authority` (always = host for now). Delivers
-  eventual consistency + "snap to correct value."
+> **Status:** Phase 1 is **done** and validated in Enu (branch
+> `feat/lsn-leader-ordering`, PR #10). Phase 0's forwarding partial subscriber is
+> still parked; Phases 2+ are future. Per-object `mode` (optimistic/confirmed)
+> and gap/replay buffering ended up **deferred** rather than landing in Phase 1 —
+> the implemented reconciliation is state-based forward correction with the
+> `op_id`-superseded rule (see `reconciliation-design.md`), not LWW-snap +
+> op-replay.
+
+- **Phase 0 — Plumbing (now, low risk).** Rebase onto main. Land forwarding
+  partial subscriber (still parked). Defer / re-aim the schema work.
+- **Phase 1 — Keystone: global LSN + sequencer. *(done)*** Worker (leader) stamps
+  monotonic LSNs; ordered apply + dedup + frontier; return-to-source;
+  reconciliation (op_id-superseded for registers, delta-dedup for collections);
+  `authority` = host. Delivers eventual consistency + smooth optimistic writes.
+  *Deferred from this phase:* durable log, per-object `mode`, gap/replay buffer.
 - **Phase 2 — Durable log + snapshots.** Persist the ordered stream; snapshot
   for compaction; schema-versioned log format. Full-replica time-travel/replay
   falls out — prototype early as a debug/replay tool to validate the design.

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -1,0 +1,119 @@
+# Phase 1 Keystone — Design Spike
+
+> Reconnaissance of Ed's current sync internals and where the Phase 1 keystone
+> (global LSN + appointed leader + ordered apply + reconciliation) plugs in.
+> Companion to `consistency-and-partial-sync-plan.md`. Scope: **cross-thread
+> first** (deterministic, no netty), per that plan's de-risking note.
+
+## How sync works today
+
+**Topology — symmetric peer mesh, no leader.** `EdContext.subscribe(ctx)`
+(`subscriptions.nim:384`) is bidirectional: each context adds a `LOCAL`
+`Subscription` holding the *other* context's inbox channel. Every context
+self-publishes its own changes directly to all subscribers. There is **no
+sequencer and no global order.**
+
+**Transport.**
+- Local (cross-thread): each `EdContext` has an inbox `chan: Chan[Message]`
+  (`pkg/threading/channels`); a `LOCAL` subscription holds the target's `chan`
+  (`types.nim:111`, `130`). Reliable, FIFO per sender, no partitions.
+- Remote: netty `Reactor` + per-sub `Connection`; flatty + snappy on the wire.
+
+**Mutation → message flow.**
+1. App mutates an `Ed` → `publish_changes` / `publish_create` / `publish_destroy`.
+2. `publish_changes` (`subscriptions.nim:306`) builds `Message`s via
+   `obj.build_message`, packs them, and for each subscriber **not** in
+   `op_ctx.source` calls `ctx.send(...)` (`:342-345`).
+3. `send` (`:178`) sets `msg.source_set` (echo-prevention) and for `LOCAL` subs
+   does `sub.chan.send(msg)` → pushes into the target's inbox.
+4. Target's `tick()` drains its `chan` via `try_recv` → `process_message(msg)`
+   (`:670-674`). Remote messages are uncompressed/deserialized and funnel to the
+   **same** `process_message` (`:776`).
+5. `process_message` (`:470`) decodes source and applies: `CREATE` → type
+   initializer; otherwise `obj.change_receiver(obj, msg, op_ctx)` (`:547-555`).
+
+**Echo prevention.** `OperationContext.source` is a `HashSet[string]` of context
+ids the change has already visited; a subscriber whose `ctx_id` is in `source` is
+skipped, and `source` grows as the op propagates through the mesh.
+
+**Ordering today — essentially none.** Channels give per-sender FIFO, but across
+senders/paths there is no global or per-object order, and **no conflict
+resolution** — whichever message is processed last clobbers (the "lost update"
+the old CRDT plan complained about). There *is* latent scaffolding:
+- `EdContext.last_msg_id` / `last_received_id` (`types.nim:132-133`) — per-peer
+  counters.
+- `Message.id` (`types.nim:64`) — assigned from `last_msg_id` in `send`
+  (`:187-192`) but **only under `-d:ed_trace`**, and per-destination, not global.
+- A receiver-side sequence check in `process_message` exists but is **commented
+  out**.
+
+So the bones of per-source sequencing exist; Phase 1 promotes them to a
+first-class, leader-assigned, global LSN and adds the apply-side ordering.
+
+## Insertion points (reserve-now primitive → where)
+
+| Primitive | Where |
+|---|---|
+| **`(epoch, lsn)` + `op_id` on every op** | add fields to `Message` (`types.nim:51`); wire into the custom `to_flatty`/`from_flatty(Message)` in `types.nim` (un-gate from `ed_trace`). Promote the `last_msg_id` idea into a real per-object LSN assigned by the authority. |
+| **Appointed leader / sequencer** | new `EdContext` state: `is_authority: bool` (or a `leader_id`), and an `authority_of(obj) -> ctx_id` indirection (constant = leader for now). Enu: the **worker-thread context** is the leader. |
+| **Ordered apply + dedup-by-LSN (frontier)** | `process_message` (`subscriptions.nim:470`) — the single apply point. Add per-object `applied_lsn`; `lsn <= applied_lsn` ⇒ idempotent no-op; `== applied_lsn+1` ⇒ apply; `> +1` ⇒ gap → buffer + request replay. |
+| **Reconciliation (snap-to-correct)** | also `process_message`: when an ordered op supersedes an optimistic local value, apply the authority value through the existing `change_receiver` path, gated by LSN + "is this my own op coming back?" (`op_id`). |
+| **Ack / commit callback** | originator tracks `pending_ops` by `op_id`; in `process_message`, after apply, if `msg.op_id` is pending, fire callback with outcome **confirmed-as-is vs corrected-to(X)**. |
+| **Durable log + persist** | Phase 2 — leader appends ordered ops; out of scope here. |
+
+## The one real design fork: routing model
+
+How does a non-leader write acquire its LSN?
+
+- **(a) Route-to-leader-first (the `confirmed` path):** the writer sends the op to
+  the authority, which assigns `(epoch, lsn)` and broadcasts the ordered op to
+  everyone (incl. the originator). The originator applies only on the ordered
+  echo. No flicker, 1 round-trip latency.
+- **(b) Optimistic local apply + leader re-stamp (the `optimistic` path):** the
+  writer applies locally and broadcasts now (≈ today's flow); the authority, on
+  receipt, assigns the canonical LSN and re-broadcasts the ordered version;
+  others reconcile/snap. Fast, may flicker.
+
+These are exactly the two **per-object modes** from the plan. Recommendation:
+**implement (b) first** (it's the primary "fast local + snap-to-correct" pattern
+and the smaller delta from today's optimistic broadcast), but lay the message +
+leader plumbing so **(a) slots in** for `confirmed` objects by selecting routing
+off the object's `mode`.
+
+## Proposed PR 1 — "LSN + appointed leader ordering (cross-thread)"
+
+Bounded, testable, minimal product-behavior change:
+
+1. Add `epoch`, `lsn`, `op_id` to `Message` + serializers (un-gate from
+   `ed_trace`).
+2. `EdContext`: `is_authority`/`leader_id`, `authority_of(obj)` (constant),
+   per-object `applied_lsn`, `pending_ops` for acks.
+3. Leader stamps `lsn` on its ordered broadcast; non-leader optimistic writes get
+   ordered at the leader and re-broadcast (model **b**).
+4. Apply side: LSN-ordered apply + dedup in `process_message`; reconciliation
+   snaps to authority value.
+5. Commit-callback plumbing (op_id echo → callback, with outcome).
+
+**Tests (in-process, two contexts, one leader):**
+- Concurrent writes to the same `EdValue` from two contexts → both converge to
+  the leader-ordered value.
+- Ack callback fires with `confirmed-as-is` for the winner, `corrected-to` for
+  the loser.
+- Re-delivering an already-applied LSN is a no-op (idempotency).
+- A collection (`EdSeq`) with concurrent adds → both present, order = leader order.
+
+## Risks / unknowns to resolve while building
+
+- **`PACKED` messages** (`subscriptions.nim:283`, `501`) batch multiple ops — LSN
+  assignment must handle a batch (one LSN per inner op, or per batch?).
+- **`SYNC_ALL_NO_OVERWRITE`** path and the subscribe-time bulk `publish_create`
+  (`add_subscriber`, `:349`) emit many CREATEs — ensure these get sensible LSNs
+  (initial snapshot vs live ops).
+- **Where exactly is the leader hop** for cross-thread, given the mesh has no
+  routing layer — likely: non-leader `send` to the leader sub only; leader
+  rebroadcasts. Need to confirm the cleanest splice into `publish_changes`/`send`.
+- **`op_ctx.source` interaction** — the new ordered re-broadcast must not be
+  suppressed by echo-prevention when it returns to the originator (it *must* come
+  back to drive the ack/snap). Reconcile LSN logic with the `source` skip.
+- **Per-object vs per-context LSN space** — per-object is cleaner for partial sync
+  later; per-context is simpler now. Decide early (leaning per-object).

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -177,6 +177,80 @@ short-id header is genuinely per-sub.
 4. **Relay topology (later).** The parked forwarding partial subscriber → host →
    relays → clients, turning host fanout O(N) into O(relays).
 
+## Ordered delivery: return-to-source, destroy ordering, and the optimism crux
+
+### Return-to-source is required (not a convenience)
+
+The originator of an optimistic write **must learn the LSN its own op was
+assigned**, or replicas diverge. Proof — A and B both write object X:
+
+- A's op → leader stamps `lsn=5`, fans to all **except A**.
+- B's op → leader stamps `lsn=6`, fans to all **except B**.
+- A applied its optimistic value, then receives B's `lsn=6` → snaps to B. **A = b.**
+- B applied `b` (no LSN — *floating*), then receives A's `lsn=5`. B can't tell its
+  own write is newer (it never heard `lsn=6`), so it applies `5` and clobbers its
+  own write. **B = a.** → **divergence.**
+
+So return-to-source is mandatory. What's returned can be the full op or a lean
+receipt (`op_id → lsn`, + value if it differs), but *some* return is required.
+Confirmed mode needs it too (it un-pends the write on return). Only fire-and-forget
+avoids it — and that can neither converge nor ack.
+
+### DESTROY must be ordered (CREATE may be deferred)
+
+CREATE is deferrable: ids are generated-unique, "exists" is monotonic, and the
+`id notin ctx` guards make concurrent creates idempotent. **DESTROY is not** —
+delete-vs-update is a real conflict. Worked example (partition):
+
+- Minority client destroys X; the DESTROY can't reach the leader.
+- Leader assigns X = v1 (`lsn=10`), v2 (`lsn=11`).
+- Heal. *Unordered destroy:* applies unconditionally → X gone everywhere, and the
+  leader's assigns hit "missing object" and vanish — **timing-dependent / can
+  diverge.** *Ordered destroy:* on heal the leader stamps it (`lsn=12`); canonical
+  order `10,11,12` → everyone converges to destroyed; late `≤ frontier` ops are
+  no-ops (the frontier is the tombstone). **Deterministic.**
+
+⇒ DESTROY joins the stamped/ordered/return-to-source path; CREATE stays deferred
+(concurrent same-id explicitly out of scope for now).
+
+**Policy note — delete-vs-update:** LSN-last-wins means a *stale* destroy (the
+destroyer never saw v1/v2) still wins if sequenced last ("delete beats concurrent
+updates"). If "an update should beat a stale delete" is wanted, the leader must
+reject a destroy of an object modified since the destroyer's observed version — a
+versioned/compare-and-set destroy (the `confirmed`/F flavor). Default =
+LSN-last-wins; the stricter policy is opt-in later.
+
+### The optimism crux (the next real decision)
+
+Surfaced while implementing: correct **model (b)** under contention needs more
+than return-to-source, because the optimistic local apply happens *before* the
+op's LSN position is known.
+
+- **Register loser:** B applies `b` optimistically, receives `a@5` (applies `a`),
+  then its own `b@6` returns. If B *skips* re-applying its own op → stays at `a`
+  (wrong). If it *re-applies* → correct for registers.
+- **Collection:** but *re-applying* a returned `seq.add` op **double-adds** the
+  item. Skipping is correct for collections, re-applying is wrong.
+
+So "skip own op" is right for collections and wrong for registers; "re-apply" is
+the reverse. The only model correct for *all* types is **apply each distinct op
+exactly once, in LSN order** — which means the optimistic local value must live in
+a **speculative layer** that is reconciled (rolled back + replayed, or
+equivalent) when the canonical stream arrives. We cannot simply suppress the local
+apply (existing code + tests rely on a mutation being immediately visible
+locally).
+
+**Decision needed (blocks the convergence demo):** how to do model (b) correctly —
+options to weigh: (i) speculative overlay with rollback/replay; (ii)
+`confirmed`-style apply as the default with opt-in optimism; (iii) register-LWW
+fast path + op-id effect-dedup for collections (correct per-type but two code
+paths). This is the heart of the consistency work and deserves its own design.
+
+**Until decided, we land the safe, type-agnostic foundation:** DESTROY stamping +
+**idempotent ordered apply** (LSN dedup + frontier advance) in `process_message`.
+This is correct and behavior-neutral for existing (no-authority) use, and sets up
+return-to-source. Routing changes and reconciliation wait on the decision above.
+
 ## Proposed PR 1 — "LSN + appointed leader ordering (cross-thread)"
 
 Bounded, testable, minimal product-behavior change:

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -56,7 +56,7 @@ first-class, leader-assigned, global LSN and adds the apply-side ordering.
 |---|---|
 | **`(epoch, lsn)` + `op_id` on every op** | add fields to `Message` (`types.nim:51`); wire into the custom `to_flatty`/`from_flatty(Message)` in `types.nim` (un-gate from `ed_trace`). Promote the `last_msg_id` idea into a real per-object LSN assigned by the authority. |
 | **Appointed leader / sequencer** | new `EdContext` state: `is_authority: bool` (or a `leader_id`), and an `authority_of(obj) -> ctx_id` indirection (constant = leader for now). Enu: the **worker-thread context** is the leader. |
-| **Ordered apply + dedup-by-LSN (frontier)** | `process_message` (`subscriptions.nim:470`) — the single apply point. Add per-object `applied_lsn`; `lsn <= applied_lsn` ⇒ idempotent no-op; `== applied_lsn+1` ⇒ apply; `> +1` ⇒ gap → buffer + request replay. |
+| **Ordered apply + dedup-by-LSN (frontier)** | `process_message` (`subscriptions.nim:470`) — the single apply point. Track a global `applied_lsn` (single int frontier for a full replica); `lsn <= applied_lsn` ⇒ idempotent no-op; `== applied_lsn+1` ⇒ apply; `> +1` ⇒ gap → buffer + request replay. `object_id` on each op keeps per-object frontiers derivable later. |
 | **Reconciliation (snap-to-correct)** | also `process_message`: when an ordered op supersedes an optimistic local value, apply the authority value through the existing `change_receiver` path, gated by LSN + "is this my own op coming back?" (`op_id`). |
 | **Ack / commit callback** | originator tracks `pending_ops` by `op_id`; in `process_message`, after apply, if `msg.op_id` is pending, fire callback with outcome **confirmed-as-is vs corrected-to(X)**. |
 | **Durable log + persist** | Phase 2 — leader appends ordered ops; out of scope here. |
@@ -74,11 +74,50 @@ How does a non-leader write acquire its LSN?
   receipt, assigns the canonical LSN and re-broadcasts the ordered version;
   others reconcile/snap. Fast, may flicker.
 
-These are exactly the two **per-object modes** from the plan. Recommendation:
-**implement (b) first** (it's the primary "fast local + snap-to-correct" pattern
-and the smaller delta from today's optimistic broadcast), but lay the message +
-leader plumbing so **(a) slots in** for `confirmed` objects by selecting routing
-off the object's `mode`.
+These are exactly the two **per-object modes** from the plan. *Decided:*
+**implement (b) first** (the primary "fast local + snap-to-correct" pattern and
+the smaller delta from today's optimistic broadcast); lay the message + leader
+plumbing so **(a) slots in** for `confirmed` objects by selecting routing off the
+object's `mode`.
+
+## LSN granularity — decided: global (per-context)
+
+*Decided:* **one global LSN per authority** for Phase 1, with `object_id` on every
+op so per-object frontiers are derivable later. Per-object LSN is the long-term
+future but far off; we keep a (laborious but clear) path to it rather than pay for
+it now.
+
+**The asymmetry that decides it:** a global LSN + `object_id` lets you *derive*
+per-object views; per-object LSNs cannot give global order without adding a global
+counter. Global is the more general primitive and the simpler Phase 1.
+
+**Regret analysis (pre-mortem).**
+
+- *We'd regret **global** LSN if:* Enu goes truly decentralized (per-object
+  authority / p2p) — one sequencer fights decentralization (funnel/SPOF), forcing
+  per-authority spaces + a merge layer; write throughput hits the single
+  sequencer's ceiling (per-object parallelizes across authorities); independent
+  worlds want to shard onto separate servers (global couples them into one
+  stream); split-brain can only discard a losing partition (per-object could merge
+  object-by-object). **All far-off and architectural — they coincide with the
+  already-deferred federated→p2p fork (Phase 6).**
+- *We'd regret **per-object** LSN if:* **causal ordering of inter-object
+  references** (the standout for Ed's ref-heavy model) — nothing guarantees a
+  referenced object's create applies before a reference to it, so you'd attach
+  causal-dependency metadata to every cross-object op (global gives "A before B"
+  free); multi-object script snapshot reads (scenario H) need a global point
+  anyway; cross-object transactions / global time-travel need a global cut. **All
+  near-term and pervasive.**
+
+**Path to per-object later (the seam we keep open):** `authority_of(obj)`
+indirection + `object_id` on every op (both already in PR 1). Migrating means
+per-authority epochs/sequence spaces, per-subscription frontiers for partial
+replicas, and a causal-dependency / merge layer for cross-object ordering — big
+work, but unblocked, not a corner.
+
+**Canaries we chose wrong:** wanting two independent worlds on one server, peers
+sequencing their own objects, or hitting the sequencer's write ceiling → revisit
+toward per-object.
 
 ## Routing & fanout — current behavior and plan
 
@@ -144,8 +183,9 @@ Bounded, testable, minimal product-behavior change:
 
 1. Add `epoch`, `lsn`, `op_id` to `Message` + serializers (un-gate from
    `ed_trace`).
-2. `EdContext`: `is_authority`/`leader_id`, `authority_of(obj)` (constant),
-   per-object `applied_lsn`, `pending_ops` for acks.
+2. `EdContext`: `is_authority`/`leader_id`, `authority_of(obj)` (constant), a
+   global `applied_lsn` frontier, `pending_ops` for acks. `object_id` stays on
+   every op (per-object frontiers derivable later).
 3. Leader stamps `lsn` on its ordered broadcast; non-leader optimistic writes get
    ordered at the leader and re-broadcast (model **b**).
 4. Apply side: LSN-ordered apply + dedup in `process_message`; reconciliation
@@ -179,5 +219,5 @@ Bounded, testable, minimal product-behavior change:
 - **`op_ctx.source` interaction** — the new ordered re-broadcast must not be
   suppressed by echo-prevention when it returns to the originator (it *must* come
   back to drive the ack/snap). Reconcile LSN logic with the `source` skip.
-- **Per-object vs per-context LSN space** — per-object is cleaner for partial sync
-  later; per-context is simpler now. Decide early (leaning per-object).
+- **LSN granularity** — *decided: global (per-context)*; see the dedicated
+  section above for the regret analysis and the path to per-object.

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -259,6 +259,15 @@ return-to-source. Routing changes and reconciliation wait on the decision above.
 
 ## Proposed PR 1 — "LSN + appointed leader ordering (cross-thread)"
 
+> **Status:** this was the original scope; PR 1 (branch `feat/lsn-leader-ordering`)
+> grew to cover all of it **plus** collection reconciliation, the
+> `op_id`-superseded register rule, flicker-free coalescing, robustness, and the
+> serialize-once fanout. Two items below drifted from what shipped: the
+> `EdContext` ack field is `latest_op_id` (used for reconciliation, not a
+> `pending_ops` ack set), and item 4's "snaps to authority value" is really the
+> `op_id`-superseded rule. The ack-callback (item 5) and its test are **deferred**
+> (#10). See `reconciliation-design.md` for the implemented rules.
+
 Bounded, testable, minimal product-behavior change:
 
 1. Add `epoch`, `lsn`, `op_id` to `Message` + serializers (un-gate from

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -162,10 +162,15 @@ short-id header is genuinely per-sub.
 
 ### Plan
 
-1. **Serialize/compress once (PR 1).** Split a `Message` into a sub-independent
-   **body** (payload + `epoch`/`lsn`, flatty'd + snappy'd **once**) and a tiny
-   per-sub **header** (source short-ids). Biggest single fanout win; lives in the
-   same `send`/`publish_changes` code as the LSN format change.
+1. **Serialize/compress once — *done*.** A remote packet is now
+   `flatty((source_short_ids, new_mappings, compressed_body))`: the per-subscriber
+   header (source + mappings) is tiny, and the shared `compressed_body` (the
+   message with source stripped, flatty'd + snappy'd) is computed **once** per
+   fanout (`fanout` / `send_remote` / `remote_body` in `subscriptions.nim`).
+   `publish_changes`/`publish_destroy` fan out through it; `publish_create` still
+   uses per-sub `send` (same format, not yet shared — fine, CREATEs are colder).
+   **Envelope change:** the wire layout moved, so this is exactly the kind of
+   change the future `protocol_version` must bump on (see transport doc).
 2. **Per-subscription delivery state (Phase 2; design now).** Give each
    `Subscription` a mode: `op_stream` vs `resyncing`. Read netty
    `saturated`/`inQueue` + local chan depth; a far-behind sub switches to

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -190,7 +190,11 @@ Bounded, testable, minimal product-behavior change:
    ordered at the leader and re-broadcast (model **b**).
 4. Apply side: LSN-ordered apply + dedup in `process_message`; reconciliation
    snaps to authority value.
-5. Commit-callback plumbing (op_id echo → callback, with outcome).
+5. Commit-callback plumbing (op_id echo → callback, with outcome). **Deferred**
+   (open Q #10): the `op_id` field is in place, but the public callback API is on
+   hold until a short **options doc** — code examples for each shape (setter
+   handle / `on_commit=` / `track_commits`) plus **perf & correctness**
+   considerations, not just ergonomics — is written and a shape chosen.
 6. **Serialize/compress once per change** — split `Message` into a sub-independent
    body (serialized + compressed a single time, carrying payload + `epoch`/`lsn`)
    and a per-sub source header; the per-subscriber `send` loop only varies the

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -240,11 +240,12 @@ equivalent) when the canonical stream arrives. We cannot simply suppress the loc
 apply (existing code + tests rely on a mutation being immediately visible
 locally).
 
-**Decision needed (blocks the convergence demo):** how to do model (b) correctly —
-options to weigh: (i) speculative overlay with rollback/replay; (ii)
-`confirmed`-style apply as the default with opt-in optimism; (iii) register-LWW
-fast path + op-id effect-dedup for collections (correct per-type but two code
-paths). This is the heart of the consistency work and deserves its own design.
+**Resolved → `reconciliation-design.md`.** Chosen model: **state-based
+authority-driven forward correction** (not client-side rollback). The authority
+sends the canonical value/state forward; clients never roll back. The own-op rule
+("authority sends value, not an echo to replay") dissolves the register-vs-
+collection dilemma; collections (the voxel hot path) use op-id delta-dedup with
+state-snapshot resync (mirroring Enu's existing `MAX_DELTAS_BEFORE_SNAPSHOT`).
 
 **Until decided, we land the safe, type-agnostic foundation:** DESTROY stamping +
 **idempotent ordered apply** (LSN dedup + frontier advance) in `process_message`.

--- a/docs/phase-1-keystone-spike.md
+++ b/docs/phase-1-keystone-spike.md
@@ -80,6 +80,64 @@ and the smaller delta from today's optimistic broadcast), but lay the message +
 leader plumbing so **(a) slots in** for `confirmed` objects by selecting routing
 off the object's `mode`.
 
+## Routing & fanout — current behavior and plan
+
+The leader model **concentrates** all fanout at the host, so the existing fanout
+costs must be addressed alongside Phase 1, not after.
+
+### Blocking points (today)
+
+- **Local send blocks the producer.** `send_or_buffer` (`subscriptions.nim:160`)
+  with `buffer=false` — the `EdContext` **default** — calls `sub.chan.send`,
+  which blocks when the target inbox `Chan` (size **100**) is full → a slow
+  consumer thread stalls every producer feeding it. `buffer=true` instead grows an
+  **unbounded** in-memory `chan_buffer`.
+- **Remote connect spins.** `subscribe(address)` blocks in
+  `while not finished: reactor.tick` until ACK (`:444`).
+- **Subscribe pushes all state synchronously.** `add_subscriber` (`:349`)
+  `publish_create`s **every object** inline — an O(objects) serialize-and-send
+  burst per join.
+
+### Netty under backpressure
+
+Defaults: **492 B** UDP payload, **25 KB** max in-flight/connection, **250 ms**
+ack/retransmit, **10 s** timeout.
+
+- `send`/`divideAndSend` only queues parts into `conn.sendParts` — **never
+  blocks, never drops, unbounded queue.**
+- `tick`/`sendNeededParts` pushes ≤25 KB in-flight then flags `saturated` and
+  stops for that conn; unacked parts retransmit every 250 ms; `deleteAckedParts`
+  frees only a *contiguous acked prefix* → one early loss head-of-line-blocks the
+  whole queue.
+- Slow client ⇒ unbounded host-memory backlog + throughput capped at ~25 KB/RTT +
+  constant retransmits, until the 10 s timeout drops it.
+- netty exposes `saturated` / `inQueue` / throughput stats — **Ed reads none of
+  them.** No backpressure feedback into publishing.
+
+### The fanout cost (the bottleneck)
+
+`publish_changes` loops subscribers → `send` per sub → `send` runs
+`msg.to_flatty` + `.compress` **per subscriber** (`:232-237`). N clients ⇒ N×
+serialize + N× compress of an essentially identical payload. Only the source
+short-id header is genuinely per-sub.
+
+### Plan
+
+1. **Serialize/compress once (PR 1).** Split a `Message` into a sub-independent
+   **body** (payload + `epoch`/`lsn`, flatty'd + snappy'd **once**) and a tiny
+   per-sub **header** (source short-ids). Biggest single fanout win; lives in the
+   same `send`/`publish_changes` code as the LSN format change.
+2. **Per-subscription delivery state (Phase 2; design now).** Give each
+   `Subscription` a mode: `op_stream` vs `resyncing`. Read netty
+   `saturated`/`inQueue` + local chan depth; a far-behind sub switches to
+   **snapshot@LSN + tail** instead of replaying the op backlog — reuses the
+   durable-log/snapshot capability. (Backpressure handling and snapshot-resync are
+   the same mechanism.)
+3. **LSN queue compaction (Phase 2/3).** Per-object LSN lets a slow sub's queued
+   `ASSIGN`s collapse to last-value-wins per object.
+4. **Relay topology (later).** The parked forwarding partial subscriber → host →
+   relays → clients, turning host fanout O(N) into O(relays).
+
 ## Proposed PR 1 — "LSN + appointed leader ordering (cross-thread)"
 
 Bounded, testable, minimal product-behavior change:
@@ -93,6 +151,10 @@ Bounded, testable, minimal product-behavior change:
 4. Apply side: LSN-ordered apply + dedup in `process_message`; reconciliation
    snaps to authority value.
 5. Commit-callback plumbing (op_id echo → callback, with outcome).
+6. **Serialize/compress once per change** — split `Message` into a sub-independent
+   body (serialized + compressed a single time, carrying payload + `epoch`/`lsn`)
+   and a per-sub source header; the per-subscriber `send` loop only varies the
+   header, never re-runs `to_flatty`/`compress` on the body.
 
 **Tests (in-process, two contexts, one leader):**
 - Concurrent writes to the same `EdValue` from two contexts → both converge to
@@ -101,6 +163,8 @@ Bounded, testable, minimal product-behavior change:
   the loser.
 - Re-delivering an already-applied LSN is a no-op (idempotency).
 - A collection (`EdSeq`) with concurrent adds → both present, order = leader order.
+- **Fanout serializes/compresses the body once regardless of subscriber count**
+  (assert a single serialize/compress per change across N subscribers).
 
 ## Risks / unknowns to resolve while building
 

--- a/docs/reconciliation-design.md
+++ b/docs/reconciliation-design.md
@@ -100,19 +100,20 @@ multi-path meshes would additionally need the deferred reorder buffer.
 Collections keep the simpler rule below (own delta ops always skipped — no
 whole-value snap-back exists for element-level adds/removes).
 
-## Own-op handling (the load-bearing rule)
+## Collection own-op handling
 
-1. Originator applies optimistically (instant local feedback — unchanged from
-   today).
-2. Originator tags the op with a client-generated `op_id`, records it in a small
-   `pending` set, and sends it to the authority.
-3. Authority assigns the LSN and broadcasts the canonical op/value to everyone.
-4. On receiving an op whose `op_id` is in `pending`: **advance the frontier, drop
-   from `pending`, fire the ack (deferred, #10) — do NOT re-run the effect.** The
-   effect is already applied optimistically; the canonical truth either matches
-   (no-op) or a *later* higher-LSN op corrects it forward.
+Collections (`delta = true`) take the simpler path: an op we originated is
+**always skipped** when it echoes back — it was already applied optimistically,
+and a re-applied `seq.add` would duplicate. There's no whole-value snap-back to
+worry about (element-level adds/removes accumulate and resolve per element by
+LSN), so no op_id comparison is needed; other-origin collection ops apply
+normally. Implemented via the `delta` flag on the message; registers use the
+`op_id`-superseded rule above.
 
-This needs `op_id` on every op (the field exists) + a per-context `pending` set.
+*(Superseded note: an earlier draft proposed a `pending`-set rule that skipped
+**every** own op. That breaks register convergence — a writer whose own op is the
+canonical winner would never re-apply it — which is why the implemented rule
+distinguishes "stale own echo" from "our latest" via `op_id`.)*
 
 ## Ordering & frontier
 
@@ -141,9 +142,10 @@ This needs `op_id` on every op (the field exists) + a per-context `pending` set.
 
 ## Relationship to other work
 
-- Builds on increments 1–2 (LSN stamping, frontier, ordered `DESTROY`).
+- Builds on the LSN stamping, frontier, and ordered `DESTROY` work.
 - Reuses Enu's snapshot+delta voxel pattern for collection resync.
-- `op_id` ties into the deferred ack-callback (#10).
+- `op_id` now **drives** the register reconciliation rule (`latest_op_id` per
+  object) and will also feed the deferred ack-callback (#10) — same field.
 - Per-object frontier is the partial-sync-ready direction noted in the spike's
   LSN-granularity section.
 
@@ -154,13 +156,23 @@ This needs `op_id` on every op (the field exists) + a per-context `pending` set.
 - **delete-vs-update policy** (LSN-last-wins default vs versioned/CAS) — from the
   spike doc.
 
-## Implementation increments
+## Implementation status
 
-- **3a — own-op dedup + `pending` set.** `op_id` assignment, `pending` tracking,
-  the "don't re-run own op" rule. Makes registers correct under contention with no
-  rollback. (Enables return-to-source safely.)
-- **3b — collection delta-idempotent apply.** op-id effect-dedup for
-  seq/table/set — the voxel hot path.
-- **3c — forward correction + coalescing.** Authority sends canonical value/state
-  to losers; coalesced (flicker-free) delivery.
-- **3d — delete → restore flow.** Authority restores objects whose delete lost.
+**Done** (what actually shipped, in order):
+- LSN fields, authority designation + stamping, ordered `DESTROY`, idempotent
+  ordered apply (dedup + frontier).
+- **Return-to-source** — registers converge under contention.
+- **Collection** reconciliation — origin + `delta` own-op dedup (voxel hot path).
+- **Flicker-free coalescing** (within-tick).
+- **op_id-superseded register rule** — no snap-back; convergence preserved (this
+  superseded the earlier "skip-all-own" idea after the movement bug surfaced).
+- **Serialize-once fanout** — shared compressed body built once per fanout.
+- delete-vs-update convergence **verified** (restore not needed under
+  LSN-last-wins; the delete is sequenced and wins).
+
+**Deferred** (documented, not built):
+- OCC / versioned writes — eliminates the observer glitch on an in-flight write
+  vs an authoritative override.
+- Ack/commit callback (#10) — the `op_id` plumbing is now in place.
+- Snapshot-vs-delta resync threshold; stricter delete-vs-update policy + the
+  delete→restore flow above.

--- a/docs/reconciliation-design.md
+++ b/docs/reconciliation-design.md
@@ -1,0 +1,125 @@
+# Ed Reconciliation Design — state-based forward correction
+
+> How optimistic local writes are reconciled to canonical (leader-ordered) state.
+> Chosen model: **authority-driven forward correction**, not client-side rollback.
+> Companion to `phase-1-keystone-spike.md` (resolves its "optimism crux") and
+> `consistency-and-partial-sync-plan.md`.
+
+## The model
+
+The authority (leader) is the source of truth. Reconciliation happens by the
+authority pushing **forward corrections** — a fresh assign carrying the canonical
+value, or a create to restore a wrongly-deleted object. **Clients never roll
+back; they apply what arrives.** This is *state-based* replication (send the
+value/state) rather than *operation-based* (replay the delta), which makes
+corrections naturally idempotent and convergent.
+
+This dissolves the register-vs-collection "skip vs re-apply own op" dilemma with
+one rule:
+
+> **The authority never echoes your op back for you to replay — it sends you the
+> canonical value/state.** You apply optimistically for instant feedback; the
+> authority's later message *is* the correction (matching → no-op; differing →
+> snap forward).
+
+### Traffic reality (drives the emphasis)
+
+Registers are the majority of Enu *objects*, but **the bulk of Enu *traffic* is
+voxel updates — seqs and tables** (`chunk_deltas: EdTable[Vector3,
+EdSeq[DeltaUpdate]]`, `packed_chunks`). So collection reconciliation is the
+**performance-critical hot path**, not an edge case. Consequences:
+
+- The hot path reconciles via **idempotent *delta* application** (op-id dedup),
+  never full-state resend.
+- **Full-state snapshot** is reserved for resync / backpressure / new-subscriber
+  catch-up — which mirrors Enu's existing `MAX_DELTAS_BEFORE_SNAPSHOT`
+  snapshot+delta compaction. Our model reuses a pattern Enu already trusts.
+
+## Per-container reconciliation
+
+### `EdValue` (register) — the easy, idempotent case
+
+- An assign carries `(value, lsn)`. Apply iff `lsn > object's last-applied lsn`.
+  Idempotent; a stale lower-LSN value can't clobber a newer one.
+- Loser reconciliation = the authority's forward assign with the canonical value.
+  No rollback. (Coalesced delivery — below — makes this flicker-free.)
+- Registers therefore nearly fall out of the LSN frontier we already built.
+
+### `EdSeq` / `EdTable` / `EdSet` (collections) — the hot path
+
+- **Apply each distinct op exactly once, in LSN order**, via **op-id dedup**: an
+  op whose `op_id` you've already applied (your own optimistic op, or a
+  redelivery) advances the frontier but does **not** re-run the effect (so no
+  double-add). This is delta-based and cheap — required for voxel traffic.
+- **Resync path:** when a receiver is too far behind / a new subscriber joins /
+  backpressure trips, the authority sends a **state snapshot** (coalesced latest)
+  instead of replaying the delta backlog — reusing the voxel snapshot+delta
+  pattern. (Same mechanism as fanout queue-compaction; see spike doc.)
+- **Conflict semantics:** voxel cells are LWW-per-cell, resolved when deltas
+  compact into a snapshot; `EdSeq` index order is guaranteed only within a tick
+  (per the main plan). Add-vs-remove of the same element resolves by LSN order.
+
+## Own-op handling (the load-bearing rule)
+
+1. Originator applies optimistically (instant local feedback — unchanged from
+   today).
+2. Originator tags the op with a client-generated `op_id`, records it in a small
+   `pending` set, and sends it to the authority.
+3. Authority assigns the LSN and broadcasts the canonical op/value to everyone.
+4. On receiving an op whose `op_id` is in `pending`: **advance the frontier, drop
+   from `pending`, fire the ack (deferred, #10) — do NOT re-run the effect.** The
+   effect is already applied optimistically; the canonical truth either matches
+   (no-op) or a *later* higher-LSN op corrects it forward.
+
+This needs `op_id` on every op (the field exists) + a per-context `pending` set.
+
+## Ordering & frontier
+
+- Global LSN assigned by the authority (already built). Receivers track a
+  **per-object last-applied LSN** (derivable from global LSN + `object_id`),
+  because coalesced/snapshot delivery skips intermediate LSNs, so a single
+  contiguous counter no longer fits.
+- Stale guard: apply a value/op only if its `lsn` exceeds the object's
+  last-applied LSN.
+
+## Delete / restore flow
+
+- Optimistic delete on a client → forwarded to the authority.
+- Canonical says **deleted** → authority confirms (ordered `DESTROY`; the frontier
+  is the tombstone — ops `≤ N` are no-ops).
+- Canonical says **alive** (delete lost/rejected per the delete-vs-update policy in
+  the spike doc) → authority sends a **create/state to restore** the object on the
+  deleter. Forward correction, no rollback. A restore is just a higher-LSN op.
+
+## Optimistic flicker & coalescing
+
+- Naive per-op delivery: the loser briefly sees an intermediate value
+  (`b → a → b`). **Coalesced delivery** (send the latest canonical value/state per
+  object) removes the flicker *and* is the fanout/backpressure win — one
+  mechanism. Recommended default for the correction path.
+
+## Relationship to other work
+
+- Builds on increments 1–2 (LSN stamping, frontier, ordered `DESTROY`).
+- Reuses Enu's snapshot+delta voxel pattern for collection resync.
+- `op_id` ties into the deferred ack-callback (#10).
+- Per-object frontier is the partial-sync-ready direction noted in the spike's
+  LSN-granularity section.
+
+## Open decisions
+
+- **Collection conflict policy details** (cell-LWW timing; seq order per-tick).
+- **Snapshot-vs-delta threshold** for resync (reuse the `MAX_DELTAS` idea).
+- **delete-vs-update policy** (LSN-last-wins default vs versioned/CAS) — from the
+  spike doc.
+
+## Implementation increments
+
+- **3a — own-op dedup + `pending` set.** `op_id` assignment, `pending` tracking,
+  the "don't re-run own op" rule. Makes registers correct under contention with no
+  rollback. (Enables return-to-source safely.)
+- **3b — collection delta-idempotent apply.** op-id effect-dedup for
+  seq/table/set — the voxel hot path.
+- **3c — forward correction + coalescing.** Authority sends canonical value/state
+  to losers; coalesced (flicker-free) delivery.
+- **3d — delete → restore flow.** Authority restores objects whose delete lost.

--- a/docs/reconciliation-design.md
+++ b/docs/reconciliation-design.md
@@ -59,6 +59,47 @@ EdSeq[DeltaUpdate]]`, `packed_chunks`). So collection reconciliation is the
   compact into a snapshot; `EdSeq` index order is guaranteed only within a tick
   (per the main plan). Add-vs-remove of the same element resolves by LSN order.
 
+## Register own-op handling: the op_id-superseded rule
+
+A naive "re-apply your own echo by LSN" is correct for *convergence* but makes a
+continuously-writing entity (player movement) **snap back** to its own stale
+echoes — an old position update echoes from the authority ~1 RTT later and
+overwrites the entity's newer optimistic position. (Cross-thread the RTT is ~0 so
+it's invisible; over the network it's visible jitter.)
+
+The fix — for **registers** — is to skip your own echo *only when a later write
+of your own supersedes it*:
+
+- Each originated write gets a per-context `op_id`; we record `latest_op_id`
+  per object.
+- On a register op we originated (`origin == self`): if `op_id < latest_op_id[obj]`
+  it's **stale** (we've written newer) → advance the frontier, skip the effect →
+  *no snap-back*. If `op_id == latest_op_id[obj]` it's our **latest** → apply it →
+  a contended register still **converges** to the canonical value.
+- Other-origin ops are always applied — an **authoritative override** (e.g. a
+  script teleport) is accepted, and the entity re-bases onto it.
+
+This preserves convergence in all cases (the accept-override variant did **not** —
+it could leave two writers permanently divergent). It's a state-based form of
+**client-side prediction + server reconciliation** (game netcode; Replicache-style
+sync engines), valid here because we ship values over a single LSN-ordered stream.
+
+**Known limitation (accepted):** a forward write already *in flight* when an
+authoritative override lands gets a higher LSN than the override, so **observers**
+briefly see the stale position before the writer's re-based write supersedes it
+(one or a few self-correcting frames). The writer's own client is unaffected.
+Fully eliminating the observer glitch needs **versioned / conditional writes**
+(OCC — the authority rejects a write whose base was superseded); deferred as
+optional, since the case is rare and self-correcting.
+
+**Precondition:** the rule needs each object's ops delivered in its authority's
+LSN order — provided by the single-leader star topology (one upstream per leaf).
+It generalizes to per-object authority (per-object frontiers + `authority_of`);
+multi-path meshes would additionally need the deferred reorder buffer.
+
+Collections keep the simpler rule below (own delta ops always skipped — no
+whole-value snap-back exists for element-level adds/removes).
+
 ## Own-op handling (the load-bearing rule)
 
 1. Originator applies optimistically (instant local feedback — unchanged from

--- a/docs/transport-and-schema-compatibility.md
+++ b/docs/transport-and-schema-compatibility.md
@@ -1,0 +1,130 @@
+# Ed: Transport Hardening & Schema Compatibility
+
+> How to keep stray/incompatible peers from corrupting an Ed context, and when
+> (and when *not*) to bump a protocol version. Captures the "phantom connection"
+> discussion. No code yet — design notes for later.
+
+## The phantom-connection problem
+
+A UDP socket bound to a port receives **any** datagram sent there — including from
+unrelated processes, a stale prior run, or a **version-skewed peer** (e.g. an old
+Enu speaking an incompatible Ed wire format). Ed then tries to `from_flatty` the
+garbage and, in the worst case, **crashes the process** (an unhandled
+`IndexDefect` on a malformed buffer — observed when a test bound the default port
+9632 and received packets from a running old Enu).
+
+This is **accidental cross-talk**, not a malicious actor. So the right tools are
+lightweight validation, not crypto. Signing / transport encryption answers a
+*different* question (untrusted peers tampering/spoofing) and is overkill here —
+it would prevent cross-talk as a side effect, at much higher cost, and wouldn't
+help with the most common real cause (version skew). Defer it until Enu actually
+needs to defend against hostile players.
+
+### Layered defense (priority order)
+
+1. **Defensive deserialization (do first, independent of identity).** Wrap the
+   `uncompress.from_flatty(Message)` in `tick()` in try/except: on any failure,
+   **drop the packet and disconnect that connection** instead of crashing. A
+   malformed / hostile / wrong-version packet must never take down the process.
+   Everything below reduces *how often* this fires; this makes firing harmless.
+2. **Protocol magic + version on the Ed payload / handshake.** netty already puts
+   a `partMagic` on each packet (filters non-netty traffic); the gap is
+   **Ed-payload-level versioning**. Add `[ed_magic: uint32][protocol_version:
+   uint16]` to the SUBSCRIBE handshake (and ideally a cheap per-message magic).
+   Reject mismatches before deserializing. This is the highest-value identity
+   check — version skew during rollout is the common real cause.
+3. **Session nonce (complements version).** A random per-instance/per-subscription
+   nonce exchanged in SUBSCRIBE/ACK, checked on both ends, rejects *same-version
+   but wrong-session* traffic — a stale process at the same address/port, or two
+   unrelated Ed instances sharing a port. Cheap; pairs with the existing
+   handshake and stale-subscription sweep. Not security (a sniffer can echo it),
+   but right-sized for accidental cross-talk.
+4. **Signing / encryption — deferred.** For an untrusted-peer threat model
+   (authentication + integrity), not phantom connections. If added later it
+   subsumes (2)/(3), but you still want (1) (a bad MAC should drop, not crash).
+
+The **SUBSCRIBE handshake is the natural gate**: carry `{magic, version,
+session_nonce}`, refuse to establish a subscription on mismatch, tag the
+connection, then validate cheaply per message with (1) as the catch-all.
+
+## Two compatibility axes — don't conflate them
+
+The protocol version protects the **envelope**, not the **application schema**.
+These change independently.
+
+| Axis | What it covers | Changes | An old peer that disagrees… |
+|---|---|---|---|
+| **Envelope / transport** | `to_flatty(Message)` field list/order, source encoding, PACKED format, compression, handshake | **rare**, global | misparses *every* message |
+| **Application schema** | `type_id`/`tid` registry, the bytes inside `msg.obj` (object/enum layout) | frequent, per type | misparses *one* type, or reads an out-of-range value |
+
+**Key fact:** `tid(T) = hash($T)` — the hash of the type's **name string**, not its
+structure (`utils/misc.nim`; ref types hash the type name in `utils/typeids.nim`).
+This is what makes the cases below behave the way they do.
+
+### Decision rule for the envelope `protocol_version`
+
+> Bump it **only** when an old peer would misparse the message envelope /
+> handshake / transport framing — i.e. you changed `Message`'s wire layout or the
+> framing. Nothing else.
+
+The `epoch`/`lsn`/`op_id`/`origin`/`delta` additions on `feat/lsn-leader-ordering`
+were exactly such a change. App data-model changes are **not** envelope changes.
+
+### Do these require a bump?
+
+- **Add a new Ed object type** → **No.** New name → new `tid`. Old peers see an
+  unknown `type_id` and hit the `type_id notin type_initializers` path (fail
+  today, or skip under `ed_partial_subscriber`). Type-registry concern, additive,
+  the easy case.
+- **Add an `EdSet` with a new enum type** → **No.** `EdSet[NewEnum]` is a new type
+  name → new `tid`. Same as above.
+- **Add a value to an *existing* enum** → **No envelope bump — and this is the
+  dangerous case.** The enum's name is unchanged, so the containing type's `tid`
+  is unchanged. An old peer still has an initializer for that `tid`, deserializes
+  happily, and reads the new ordinal as an **out-of-range enum value** →
+  undefined/corrupt, **silently**. Caught by **neither** the envelope version
+  **nor** the name-based `tid`.
+
+## The real gap: silent structural breaks
+
+Because `tid` is name-based and there's no schema check, **any structural change
+to an *existing* type — a new field, a reordered field, a new enum value —
+silently breaks cross-version peers.** A manually-bumped version "fixes" this only
+if you remember every time; that's the fragile dance to avoid.
+
+Better, mostly-automatic options:
+
+1. **Structure-aware `tid` (best lightweight win).** Hash the type's *field layout
+   + enum members*, not just `$T`. Then any structural change → different `tid` →
+   old peers see an *unknown type* and fail safely (existing `notin
+   type_initializers` path) instead of corrupting. You never bump manually — a
+   type's identity *is* its shape. Tradeoffs: all-or-nothing per type (a changed
+   type simply won't sync across versions — fine for "everyone runs the same
+   build", less so for rolling upgrades), and **durable logs then need the schema
+   stored to read old entries** (the `TypeSchema` work's job).
+2. **Range-checked enum deserialization.** Cheap robustness so an unknown ordinal
+   is detected and dropped, never UB. Worth doing regardless.
+3. **`TypeSchema` on the wire (the parked work).** The path to *graceful*
+   cross-version handling and durable-log/schema evolution, rather than just safe
+   failure. See the spike doc — this is its real justification.
+
+## Bottom line
+
+- **Almost never** bump the envelope version for app changes — "new type? new
+  enum?" → **no**.
+- Bump the envelope version only for `Message`/handshake/transport framing changes
+  (rare).
+- The thing that actually bites is **structural changes to existing types being
+  silent** — a `tid`/schema concern, best solved by **structure-aware tids +
+  range-checked enums**, with `TypeSchema` for graceful evolution and durable
+  logs. Not a protocol-version counter.
+
+## Open items
+
+- Implement defensive deserialization (try/except + disconnect) — high value,
+  independent of everything else.
+- Add envelope `ed_magic` + `protocol_version` to the SUBSCRIBE handshake.
+- Add a session nonce to SUBSCRIBE/ACK.
+- Decide structure-aware `tid` vs `TypeSchema`-on-wire (or both: tids for
+  live-sync safety, schema for durable/graceful evolution).
+- Range-check enum deserialization.

--- a/docs/transport-and-schema-compatibility.md
+++ b/docs/transport-and-schema-compatibility.md
@@ -119,6 +119,82 @@ Better, mostly-automatic options:
   range-checked enums**, with `TypeSchema` for graceful evolution and durable
   logs. Not a protocol-version counter.
 
+## Principle: strict envelope, forgiving payload
+
+The whole posture below reduces to one rule:
+
+> **Strict on the envelope, forgiving on the payload.** The framing/version is the
+> one place a hard fail is right (you literally can't parse). Once a message
+> *parses*, an unfamiliar **type or value** should be logged-and-skipped or
+> relayed — not fatal.
+
+### Why we can relax now
+
+Ed's defensive "blow up on anything unexpected" was a *proxy for correctness
+verification* — when a missing TID or odd value was the only signal that something
+was wrong, treating every anomaly as serious was rational. The consistency layer
+(LSN ordering, frontier, reconciliation) now gives **independent, verifiable
+correctness**, so a single weird object is no longer evidence of systemic failure.
+We can downgrade many payload-level hard-fails to log-and-continue — especially
+once we accept version-skewed clients.
+
+### Triage of the hard-fail sites
+
+Survey: ~12 production hard-fails (`fail`/`do_assert`/`raise`), concentrated in
+`subscriptions.nim`, `initializers.nim`, `contexts.nim`; plus ~60 plain `assert`s
+(dev-only, stripped in release). Classify each:
+
+- **Keep hard** — envelope/transport framing, genuine corruption, and our own
+  routing invariants where continuing would corrupt shared state.
+- **Downgrade to log-and-skip/relay** — unknown `type_id` / missing initializer /
+  unregistered ref tid (e.g. `subscriptions.nim` "No type initializer for type",
+  the `do_assert lookup_type(...)`). The `ed_partial_subscriber` flag already does
+  this for some; make it the default policy, not a flag.
+- **Log loudly but continue** — our-own-invariant violations that are *not*
+  corrupting (e.g. the `assert self.id notin source` own-message guard already
+  logs an error before asserting). In production: log + drop the message.
+
+Pair with the defensive-deserialize backstop (drop packet + disconnect on parse
+failure) so even the "keep hard" cases isolate instead of crashing the process.
+
+## Relaying unknown types (older server, newer clients)
+
+A nice property of the leader model: **the authority can sequence and relay a
+message without understanding its type.** It has `type_id`, `object_id`, the
+opaque `obj` bytes, and the envelope fields (`lsn`/`origin`/`delta`) — enough to
+**assign an LSN and forward** to subscribers without deserializing the payload.
+
+So an **older server can relay newer clients' types it doesn't know**: it stamps
+the order and fans the opaque bytes out; clients that *do* know the type apply it.
+This needs:
+
+1. **Don't hard-fail on unknown type** (the relaxation above).
+2. **Store/forward opaque bytes** — the parked `EdDynamic` / forwarding-partial-
+   subscriber work.
+3. **Stamp LSN without applying** — the leader orders but keeps no typed state for
+   the object (pure relay).
+
+Crucially, `lsn`/`origin`/`delta` are **envelope-level**, so a relay can even
+coalesce/dedup correctly (e.g. honor `delta`) without knowing the type. Unknown
+types fall back to operation-based ordering (apply ops in LSN order); state-based
+forward-correction needs a peer that can apply, which the knowledgeable clients
+provide.
+
+## Versioning: two tiers (Ed envelope + app policy)
+
+- **Ed envelope `protocol_version`** — a constant bumped on `Message`/handshake/
+  transport-framing changes (the decision rule above). Exchanged in SUBSCRIBE;
+  Ed enforces envelope **compatibility** as a hard gate (can't parse → reject).
+- **App version (Enu)** — separate, carried opaquely in the handshake, enforced by
+  an **Ed-provided policy hook** so the app decides accept/reject (e.g. "reject
+  clients older than vX"). Enu's version moves independently of Ed's.
+
+These compose with relaying: keep the **envelope stable across app-type changes**
+(don't bump it for new types/enums), let the **app policy** gate on app version,
+and let an **envelope-compatible but app-newer** client relay its unknown types
+through an older server (previous section). Reject only on envelope incompatibility
+or an explicit app-version policy — not on "I don't recognize this type."
+
 ## Open items
 
 - Implement defensive deserialization (try/except + disconnect) — high value,
@@ -128,3 +204,11 @@ Better, mostly-automatic options:
 - Decide structure-aware `tid` vs `TypeSchema`-on-wire (or both: tids for
   live-sync safety, schema for durable/graceful evolution).
 - Range-check enum deserialization.
+- **Triage the hard-fail sites** (keep-hard / log-and-skip / log-and-continue);
+  make graceful payload handling the default rather than the `ed_partial_subscriber`
+  flag.
+- **Relay unknown types** at the authority (sequence + forward opaque bytes;
+  finish the `EdDynamic`/forwarding-partial-subscriber work).
+- **Two-tier versioning:** an Ed envelope `protocol_version` (hard gate) plus an
+  app-version policy hook (Enu rejects old clients). Decide how the policy hook is
+  exposed.

--- a/src/ed.nim
+++ b/src/ed.nim
@@ -25,3 +25,6 @@ export channels, flatty
 
 import ed/[types, zens, components, utils]
 export types, zens, components, utils
+
+import ed/client
+export client

--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -1,0 +1,96 @@
+## Connection helpers for keeping a remote `EdContext` subscribed and live.
+##
+## A context only stays healthy if it is `tick`ed regularly: ticking drives
+## netty's keepalives and reaps dead connections. Tick on a timer and
+## `connected` (subscribers present) becomes an authoritative liveness
+## signal — no application-level ping needed.
+
+import std/[times, monotimes, os]
+
+import ed/[types, utils/misc, utils/logging]
+import ed/zens/contexts
+import ed/components/subscriptions
+
+proc connected*(self: EdContext): bool =
+  ## True if at least one subscriber is live. Reliable as long as the
+  ## context is `tick`ed regularly (tick reaps dead connections).
+  self.subscribers.len > 0
+
+template every*(ctx: EdContext, interval: Duration, body: untyped) =
+  ## `tick` `ctx` then run `body`, every `interval`, until `body` `break`s.
+  ## The one loop primitive behind idle keepalives, change polling, and
+  ## frame-paced animation.
+  block:
+    let interval_ms = max(0, interval.in_milliseconds.int)
+    while true:
+      ctx.tick
+      body
+      sleep interval_ms
+
+const DEFAULT_RECONNECT_INTERVAL = init_duration(seconds = 1)
+
+type EdClient* = ref object
+  ## A remote `EdContext` that reconnects itself. `id` is stable across
+  ## reconnects so the peer can recognize and supersede the prior session.
+  id*: string
+  address*: string
+  chan_size*: int
+  on_connect*: proc()
+    ## (Re)create this client's objects after each (re)connect. Runs with
+    ## `Ed.thread_ctx` set to the fresh context. Single-threaded — runs on
+    ## the caller's thread, so it may touch the caller's globals.
+  ctx*: EdContext
+  reconnect_interval*: Duration
+    ## Minimum gap between re-subscribe attempts while down (default 1 s).
+    ## Re-subscribing tears down the context, so doing it every tick would
+    ## prevent any handshake from completing; the gap lets one settle.
+  last_attempt: MonoTime
+
+proc connect*(self: EdClient) =
+  ## (Re)create the context with the stable `id`, subscribe to `address`,
+  ## and run `on_connect`. Resilient: if the peer is unreachable the new
+  ## context simply has no subscribers, so a later `tick` retries.
+  self.last_attempt = get_mono_time()
+  if not self.ctx.is_nil:
+    self.ctx.close
+  let chan_size = if self.chan_size > 0: self.chan_size else: 100
+  self.ctx = EdContext.init(chan_size = chan_size, buffer = false, id = self.id)
+  Ed.thread_ctx = self.ctx
+  try:
+    self.ctx.subscribe(self.address)
+    if self.on_connect != nil:
+      self.on_connect()
+  except ConnectionError as e:
+    debug "EdClient connect failed; will retry",
+      address = self.address, msg = e.msg
+
+proc connected*(self: EdClient): bool =
+  not self.ctx.is_nil and self.ctx.connected
+
+proc ensure_connected*(self: EdClient) =
+  ## Reconnect if the link is down. Cheap when already connected.
+  if not self.connected:
+    self.connect
+
+proc tick*(self: EdClient) =
+  ## Tick the context, reconnecting if it has dropped. Call on a timer to
+  ## keep an otherwise-idle connection alive. While down, keep ticking the
+  ## existing context so an in-flight handshake can complete, and only
+  ## re-subscribe once per `reconnect_interval` — re-subscribing every tick
+  ## would restart the handshake before it finishes and spin the CPU.
+  if self.ctx.is_nil:
+    self.connect
+    return
+  try:
+    self.ctx.tick
+  except CatchableError as e:
+    debug "EdClient tick raised; reconnecting", msg = e.msg
+    self.connect
+    return
+  if self.ctx.connected:
+    return
+  let interval =
+    if self.reconnect_interval > DurationZero: self.reconnect_interval
+    else: DEFAULT_RECONNECT_INTERVAL
+  if get_mono_time() - self.last_attempt >= interval:
+    self.connect

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -264,6 +264,11 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   # so every subscriber receives the same ordered op. DESTROY is ordered like
   # ASSIGN — delete-vs-update is a real conflict (see spike doc).
   var msg = Message(kind: DESTROY, object_id: self.id)
+  msg.origin =
+    if op_ctx.origin != "":
+      op_ctx.origin
+    else:
+      self.ctx.id
   when defined(ed_trace):
     msg.trace = \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}"
   self.ctx.stamp_lsn(msg)
@@ -276,8 +281,12 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
 
 proc pack_messages(msgs: seq[Message]): seq[Message] =
   if msgs.len > 1:
-    var packed_msg =
-      Message(kind: PACKED, source: msgs[0].source, flags: msgs[0].flags)
+    var packed_msg = Message(
+      kind: PACKED,
+      source: msgs[0].source,
+      flags: msgs[0].flags,
+      delta: msgs[0].delta,
+    )
     var ops: seq[PackedMessageOperation]
 
     for msg in msgs:
@@ -333,9 +342,19 @@ proc publish_changes*[T, O](
 
       msgs = pack_messages(msgs)
 
+      # Tag each op with its origin (the original writer) so writers can dedup
+      # their own returned delta ops. Forwards preserve the incoming origin;
+      # original mutations stamp our own id.
+      let out_origin =
+        if op_ctx.origin != "":
+          op_ctx.origin
+        else:
+          self.ctx.id
+
       # Authority stamps each ordered op with its global LSN, once, before
       # fanout so every subscriber receives the same LSN.
       for msg in msgs.mitems:
+        msg.origin = out_origin
         self.ctx.stamp_lsn(msg)
 
       if self.ctx.is_authority:
@@ -542,6 +561,16 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       lsn = msg.lsn, frontier = self.applied_lsn
     return
 
+  # Own-op dedup: a delta (collection) op we originated has already been applied
+  # optimistically. When it returns canonically, advance the frontier (and ack,
+  # deferred #10) but don't re-run the effect — re-applying a seq.add would
+  # double it. Registers (delta = false) are re-applied by LSN so a losing
+  # optimistic write still converges to the canonical value.
+  if msg.delta and msg.origin == self.id:
+    if msg.lsn > self.applied_lsn:
+      self.applied_lsn = msg.lsn
+    return
+
   if msg.kind == PACKED:
     let ops = msg.obj.from_flatty(seq[PackedMessageOperation])
     for op in ops:
@@ -577,7 +606,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         self,
         msg.object_id,
         msg.flags,
-        OperationContext.init(source = source, ctx = self),
+        OperationContext.init(source = source, ctx = self, origin = msg.origin),
       )
       # :(
   elif msg.kind != BLANK:
@@ -587,7 +616,9 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       return
     let obj = self.objects[msg.object_id]
     obj.change_receiver(
-      obj, msg, op_ctx = OperationContext.init(source = source, ctx = self)
+      obj,
+      msg,
+      op_ctx = OperationContext.init(source = source, ctx = self, origin = msg.origin),
     )
     if msg.lsn > self.applied_lsn:
       self.applied_lsn = msg.lsn

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -338,10 +338,21 @@ proc publish_changes*[T, O](
       for msg in msgs.mitems:
         self.ctx.stamp_lsn(msg)
 
-      for sub in self.ctx.subscribers:
-        if sub.ctx_id notin op_ctx.source:
+      if self.ctx.is_authority:
+        # Canonical ops originate from the authority. Re-origin the source to us
+        # and deliver to ALL subscribers — including the original writer
+        # (return-to-source) — so writers learn the canonical order/value and
+        # converge. LSN dedup in process_message keeps this idempotent and
+        # loop-free (receivers won't echo back to us: we're in their source).
+        let canon_ctx = OperationContext.init(source = [self.ctx.id].toHashSet)
+        for sub in self.ctx.subscribers:
           for msg in msgs:
-            self.ctx.send(sub, msg, op_ctx, self.flags)
+            self.ctx.send(sub, msg, canon_ctx, self.flags)
+      else:
+        for sub in self.ctx.subscribers:
+          if sub.ctx_id notin op_ctx.source:
+            for msg in msgs:
+              self.ctx.send(sub, msg, op_ctx, self.flags)
 
     self.ctx.tick_reactor
 

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -270,6 +270,8 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
       op_ctx.origin
     else:
       self.ctx.id
+  msg.op_id =
+    if op_ctx.op_id != 0: op_ctx.op_id else: self.ctx.next_op_id
   when defined(ed_trace):
     msg.trace = \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}"
   self.ctx.stamp_lsn(msg)
@@ -352,10 +354,20 @@ proc publish_changes*[T, O](
         else:
           self.ctx.id
 
+      # op id identifies the originating write. Forwards preserve the incoming
+      # one; an original mutation allocates a fresh id and records it as our
+      # latest for this object (used to skip our own superseded echoes).
+      let originating = op_ctx.op_id == 0
+      let out_op_id =
+        if originating: self.ctx.next_op_id else: op_ctx.op_id
+
       # Authority stamps each ordered op with its global LSN, once, before
       # fanout so every subscriber receives the same LSN.
       for msg in msgs.mitems:
         msg.origin = out_origin
+        msg.op_id = out_op_id
+        if originating:
+          self.ctx.latest_op_id[msg.object_id] = out_op_id
         self.ctx.stamp_lsn(msg)
 
       if self.ctx.is_authority:
@@ -574,15 +586,23 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       lsn = msg.lsn, frontier = self.applied_lsn
     return
 
-  # Own-op dedup: a delta (collection) op we originated has already been applied
-  # optimistically. When it returns canonically, advance the frontier (and ack,
-  # deferred #10) but don't re-run the effect — re-applying a seq.add would
-  # double it. Registers (delta = false) are re-applied by LSN so a losing
-  # optimistic write still converges to the canonical value.
-  if msg.delta and msg.origin == self.id:
-    if msg.lsn > self.applied_lsn:
-      self.applied_lsn = msg.lsn
-    return
+  # Own-op reconciliation: an op we originated, echoed back canonically.
+  #  - Collections (delta): already applied optimistically — skip to avoid
+  #    double-applying (a seq.add would duplicate).
+  #  - Registers: skip only if a *later* write of ours supersedes this echo
+  #    (op_id < our latest for this object) — that's what stops a moving entity
+  #    snapping back to its own stale echoes. Our *latest* own write (op_id ==
+  #    latest) is applied, so a contended register still converges to the
+  #    canonical value. (The op_id-superseded rule; see reconciliation-design.md.)
+  if msg.origin == self.id:
+    let superseded =
+      msg.delta or
+      msg.op_id < self.latest_op_id.getOrDefault(msg.object_id, 0'i64)
+    if superseded:
+      if msg.lsn > self.applied_lsn:
+        self.applied_lsn = msg.lsn
+      return
+    # else: our latest own write — fall through and apply it.
 
   if msg.kind == PACKED:
     let ops = msg.obj.from_flatty(seq[PackedMessageOperation])
@@ -621,7 +641,9 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         self,
         msg.object_id,
         msg.flags,
-        OperationContext.init(source = source, ctx = self, origin = msg.origin),
+        OperationContext.init(
+          source = source, ctx = self, origin = msg.origin, op_id = msg.op_id
+        ),
       )
       # :(
   elif msg.kind != BLANK:
@@ -633,7 +655,9 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     obj.change_receiver(
       obj,
       msg,
-      op_ctx = OperationContext.init(source = source, ctx = self, origin = msg.origin),
+      op_ctx = OperationContext.init(
+        source = source, ctx = self, origin = msg.origin, op_id = msg.op_id
+      ),
     )
     if msg.lsn > self.applied_lsn:
       self.applied_lsn = msg.lsn

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -260,23 +260,17 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   log_defaults("ed publishing")
 
   trace "publishing destroy", ed_id = self.id
+  # Build the DESTROY once and stamp it with the global LSN (authority only),
+  # so every subscriber receives the same ordered op. DESTROY is ordered like
+  # ASSIGN — delete-vs-update is a real conflict (see spike doc).
+  var msg = Message(kind: DESTROY, object_id: self.id)
+  when defined(ed_trace):
+    msg.trace = \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}"
+  self.ctx.stamp_lsn(msg)
+
   for sub in self.ctx.subscribers:
     if sub.ctx_id notin op_ctx.source:
-      when defined(ed_trace):
-        self.ctx.send(
-          sub,
-          Message(
-            kind: DESTROY,
-            object_id: self.id,
-            trace: \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}",
-          ),
-          op_ctx,
-          self.flags,
-        )
-      else:
-        self.ctx.send(
-          sub, Message(kind: DESTROY, object_id: self.id), op_ctx, self.flags
-        )
+      self.ctx.send(sub, msg, op_ctx, self.flags)
 
   self.ctx.tick_reactor
 
@@ -528,6 +522,15 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   #   self.last_received_id[src] = msg.id
   debug "receiving", msg, topics = "networking"
 
+  # Ordered-op idempotency: a stamped op at or below our frontier was already
+  # applied or superseded — drop it. lsn == 0 (CREATE / unordered) always
+  # proceeds. Gap/reorder buffering (lsn > frontier + 1) is deferred to the
+  # network phase; cross-thread delivery is FIFO from a single sequencer.
+  if msg.lsn > 0 and msg.lsn <= self.applied_lsn:
+    debug "skipping already-applied op",
+      lsn = msg.lsn, frontier = self.applied_lsn
+    return
+
   if msg.kind == PACKED:
     let ops = msg.obj.from_flatty(seq[PackedMessageOperation])
     for op in ops:
@@ -545,6 +548,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       )
 
       self.process_message(new_msg, sub)
+    if msg.lsn > self.applied_lsn:
+      self.applied_lsn = msg.lsn
   elif msg.kind == CREATE:
     {.gcsafe.}:
       if msg.type_id notin type_initializers:
@@ -573,6 +578,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     obj.change_receiver(
       obj, msg, op_ctx = OperationContext.init(source = source, ctx = self)
     )
+    if msg.lsn > self.applied_lsn:
+      self.applied_lsn = msg.lsn
   else:
     fail "Can't recv a blank message"
 

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -120,12 +120,13 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
         value = value.type()(flatty_ctx.ref_pool[val.ref_id].obj)
       else:
         var registered_type: RegisteredType
-        when defined(ed_partial_subscriber):
-          if lookup_type(val.tid, registered_type):
-            value = value.type()(registered_type.parse(flatty_ctx, val.item))
-        else:
-          do_assert lookup_type(val.tid, registered_type)
+        if lookup_type(val.tid, registered_type):
           value = value.type()(registered_type.parse(flatty_ctx, val.item))
+        else:
+          # Unknown ref type (version skew / type not compiled here). Leave the
+          # ref nil and carry on rather than aborting — forgiving on payload,
+          # strict only on the envelope.
+          debug "skipping ref for unknown type", ref_tid = val.tid
     else:
       var is_nil: bool
       s.from_flatty(i, is_nil)
@@ -593,11 +594,13 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   elif msg.kind == CREATE:
     {.gcsafe.}:
       if msg.type_id notin type_initializers:
-        when defined(ed_partial_subscriber):
-          return
-        else:
-          print msg
-          fail "No type initializer for type {msg.type_id}"
+        # Unknown type: a version-skewed peer or a type this context wasn't
+        # compiled with. Skip it rather than aborting — the consistency layer no
+        # longer needs every object present to trust the rest. (Relaying unknown
+        # types through the authority is a separate, future step.)
+        debug "skipping create for unknown type",
+          type_id = msg.type_id, object_id = msg.object_id
+        return
 
     {.gcsafe.}:
       let fn = type_initializers[msg.type_id]
@@ -767,7 +770,18 @@ proc tick*(
         # Handle keepalive pings - just ignore them (receiving updates lastActiveTime in netty)
         if raw_msg.data == "PING":
           continue
-        var msg = raw_msg.data.uncompress.from_flatty(Message, self)
+        # Parse boundary for untrusted bytes: a version-skewed peer or stray
+        # packet (e.g. another process on the same port) can't be parsed with
+        # our envelope. Drop it instead of crashing — don't let one bad packet
+        # take down the process. Scoped to (de)serialization so it doesn't mask
+        # logic bugs in process_message.
+        var msg: Message
+        try:
+          msg = raw_msg.data.uncompress.from_flatty(Message, self)
+        except CatchableError, Defect:
+          warn "dropping unparseable remote message",
+            bytes = raw_msg.data.len, peer = $raw_msg.conn.address
+          continue
         when defined(zen_debug_messages):
           inc self.messages_received
           self.obj_bytes_received += msg.obj.len

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -339,6 +339,11 @@ proc publish_changes*[T, O](
 
       msgs = pack_messages(msgs)
 
+      # Authority stamps each ordered op with its global LSN, once, before
+      # fanout so every subscriber receives the same LSN.
+      for msg in msgs.mitems:
+        self.ctx.stamp_lsn(msg)
+
       for sub in self.ctx.subscribers:
         if sub.ctx_id notin op_ctx.source:
           for msg in msgs:

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -176,6 +176,29 @@ proc flush_buffers*(self: EdContext) =
       for msg in buffer:
         sub.send_or_buffer(msg, true)
 
+proc remote_body(msg: Message, no_overwrite: bool): string =
+  ## The shared, compressed wire body for a remote message — identical across
+  ## subscribers (source / id_mappings travel per-subscriber, outside it), so a
+  ## fanout serializes + compresses it once.
+  var body_msg = msg
+  body_msg.source = @[]
+  body_msg.id_mappings = @[]
+  if no_overwrite:
+    body_msg.obj = ""
+  result = body_msg.to_flatty.compress
+
+proc send_remote(
+    self: EdContext, sub: Subscription, source: HashSet[string], body: string
+) =
+  ## One remote packet: a small per-subscriber header (source short-ids + any
+  ## new mappings) followed by the shared compressed body.
+  let (encoded_source, new_mappings) = sub.encode_source(source)
+  let packet = (encoded_source, new_mappings, body).to_flatty
+  self.bytes_sent += packet.len
+  self.reactor.send(sub.connection, packet)
+  sub.last_sent_time = epoch_time()
+  sent_message_counter.inc(label_values = [self.metrics_label])
+
 proc send*(
     self: EdContext,
     sub: Subscription,
@@ -184,7 +207,6 @@ proc send*(
     flags = DEFAULT_FLAGS,
 ) =
   log_defaults("ed networking")
-  sent_message_counter.inc(label_values = [self.metrics_label])
   when defined(ed_trace):
     if sub.ctx_id notin self.last_msg_id:
       self.last_msg_id[sub.ctx_id] = 1
@@ -207,15 +229,13 @@ proc send*(
     # Local: just use the HashSet, no encoding needed
     msg.source_set = source
     sub.send_or_buffer(msg, self.buffer)
+    sent_message_counter.inc(label_values = [self.metrics_label])
   elif sub.kind == LOCAL and SYNC_ALL_NO_OVERWRITE in flags:
     msg.source_set = source
     msg.obj = ""
     sub.send_or_buffer(msg, self.buffer)
+    sent_message_counter.inc(label_values = [self.metrics_label])
   elif sub.kind == REMOTE and SYNC_REMOTE in flags:
-    # Remote: encode source to short IDs
-    let (encoded_source, new_mappings) = sub.encode_source(source)
-    msg.source = encoded_source
-    msg.id_mappings = new_mappings
     when defined(zen_debug_messages):
       inc self.messages_sent
       inc self.messages_sent_by_kind[msg.kind]
@@ -230,31 +250,39 @@ proc send*(
         if msg.type_id notin self.obj_bytes_by_type:
           self.obj_bytes_by_type[msg.type_id] = 0
         self.obj_bytes_by_type[msg.type_id] += msg.obj.len
-    let serialized = msg.to_flatty
-    when defined(zen_debug_messages):
-      self.pre_compression_bytes += serialized.len
-    let data = serialized.compress
-    self.bytes_sent += data.len
-    self.reactor.send(sub.connection, data)
-    sub.last_sent_time = epoch_time()
+    self.send_remote(sub, source, remote_body(msg, no_overwrite = false))
   elif sub.kind == REMOTE and SYNC_ALL_NO_OVERWRITE in flags:
-    # Remote: encode source to short IDs
-    let (encoded_source, new_mappings) = sub.encode_source(source)
-    msg.source = encoded_source
-    msg.id_mappings = new_mappings
     when defined(zen_debug_messages):
       inc self.messages_sent
       inc self.messages_sent_by_kind[msg.kind]
-      # obj is empty for NoOverwrite, track 0 bytes
       inc self.messages_by_kind[msg.kind]
-    msg.obj = ""
-    let serialized = msg.to_flatty
-    when defined(zen_debug_messages):
-      self.pre_compression_bytes += serialized.len
-    let data = serialized.compress
-    self.bytes_sent += data.len
-    self.reactor.send(sub.connection, data)
-    sub.last_sent_time = epoch_time()
+    self.send_remote(sub, source, remote_body(msg, no_overwrite = true))
+
+proc fanout(
+    self: EdContext,
+    msg: sink Message,
+    op_ctx: OperationContext,
+    flags: set[EdFlags],
+    targets: seq[Subscription],
+) =
+  ## Send `msg` to many subscribers, serializing + compressing the shared remote
+  ## body only **once** across the fanout. Local subscribers get the struct (no
+  ## serialization). The caller pre-filters `targets` for source/skip rules.
+  var source = op_ctx.source
+  if source.len == 0:
+    source.incl self.id
+  var body, body_no_overwrite: string
+  for sub in targets:
+    if sub.kind == LOCAL:
+      self.send(sub, msg, op_ctx, flags)
+    elif sub.kind == REMOTE and SYNC_REMOTE in flags:
+      if body.len == 0:
+        body = remote_body(msg, no_overwrite = false)
+      self.send_remote(sub, source, body)
+    elif sub.kind == REMOTE and SYNC_ALL_NO_OVERWRITE in flags:
+      if body_no_overwrite.len == 0:
+        body_no_overwrite = remote_body(msg, no_overwrite = true)
+      self.send_remote(sub, source, body_no_overwrite)
 
 proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   privileged
@@ -276,9 +304,8 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
     msg.trace = \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}"
   self.ctx.stamp_lsn(msg)
 
-  for sub in self.ctx.subscribers:
-    if sub.ctx_id notin op_ctx.source:
-      self.ctx.send(sub, msg, op_ctx, self.flags)
+  let targets = self.ctx.subscribers.filter_it(it.ctx_id notin op_ctx.source)
+  self.ctx.fanout(msg, op_ctx, self.flags, targets)
 
   self.ctx.tick_reactor
 
@@ -377,14 +404,13 @@ proc publish_changes*[T, O](
         # converge. LSN dedup in process_message keeps this idempotent and
         # loop-free (receivers won't echo back to us: we're in their source).
         let canon_ctx = OperationContext.init(source = [self.ctx.id].toHashSet)
-        for sub in self.ctx.subscribers:
-          for msg in msgs:
-            self.ctx.send(sub, msg, canon_ctx, self.flags)
+        for msg in msgs:
+          self.ctx.fanout(msg, canon_ctx, self.flags, self.ctx.subscribers)
       else:
-        for sub in self.ctx.subscribers:
-          if sub.ctx_id notin op_ctx.source:
-            for msg in msgs:
-              self.ctx.send(sub, msg, op_ctx, self.flags)
+        let targets =
+          self.ctx.subscribers.filter_it(it.ctx_id notin op_ctx.source)
+        for msg in msgs:
+          self.ctx.fanout(msg, op_ctx, self.flags, targets)
 
     self.ctx.tick_reactor
 
@@ -813,7 +839,13 @@ proc tick*(
         # logic bugs in process_message.
         var msg: Message
         try:
-          msg = raw_msg.data.uncompress.from_flatty(Message, self)
+          # Wire format: a small per-subscriber header (source short-ids + new
+          # mappings) followed by the shared, compressed body (see send_remote).
+          let (enc_source, mappings, body) =
+            raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
+          msg = body.uncompress.from_flatty(Message, self)
+          msg.source = enc_source
+          msg.id_mappings = mappings
         except CatchableError, Defect:
           warn "dropping unparseable remote message",
             bytes = raw_msg.data.len, peer = $raw_msg.conn.address

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -1,7 +1,7 @@
 import
   std/[
     importutils, isolation, tables, sets, sequtils, algorithm, intsets, locks,
-    math, times, strutils, macros,
+    math, times, strutils, macros, os,
   ]
 
 import pkg/threading/channels {.all.}
@@ -471,6 +471,7 @@ proc subscribe*(
   var received_objects: HashSet[string]
   var finished = false
   var remote_objects: HashSet[string]
+  var last_progress = epoch_time()
   while not finished:
     self.reactor.tick
     self.dead_connections &= self.reactor.dead_connections
@@ -478,7 +479,9 @@ proc subscribe*(
       if connection == conn:
         raise ConnectionError.init(\"Unable to connect to {address}:{port}")
 
+    var got_messages = false
     for msg in self.reactor.messages:
+      got_messages = true
       self.bytes_received += msg.data.len
       if msg.data.starts_with("ACK:"):
         if bidirectional:
@@ -492,6 +495,15 @@ proc subscribe*(
         self.remote_messages &= msg
     if callback != nil:
       callback()
+    if got_messages:
+      last_progress = epoch_time()
+    # reactor.tick is non-blocking, so an unyielding loop pegs a core for the
+    # whole connect-timeout window when the peer is down. Spin hot at first so a
+    # healthy handshake (sub-ms on localhost) is timing-identical to before, then
+    # yield once we've gone a while with no traffic — the peer is gone and we're
+    # just waiting out the timeout.
+    elif epoch_time() - last_progress > 0.2:
+      sleep 1
 
   # Create bidirectional subscription BEFORE processing messages so mappings get registered
   var bi_sub: Subscription = nil

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -723,9 +723,29 @@ proc tick*(
   self.flush_buffers
   while true:
     if poll:
+      # Drain the available batch, then coalesce superseded register updates:
+      # a non-delta ASSIGN for an object that a higher-LSN ASSIGN in the same
+      # batch overwrites is frontier-advanced but its effect is skipped, so a
+      # losing optimistic writer converges to the latest value without applying
+      # (or showing) the intermediate one. Deltas (collections) are never
+      # coalesced — every add matters.
+      var batch: seq[Message]
       while get_mono_time() < timeout and self.chan.try_recv(msg):
-        self.process_message(msg)
-        inc count
+        batch.add msg
+      if batch.len > 0:
+        var latest: Table[string, int64]
+        for m in batch:
+          if m.kind == ASSIGN and not m.delta and m.lsn > 0 and
+              m.lsn > latest.getOrDefault(m.object_id, 0'i64):
+            latest[m.object_id] = m.lsn
+        for m in batch:
+          if m.kind == ASSIGN and not m.delta and m.lsn > 0 and
+              m.lsn < latest.getOrDefault(m.object_id, 0'i64):
+            if m.lsn > self.applied_lsn:
+              self.applied_lsn = m.lsn  # superseded register update: skip effect
+          else:
+            self.process_message(m)
+          inc count
 
     if ?self.reactor:
       if poll:

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -40,6 +40,7 @@ type
 
   OperationContext = object
     source*: HashSet[string]
+    origin*: string  # ctx id that originated the op (threaded for own-op dedup)
     when defined(ed_trace):
       trace*: string
 
@@ -63,6 +64,8 @@ type
     epoch*: int64   # authority epoch; bumped on host/leader change
     lsn*: int64     # global sequence number from the authority (0 = unordered)
     op_id*: int64   # originator-generated id for ack/commit correlation (0 = none)
+    origin*: string # ctx id that originated the op (for own-op dedup)
+    delta*: bool    # true for collection (non-idempotent) ops, false for registers
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -243,6 +246,8 @@ proc to_flatty*(s: var string, msg: Message) =
   s.to_flatty msg.epoch
   s.to_flatty msg.lsn
   s.to_flatty msg.op_id
+  s.to_flatty msg.origin
+  s.to_flatty msg.delta
   when defined(ed_trace):
     s.to_flatty msg.trace
     s.to_flatty msg.id
@@ -262,6 +267,8 @@ proc from_flatty*(s: string, i: var int, msg: var Message) =
   s.from_flatty(i, msg.epoch)
   s.from_flatty(i, msg.lsn)
   s.from_flatty(i, msg.op_id)
+  s.from_flatty(i, msg.origin)
+  s.from_flatty(i, msg.delta)
   when defined(ed_trace):
     s.from_flatty(i, msg.trace)
     s.from_flatty(i, msg.id)

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -59,6 +59,10 @@ type
     source_set*: HashSet[string]  # Full source for internal use (Local) - not serialized
     id_mappings*: seq[IdMapping]  # New mappings for unknown IDs
     flags*: set[EdFlags]
+    # Phase 1: global ordering (see docs/phase-1-keystone-spike.md)
+    epoch*: int64   # authority epoch; bumped on host/leader change
+    lsn*: int64     # global sequence number from the authority (0 = unordered)
+    op_id*: int64   # originator-generated id for ack/commit correlation (0 = none)
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -120,6 +124,11 @@ type
     ## Central coordination object managing `Ed` container lifecycle, subscriptions,
     ## and message passing between threads/network.
     id*: string
+    # Phase 1: global LSN + appointed leader (docs/phase-1-keystone-spike.md)
+    is_authority*: bool   # this context is the sequencer (leader) for its objects
+    leader_id*: string    # ctx_id of the authority (own id when is_authority)
+    lsn_counter*: int64   # authority-only: next global LSN to assign
+    applied_lsn*: int64   # highest global LSN applied (frontier)
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]
@@ -231,6 +240,9 @@ proc to_flatty*(s: var string, msg: Message) =
   # Skip source_set - internal use only
   s.to_flatty msg.id_mappings
   s.to_flatty msg.flags
+  s.to_flatty msg.epoch
+  s.to_flatty msg.lsn
+  s.to_flatty msg.op_id
   when defined(ed_trace):
     s.to_flatty msg.trace
     s.to_flatty msg.id
@@ -247,6 +259,9 @@ proc from_flatty*(s: string, i: var int, msg: var Message) =
   # source_set not in wire format
   s.from_flatty(i, msg.id_mappings)
   s.from_flatty(i, msg.flags)
+  s.from_flatty(i, msg.epoch)
+  s.from_flatty(i, msg.lsn)
+  s.from_flatty(i, msg.op_id)
   when defined(ed_trace):
     s.from_flatty(i, msg.trace)
     s.from_flatty(i, msg.id)

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -41,6 +41,7 @@ type
   OperationContext = object
     source*: HashSet[string]
     origin*: string  # ctx id that originated the op (threaded for own-op dedup)
+    op_id*: int64    # originator's op id (threaded so forwards preserve it)
     when defined(ed_trace):
       trace*: string
 
@@ -132,6 +133,8 @@ type
     leader_id*: string    # ctx_id of the authority (own id when is_authority)
     lsn_counter*: int64   # authority-only: next global LSN to assign
     applied_lsn*: int64   # highest global LSN applied (frontier)
+    op_id_counter*: int64 # next op id to assign to a write we originate
+    latest_op_id*: Table[string, int64]  # object_id -> our highest op id (own-op reconciliation)
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -116,6 +116,11 @@ proc next_lsn*(self: EdContext): int64 =
   inc self.lsn_counter
   self.lsn_counter
 
+proc next_op_id*(self: EdContext): int64 =
+  ## Allocate the next op id for a write this context originates.
+  inc self.op_id_counter
+  self.op_id_counter
+
 proc stamp_lsn*(self: EdContext, msg: var Message) =
   ## If this context is the authority, assign the op its global LSN, once.
   ## Applies to the ordered ops the authority broadcasts (self-originated or

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -57,8 +57,11 @@ proc init*(
     max_recv_duration = Duration.default,
     min_recv_duration = Duration.default,
     label = "default",
+    is_authority = false,
 ): EdContext =
   ## Create a new `EdContext`. Set `listen_address` to enable network sync.
+  ## Set `is_authority` to make this context the sequencer (leader) that assigns
+  ## global LSNs — see docs/phase-1-keystone-spike.md.
   privileged
   log_scope:
     topics = "ed"
@@ -73,7 +76,10 @@ proc init*(
     buffer: buffer,
     metrics_label: label,
     last_keepalive_tick: epoch_time(),
+    is_authority: is_authority,
   )
+  if is_authority:
+    result.leader_id = id
 
   result.chan = new_chan[Message](elements = chan_size)
   if ?listen_address:
@@ -104,6 +110,20 @@ proc `thread_ctx=`*(_: type Ed, ctx: EdContext) =
 
 proc `$`*(self: EdContext): string =
   \"EdContext {self.id}"
+
+proc next_lsn*(self: EdContext): int64 =
+  ## Authority-only: allocate the next global sequence number.
+  inc self.lsn_counter
+  self.lsn_counter
+
+proc stamp_lsn*(self: EdContext, msg: var Message) =
+  ## If this context is the authority, assign the op its global LSN, once.
+  ## Applies to the change ops the authority broadcasts (self-originated or
+  ## forwarded). CREATE/DESTROY are intentionally not stamped yet — the
+  ## subscribe-time resend distinction needs its own step (see spike doc).
+  if self.is_authority and msg.lsn == 0 and
+      msg.kind in {ASSIGN, UNASSIGN, TOUCH, PACKED}:
+    msg.lsn = self.next_lsn
 
 proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =
   result = Ed[T, O](self.objects[src.id])

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -206,6 +206,7 @@ proc clear*(self: EdContext) =
   ## Remove all objects from this context.
   debug "Clearing EdContext"
   self.objects.clear
+  self.latest_op_id.clear
   self.objects_need_packing = false
 
 proc close*(self: EdContext) =

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -118,11 +118,13 @@ proc next_lsn*(self: EdContext): int64 =
 
 proc stamp_lsn*(self: EdContext, msg: var Message) =
   ## If this context is the authority, assign the op its global LSN, once.
-  ## Applies to the change ops the authority broadcasts (self-originated or
-  ## forwarded). CREATE/DESTROY are intentionally not stamped yet — the
-  ## subscribe-time resend distinction needs its own step (see spike doc).
+  ## Applies to the ordered ops the authority broadcasts (self-originated or
+  ## forwarded). CREATE is intentionally not stamped — concurrent same-id
+  ## creation is out of scope and the subscribe-time resend distinction needs
+  ## its own step (see spike doc). DESTROY *is* stamped: delete-vs-update is a
+  ## real conflict that must be ordered.
   if self.is_authority and msg.lsn == 0 and
-      msg.kind in {ASSIGN, UNASSIGN, TOUCH, PACKED}:
+      msg.kind in {ASSIGN, UNASSIGN, TOUCH, DESTROY, PACKED}:
     msg.lsn = self.next_lsn
 
 proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -118,6 +118,10 @@ proc defaults[T, O](
       self: ref EdBase, change: BaseChange, id, trace: string
   ): Message =
     var msg = Message(object_id: id, type_id: Ed[T, O].tid)
+    # Collections (change object O differs from tracked T) are delta /
+    # non-idempotent ops; registers (O is T) are whole-value and idempotent.
+    when O isnot T:
+      msg.delta = true
     when defined(ed_trace):
       msg.trace = trace
     assert ADDED in change.changes or REMOVED in change.changes or

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -183,7 +183,10 @@ proc defaults[T, O](
       if msg.object_id notin self.ctx:
         when defined(ed_trace):
           echo msg.trace
-        fail "object not in context " & msg.object_id & " " & $Ed[T, O]
+        # Change for an object we don't have (version skew / not yet
+        # materialized). Skip rather than abort, matching the non-Pair path.
+        debug "skipping change for missing object", object_id = msg.object_id
+        return
 
       if msg.change_object_id notin self.ctx and msg.kind == UNASSIGN:
         debug "can't find ", obj = msg.change_object_id
@@ -206,7 +209,10 @@ proc defaults[T, O](
                 debug "item found (not restored)",
                   item = item.type.name, ref_id = item.ref_id
             else:
-              fail \"Type for ref_id {msg.ref_id} not registered"
+              # Unknown ref type — can't parse the item, so skip this change
+              # rather than aborting. Forgiving on payload.
+              debug "skipping change for unknown ref type", ref_tid = msg.ref_id
+              return
           else:
             {.gcsafe.}:
               item = msg.obj.from_flatty(O, self.ctx)

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -285,6 +285,7 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
   self.destroyed = true
   self.ctx.objects[self.id] = nil
   self.ctx.objects_need_packing = true
+  self.ctx.latest_op_id.del(self.id)  # drop own-op reconciliation state
 
   if publish:
     self.publish_destroy OperationContext(source: [self.ctx.id].toHashSet)

--- a/src/ed/zens/private.nim
+++ b/src/ed/zens/private.nim
@@ -17,10 +17,12 @@ proc init*(
     source: HashSet[string] = initHashSet[string](),
     ctx: EdContext = nil,
     origin = "",
+    op_id: int64 = 0,
 ): OperationContext =
   result = OperationContext()
   result.source = source
   result.origin = origin
+  result.op_id = op_id
   if ?ctx:
     result.source.incl ctx.id
   when defined(ed_trace):

--- a/src/ed/zens/private.nim
+++ b/src/ed/zens/private.nim
@@ -16,9 +16,11 @@ proc init*(
     _: type OperationContext,
     source: HashSet[string] = initHashSet[string](),
     ctx: EdContext = nil,
+    origin = "",
 ): OperationContext =
   result = OperationContext()
   result.source = source
+  result.origin = origin
   if ?ctx:
     result.source.incl ctx.id
   when defined(ed_trace):

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -5,6 +5,7 @@ import
   ]
 import pkg/[pretty, chronicles, netty]
 import ed
+import test_util
 from std/times import init_duration
 import ed/[types {.all.}, zens {.all.}, zens/contexts {.all.}]
 
@@ -56,10 +57,11 @@ proc run*() =
     block remote:
       debug "remote run"
       const recv_duration = init_duration(milliseconds = 10)
+      let host = free_addr()
       var
         ctx1 {.inject.} = EdContext.init(
           id = "ctx1",
-          listen_address = "127.0.0.1",
+          listen_address = host,
           min_recv_duration = recv_duration,
           blocking_recv = true,
         )
@@ -68,7 +70,7 @@ proc run*() =
           id = "ctx2", min_recv_duration = recv_duration, blocking_recv = true
         )
 
-      ctx2.subscribe "127.0.0.1",
+      ctx2.subscribe host,
         callback = proc() =
           ctx1.tick(blocking = false)
 

--- a/tests/client_tests.nim
+++ b/tests/client_tests.nim
@@ -1,0 +1,135 @@
+import test_util
+import std/[unittest, atomics, os, times]
+import ed
+import ed/types {.all.}
+
+# A per-process random loopback address (via test_util) so a live Enu / MCP
+# server on the host can't leak packets into the test reactor.
+let test_address = free_addr()
+
+# A listening peer on its own thread, ticking continuously — the role Enu
+# plays for the MCP server (separate process, independent tick loop). An
+# in-process same-thread server would deadlock the client's blocking
+# subscribe, so a thread is the faithful setup.
+
+var server_running: Atomic[bool]
+var server_ready: Atomic[bool]
+var server_thread: Thread[string]
+
+proc server_loop(address: string) {.thread.} =
+  let server = EdContext.init(id = "test-server", listen_address = address)
+  Ed.thread_ctx = server
+  var shared = EdValue[string].init(id = "shared", ctx = server)
+  shared.value = "hello"
+  server_ready.store(true)
+  while server_running.load:
+    server.tick
+    sleep 5
+  server.close
+
+proc start_server() =
+  server_ready.store(false)
+  server_running.store(true)
+  create_thread(server_thread, server_loop, test_address)
+  while not server_ready.load:
+    sleep 5
+
+proc stop_server() =
+  server_running.store(false)
+  join_thread(server_thread)
+
+var setups = 0
+
+proc on_connect() {.gcsafe.} =
+  inc setups
+
+proc run*() =
+  test "EdClient connects, stays live, and reconnects on the same id":
+    setups = 0
+    start_server()
+    defer:
+      stop_server()
+
+    let client = EdClient(
+      id: "test-agent",
+      address: test_address,
+      chan_size: 100,
+      on_connect: on_connect,
+    )
+
+    check not client.connected
+    client.connect
+    check client.connected
+    check setups == 1
+
+    # The server's object syncs to the client through ticks.
+    var received = ""
+    for _ in 0 ..< 20:
+      client.tick
+      if "shared" in client.ctx:
+        received = EdValue[string](client.ctx["shared"]).value
+        if received == "hello":
+          break
+      sleep 5
+    check received == "hello"
+
+    # Idle ticking keeps the link up — no spurious reconnect, no re-setup.
+    for _ in 0 ..< 10:
+      client.tick
+      sleep 5
+    check client.connected
+    check setups == 1
+
+    # ensure_connected is a no-op while connected.
+    client.ensure_connected
+    check setups == 1
+
+    # An explicit reconnect rebuilds the context under the same id and
+    # reruns on_connect; the server's stale-sub sweep accepts it.
+    client.connect
+    check client.connected
+    check setups == 2
+
+  test "EdClient reconnects after the peer goes away and returns":
+    # The MCP-server-survives-an-Enu-restart path. A dropped peer must be
+    # detected (netty reaps the connection after its ~10s timeout) and the
+    # client must re-subscribe under the same id once the peer is back —
+    # all from plain idle ticking, no manual intervention.
+    setups = 0
+    start_server()
+    let client = EdClient(
+      id: "test-agent-restart",
+      address: test_address,
+      chan_size: 100,
+      on_connect: on_connect,
+    )
+    client.connect
+    check client.connected
+    check setups == 1
+
+    # Peer disappears. Tick the context directly (not `client.tick`, which
+    # would also try a blocking reconnect) until the dead connection is
+    # reaped and the link reads as down.
+    stop_server()
+    var dropped = false
+    for _ in 0 ..< 1000: # generous: netty connTimeout is 10s
+      client.ctx.tick
+      if not client.connected:
+        dropped = true
+        break
+      sleep 20
+    check dropped
+
+    # Peer returns; idle `client.tick`s alone bring it back.
+    start_server()
+    defer:
+      stop_server()
+    var recovered = false
+    for _ in 0 ..< 200:
+      client.tick
+      if client.connected:
+        recovered = true
+        break
+      sleep 20
+    check recovered
+    check setups >= 2

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -57,6 +57,34 @@ proc run*() =
       check follower.applied_lsn >= 3
       check EdValue[int](follower["lsn_obj_c"]).value == 3
 
+    test "concurrent register writers converge to the authority's order":
+      var leader = EdContext.init(id = "lsn_leader_e", is_authority = true)
+      var fa = EdContext.init(id = "lsn_fa")
+      var fb = EdContext.init(id = "lsn_fb")
+      fa.subscribe(leader)
+      fb.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_e")
+      fa.tick()
+      fb.tick()
+      check "lsn_obj_e" in fa
+      check "lsn_obj_e" in fb
+
+      # Two optimistic writers race the same register.
+      EdValue[int](fa["lsn_obj_e"]).value = 10
+      EdValue[int](fb["lsn_obj_e"]).value = 20
+
+      # Authority orders them (FIFO: fa then fb) and fans the canonical values
+      # back to everyone — including the writers (return-to-source).
+      leader.tick()
+      fa.tick()
+      fb.tick()
+
+      let lv = EdValue[int](leader["lsn_obj_e"]).value
+      check EdValue[int](fa["lsn_obj_e"]).value == lv  # no divergence
+      check EdValue[int](fb["lsn_obj_e"]).value == lv
+      check lv == 20  # later writer in the authority's order wins
+
     test "ordered destroy propagates and advances the frontier":
       var leader = EdContext.init(id = "lsn_leader_d", is_authority = true)
       var follower = EdContext.init(id = "lsn_follower_d")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -39,3 +39,36 @@ proc run*() =
       fobj.value = 7
       fobj.value = 8
       check follower.lsn_counter == 0
+
+    test "follower frontier tracks the authority's ordered ops":
+      var leader = EdContext.init(id = "lsn_leader_c", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_c")
+      follower.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_c")
+      obj.value = 1
+      obj.value = 2
+      obj.value = 3
+      follower.tick()
+
+      # Follower applied the ordered ops; its frontier matches the authority's
+      # LSN counter (CREATE is unstamped, so only the 3 assigns count).
+      check follower.applied_lsn == leader.lsn_counter
+      check follower.applied_lsn >= 3
+      check EdValue[int](follower["lsn_obj_c"]).value == 3
+
+    test "ordered destroy propagates and advances the frontier":
+      var leader = EdContext.init(id = "lsn_leader_d", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_d")
+      follower.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_d")
+      obj.value = 5
+      follower.tick()
+      check "lsn_obj_d" in follower
+
+      let before = follower.applied_lsn
+      obj.destroy()
+      follower.tick()
+      check "lsn_obj_d" notin follower
+      check follower.applied_lsn > before  # DESTROY is a stamped, ordered op

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -114,6 +114,33 @@ proc run*() =
       check EdValue[int](fb["lsn_obj_h"]).value == 20
       check 10 notin seen
 
+    test "a non-leader's writes don't snap back to their own stale echoes":
+      # The movement case: a writer keeps updating a register; an earlier write
+      # echoes back from the authority after the writer has moved on. The stale
+      # echo must NOT snap the value backward (op_id-superseded rule).
+      var leader = EdContext.init(id = "lsn_leader_j", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_j")
+      follower.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_j")
+      follower.tick()
+      check "lsn_obj_j" in follower
+
+      # Write 1; let the authority order it (the echo is now queued for us)...
+      EdValue[int](follower["lsn_obj_j"]).value = 1
+      leader.tick()
+      # ...but before applying that echo we move on to 2.
+      EdValue[int](follower["lsn_obj_j"]).value = 2
+      follower.tick()
+      # The stale echo of 1 must not drag us back.
+      check EdValue[int](follower["lsn_obj_j"]).value == 2
+
+      # And we still converge: the latest write is the canonical value.
+      leader.tick()
+      follower.tick()
+      check EdValue[int](follower["lsn_obj_j"]).value == 2
+      check EdValue[int](leader["lsn_obj_j"]).value == 2
+
     test "a follower's collection op is not double-applied":
       var leader = EdContext.init(id = "lsn_leader_f", is_authority = true)
       var follower = EdContext.init(id = "lsn_follower_f")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -85,6 +85,47 @@ proc run*() =
       check EdValue[int](fb["lsn_obj_e"]).value == lv
       check lv == 20  # later writer in the authority's order wins
 
+    test "a follower's collection op is not double-applied":
+      var leader = EdContext.init(id = "lsn_leader_f", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_f")
+      follower.subscribe(leader)
+
+      var s = EdSeq[int].init(ctx = leader, id = "lsn_seq_f")
+      follower.tick()
+      check "lsn_seq_f" in follower
+
+      # Applied optimistically, sent to the authority, ordered, returned —
+      # must NOT be re-applied (no duplicate).
+      EdSeq[int](follower["lsn_seq_f"]).add 42
+      leader.tick()
+      follower.tick()
+
+      check EdSeq[int](follower["lsn_seq_f"]).len == 1
+      check EdSeq[int](leader["lsn_seq_f"]).len == 1
+      check 42 in EdSeq[int](follower["lsn_seq_f"])
+
+    test "concurrent collection writers converge without duplication":
+      var leader = EdContext.init(id = "lsn_leader_g", is_authority = true)
+      var fa = EdContext.init(id = "lsn_fa_g")
+      var fb = EdContext.init(id = "lsn_fb_g")
+      fa.subscribe(leader)
+      fb.subscribe(leader)
+
+      var s = EdSeq[int].init(ctx = leader, id = "lsn_seq_g")
+      fa.tick()
+      fb.tick()
+
+      EdSeq[int](fa["lsn_seq_g"]).add 1
+      EdSeq[int](fb["lsn_seq_g"]).add 2
+      leader.tick()
+      fa.tick()
+      fb.tick()
+
+      # Both adds present exactly once on every replica.
+      check EdSeq[int](leader["lsn_seq_g"]).len == 2
+      check EdSeq[int](fa["lsn_seq_g"]).len == 2
+      check EdSeq[int](fb["lsn_seq_g"]).len == 2
+
     test "ordered destroy propagates and advances the frontier":
       var leader = EdContext.init(id = "lsn_leader_d", is_authority = true)
       var follower = EdContext.init(id = "lsn_follower_d")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -155,6 +155,33 @@ proc run*() =
       check EdSeq[int](fa["lsn_seq_g"]).len == 2
       check EdSeq[int](fb["lsn_seq_g"]).len == 2
 
+    test "concurrent update and delete converge (delete wins, no divergence)":
+      var leader = EdContext.init(id = "lsn_leader_i", is_authority = true)
+      var fa = EdContext.init(id = "lsn_fa_i")
+      var fb = EdContext.init(id = "lsn_fb_i")
+      fa.subscribe(leader)
+      fb.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_i")
+      obj.value = 1
+      fa.tick()
+      fb.tick()
+      check "lsn_obj_i" in fa
+      check "lsn_obj_i" in fb
+
+      # fa updates the object; fb deletes it — concurrently.
+      EdValue[int](fa["lsn_obj_i"]).value = 99
+      EdValue[int](fb["lsn_obj_i"]).destroy()
+
+      leader.tick()
+      fa.tick()
+      fb.tick()
+
+      # All replicas agree (no divergence); the ordered delete wins.
+      check ("lsn_obj_i" in leader) == ("lsn_obj_i" in fa)
+      check ("lsn_obj_i" in fa) == ("lsn_obj_i" in fb)
+      check "lsn_obj_i" notin leader
+
     test "ordered destroy propagates and advances the frontier":
       var leader = EdContext.init(id = "lsn_leader_d", is_authority = true)
       var follower = EdContext.init(id = "lsn_follower_d")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -85,6 +85,35 @@ proc run*() =
       check EdValue[int](fb["lsn_obj_e"]).value == lv
       check lv == 20  # later writer in the authority's order wins
 
+    test "register reconciliation is flicker-free (coalesced)":
+      var leader = EdContext.init(id = "lsn_leader_h", is_authority = true)
+      var fa = EdContext.init(id = "lsn_fa_h")
+      var fb = EdContext.init(id = "lsn_fb_h")
+      fa.subscribe(leader)
+      fb.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_h")
+      fa.tick()
+      fb.tick()
+
+      var seen: seq[int]
+      EdValue[int](fb["lsn_obj_h"]).track proc(
+          changes: seq[Change[int]]
+      ) {.gcsafe.} =
+        for c in changes:
+          if ADDED in c.changes:
+            seen.add c.item
+
+      EdValue[int](fa["lsn_obj_h"]).value = 10
+      EdValue[int](fb["lsn_obj_h"]).value = 20
+      leader.tick()
+      fa.tick()
+      fb.tick()
+
+      # fb converges to 20 without ever applying the superseded intermediate 10.
+      check EdValue[int](fb["lsn_obj_h"]).value == 20
+      check 10 notin seen
+
     test "a follower's collection op is not double-applied":
       var leader = EdContext.init(id = "lsn_leader_f", is_authority = true)
       var follower = EdContext.init(id = "lsn_follower_f")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -1,0 +1,41 @@
+import std/unittest
+import ed
+import ed/zens/contexts
+
+proc run*() =
+  suite "lsn leader stamping":
+    test "authority is designated via init":
+      var leader = EdContext.init(id = "lsn_leader", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower")
+      check leader.is_authority
+      check leader.leader_id == "lsn_leader"
+      check not follower.is_authority
+      check follower.leader_id == ""
+
+    test "authority stamps increasing LSNs on its mutations":
+      var leader = EdContext.init(id = "lsn_leader_a", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_a")
+      follower.subscribe(leader)
+
+      var obj = EdValue[int].init(ctx = leader, id = "lsn_obj_a")
+      let before = leader.lsn_counter  # CREATE is not stamped yet
+      obj.value = 1
+      obj.value = 2
+      obj.value = 3
+      # Each assignment is an ordered op stamped by the authority.
+      check leader.lsn_counter >= before + 3
+
+      # LSNs are strictly increasing.
+      let mid = leader.lsn_counter
+      obj.value = 4
+      check leader.lsn_counter > mid
+
+    test "non-authority never stamps":
+      var leader = EdContext.init(id = "lsn_leader_b", is_authority = true)
+      var follower = EdContext.init(id = "lsn_follower_b")
+      follower.subscribe(leader)
+
+      var fobj = EdValue[int].init(ctx = follower, id = "lsn_obj_b")
+      fobj.value = 7
+      fobj.value = 8
+      check follower.lsn_counter == 0

--- a/tests/network_tests.nim
+++ b/tests/network_tests.nim
@@ -3,6 +3,7 @@ import pkg/[flatty, chronicles, pretty]
 import ed
 import ed/types {.all.}
 import ed/zens/private {.all.}
+import test_util
 from std/times import init_duration
 
 const recv_duration = init_duration(milliseconds = 10)
@@ -11,11 +12,12 @@ type Vector3 = array[3, float]
 
 proc run*() =
   test "4 way sync":
+    let host = free_addr()
     var
       ctx1 = EdContext.init(id = "ctx1")
       ctx2 = EdContext.init(
         id = "ctx2",
-        listen_address = "127.0.0.1",
+        listen_address = host,
         min_recv_duration = recv_duration,
         blocking_recv = true,
       )
@@ -26,7 +28,7 @@ proc run*() =
 
     ctx2.subscribe(ctx1)
     ctx3.subscribe(ctx4)
-    ctx3.subscribe "127.0.0.1",
+    ctx3.subscribe host,
       callback = proc() =
         ctx2.tick(blocking = false)
 
@@ -49,12 +51,13 @@ proc run*() =
     ctx2.close
 
   test "trigger changes on subscribe":
+    let host = free_addr()
     var
       count = 0
       ctx1 = EdContext.init(id = "ctx1")
       ctx2 = EdContext.init(
         id = "ctx2",
-        listen_address = "127.0.0.1",
+        listen_address = host,
         min_recv_duration = recv_duration,
         blocking_recv = true,
       )
@@ -82,7 +85,7 @@ proc run*() =
     check b.value == @["a1", "a2"]
 
     ctx4.tick
-    ctx3.subscribe "127.0.0.1",
+    ctx3.subscribe host,
       callback = proc() =
         ctx2.tick(blocking = false)
 
@@ -99,6 +102,7 @@ proc run*() =
     ctx2.close
 
   test "nested collection":
+    let host = free_addr()
     type Unit = object
       code: EdValue[string]
 
@@ -107,7 +111,7 @@ proc run*() =
       ctx1 = EdContext.init(id = "ctx1")
       ctx2 = EdContext.init(
         id = "ctx2",
-        listen_address = "127.0.0.1",
+        listen_address = host,
         min_recv_duration = recv_duration,
         blocking_recv = true,
       )
@@ -135,7 +139,7 @@ proc run*() =
     check b.value == @["a1", "a2"]
 
     ctx4.tick
-    ctx3.subscribe "127.0.0.1",
+    ctx3.subscribe host,
       callback = proc() =
         ctx2.tick(blocking = false)
 
@@ -152,11 +156,12 @@ proc run*() =
     ctx2.close
 
   test "Vector3 array network sync":
+    let host = free_addr()
     var
       ctx1 = EdContext.init(id = "ctx1")
       ctx2 = EdContext.init(
         id = "ctx2",
-        listen_address = "127.0.0.1",
+        listen_address = host,
         min_recv_duration = recv_duration,
         blocking_recv = true,
       )
@@ -192,17 +197,18 @@ proc run*() =
     # die — same id, fresh context) and subscribes again. The publisher
     # must drop the stale subscriber so it doesn't route messages to a
     # connection that now belongs to the new context.
+    let host = free_addr()
     Ed.thread_ctx = EdContext.init(id = "mainA")
     var
       publisher = EdContext.init(
         id = "publisher",
-        listen_address = "127.0.0.1:19632",
+        listen_address = host,
         min_recv_duration = recv_duration,
         blocking_recv = true,
       )
       client_a = Ed.thread_ctx
 
-    client_a.subscribe "127.0.0.1:19632",
+    client_a.subscribe host,
       callback = proc() =
         publisher.tick(blocking = false)
 
@@ -212,7 +218,7 @@ proc run*() =
     # Simulate the reconnect: same ctx id, fresh EdContext.
     Ed.thread_ctx = EdContext.init(id = "mainA")
     var client_b = Ed.thread_ctx
-    client_b.subscribe "127.0.0.1:19632",
+    client_b.subscribe host,
       callback = proc() =
         publisher.tick(blocking = false)
 

--- a/tests/network_threading_tests.nim
+++ b/tests/network_threading_tests.nim
@@ -1,6 +1,7 @@
 import std/[locks, os, unittest, tables]
 import pkg/[pretty, chronicles]
 import ed
+import test_util
 
 var global_lock: Lock
 global_lock.init_lock
@@ -42,8 +43,9 @@ proc run*() =
   test "reload":
     Ed.thread_ctx.clear
     Ed.thread_ctx = EdContext.init(id = "main")
-    var ctx = EdContext.init(id = "worker", listen_address = "127.0.0.1")
-    Ed.thread_ctx.subscribe "127.0.0.1",
+    let host = free_addr()
+    var ctx = EdContext.init(id = "worker", listen_address = host)
+    Ed.thread_ctx.subscribe host,
       callback = proc() =
         ctx.tick
 

--- a/tests/test_util.nim
+++ b/tests/test_util.nim
@@ -1,0 +1,16 @@
+import std/net
+
+proc free_port*(): int =
+  ## Ask the OS for a free UDP port on loopback, then release it so the caller
+  ## can bind it. Avoids hard-coded ports (e.g. 9632) colliding with a running
+  ## Enu instance or with other tests.
+  let s = newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+  try:
+    s.bindAddr(Port(0), "127.0.0.1")
+    result = s.getLocalAddr()[1].int
+  finally:
+    s.close()
+
+proc free_addr*(): string =
+  ## "127.0.0.1:<free-port>", for use as both listen_address and subscribe target.
+  "127.0.0.1:" & $free_port()

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,7 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
-  lsn_tests
+  lsn_tests, client_tests
 
 Ed.bootstrap
 
@@ -15,3 +15,4 @@ validation_tests.run()
 error_handling_tests.run()
 memory_tests.run()
 lsn_tests.run()
+client_tests.run()

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,6 +1,7 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
-  object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests
+  object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
+  lsn_tests
 
 Ed.bootstrap
 
@@ -13,3 +14,4 @@ utils_tests.run()
 validation_tests.run()
 error_handling_tests.run()
 memory_tests.run()
+lsn_tests.run()

--- a/tests/threading_tests.nim
+++ b/tests/threading_tests.nim
@@ -1,6 +1,7 @@
 import std/[locks, os, unittest, tables]
 import pkg/[pretty, chronicles]
 import ed
+import test_util
 
 var global_lock: Lock
 global_lock.init_lock
@@ -33,8 +34,9 @@ proc run*() =
   test "basic":
     Ed.thread_ctx.clear
     Ed.thread_ctx = EdContext.init(id = "main")
-    var ctx = EdContext.init(id = "worker", listen_address = "127.0.0.1")
-    Ed.thread_ctx.subscribe "127.0.0.1",
+    let host = free_addr()
+    var ctx = EdContext.init(id = "worker", listen_address = host)
+    Ed.thread_ctx.subscribe host,
       callback = proc() =
         ctx.tick
 


### PR DESCRIPTION
Phase 1 of eventual consistency for Ed: a **leader-sequenced global operation log** with **state-based forward-correction** reconciliation. Validated end-to-end in Enu (cross-thread + a network client; smooth movement, syncing).

## What's implemented (all tested)
- **Global LSN + appointed leader** (`is_authority`); ordered apply with dedup + a frontier; ordered `DESTROY`.
- **Return-to-source**: the authority re-origins canonical ops and delivers to all subscribers including the writer.
- **Register reconciliation — the `op_id`-superseded rule**: a writer skips its own *stale* echoes (no snap-back for moving entities) but applies its latest, so contended registers still converge; other-origin writes are accepted as authoritative overrides. Client-prediction + reconciliation, in a state-based form.
- **Collections** (the voxel hot path): own-op dedup, no double-apply; concurrent edits converge.
- **Flicker-free coalescing**; delete-vs-update converges.
- **Robustness**: defensive deserialize (a bad/stray/version-skewed packet drops instead of crashing); unknown types/refs/missing objects skipped, not fatal.
- **Serialize-once fanout**: the shared compressed body is built once per fanout instead of once per subscriber (wire-format/envelope change).
- **EdClient**: a self-reconnecting remote context (for the Enu MCP server).
- Tests use OS-assigned random ports (no 9632 collision with a running Enu).

## Design docs (`docs/`)
`consistency-and-partial-sync-plan.md`, `phase-1-keystone-spike.md`, `reconciliation-design.md`, `transport-and-schema-compatibility.md`.

## Known limitations / deferred (documented)
- A forward write in flight when an authoritative override lands gives *observers* a brief, self-correcting glitch — full fix is versioned/conditional writes (OCC), deferred.
- Ack/commit callback (#10), partial/lazy sync + eviction, durable log + time-travel, per-object authority, and network-scope failover are future phases.

Ready for review — not for merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)