### PR TITLE
Partial replicas: interest sets, capability handshake, materialize-on-access

### DIFF
--- a/docs/partial-replicas-spike.md
+++ b/docs/partial-replicas-spike.md
@@ -69,24 +69,51 @@ unknown-type schema part is unneeded, since `O` gives the type.)
 So a context can now subscribe to a subset, receive only that subset's ops, and
 **explicitly** pull more on demand with `fetch` — the core of partial replicas.
 
-**Logged for tomorrow** (not yet built — the ergonomic layer, and the riskier
-bits I didn't want to rush solo):
+**Done & tested (later session) — capability handshake + materialize-on-access:**
 
-- **Transparent materialize-on-access.** Today fetch is *explicit*. The "nested
-  objects don't exist until accessed via the seq" experience needs: a **typed
-  lazy handle** for a non-resident nested `Ed` (turn the `assert object_id in
-  self.ctx` at `initializers.nim` `when O is Ed:` into a placeholder), plus
-  container access (`[]`/`items`) auto-firing a `fetch`. The blocker is a
-  **non-broadcasting placeholder constructor** for an arbitrary `Ed[T,O]` — the
-  current `init`/`defaults` always `publish_create`s. (The parked `EdDynamic`
-  work is the untyped version of this primitive.)
-- **`tick` receive/process split + `blocking:` scope** (decisions 3–4). I kept
-  `tick` untouched this session; the split + silent-materialize is the next piece.
-- **Initial / Fill callbacks + `Change.trigger`** (decision 5).
+- **TID capability handshake** (`Subscription.capabilities: HashSet[int]`). On
+  subscribe a peer advertises its registered `type_initializers` tids; the
+  authority filters every send (`publish_create` send_msg + `fanout`) so a peer
+  **never receives an object it can't construct**. type_id == 0 (DESTROY/control)
+  is exempt. Empty set = unfiltered (same-build/local/older peer). See
+  `ref-registration.md` for the crash this prevents. (`capability_tests.nim`)
+- **Placeholder primitive.** `EdBase.placeholder` + `loaded` predicate (option-1
+  model: empty stand-in, queryable loaded-bit). `Ed.init_placeholder` — a
+  non-broadcasting typed constructor (`defaults(..., broadcast = false)`). The two
+  `assert object_id in self.ctx` deserialize sites (`when O is Ed` / `Pair[auto,
+  Ed]`) now create a placeholder instead of asserting. Fill clears the bit in all
+  restore paths. `fetch` no longer early-returns on an unloaded placeholder.
+- **Materialize-on-access.** `EdContext.materialize` proc field, wired at subscribe
+  time (it needs `fetch`/`tick`); the read accessors (`value`/`items`/`pairs`/`[]`)
+  call it via `touch_placeholder`. Non-blocking: kicks a `fetch`, returns empty
+  now, fills on a later tick. Blocking: `EdContext.blocking` flag + `blocking:`
+  template (manages the flag; settable by hand) — the accessor pumps `tick` until
+  the object fills, **bounded by a 5s deadline** so a gone authority can't hang the
+  caller. (`materialize_tests.nim`)
 
-Recommend reviewing the explicit-fetch core first, then deciding the order of the
-ergonomic layer — materialize-on-access is the headline UX, blocking is what the
-MCP server wants.
+**Done & tested — silent materialize + change tagging:**
+
+- **`Change.reason: ChangeReason` (Normal | Initial | Fill)** (decision 5, renamed
+  from `trigger` to avoid confusion with `triggered_by`). A placeholder fill is
+  tagged `Fill` via a `ctx.filling` flag read in `trigger_callbacks`. `Initial`
+  reserved (track-time replay not built).
+- **Silent materialize** (decision 4). A `blocking:` read now applies **only the
+  fetched object**, silently: `ctx.silent` makes `trigger_callbacks` defer its
+  callbacks to `ctx.pending_fills`, and the pump buffers every non-target message
+  to `ctx.pending_msgs`. Both are replayed at the start of the next explicit
+  `tick`, so nothing application-visible happens mid-read (clean reentrancy, and a
+  deterministic single-threaded test). (`materialize_tests.nim`)
+
+**Still open:**
+
+- **Remote silent pump.** The silent pump drains the **local** (cross-thread)
+  transport; the deferral machinery (`pending_msgs`/`pending_fills`/`silent`) is
+  transport-agnostic, but the network receive (reactor parse + per-sub source
+  decode) isn't wired into it yet. enu_mcp's poll loop uses the (working)
+  non-blocking path, so this is the blocking-scope-over-network gap.
+- **`tick` receive/process split** (decision 3) — `tick` itself is untouched; the
+  silent pump sits beside it rather than being a true split.
+- **`Initial` reason** — track-time replay of current contents.
 
 ## Decisions log (for review)
 

--- a/docs/partial-replicas-spike.md
+++ b/docs/partial-replicas-spike.md
@@ -52,6 +52,42 @@ unknown-type schema part is unneeded, since `O` gives the type.)
 | **Fetch protocol** | New message exchange: subscriber → authority **REQUEST(object_id)**; authority → subscriber the object's `CREATE` + current state, and adds it to that sub's interest set so future ops flow. Mirrors the existing SUBSCRIBE/ACK handshake. |
 | **Materialize-on-access** | The container's access paths (`items`/`[]`) detect a lazy handle and kick off a fetch **once**; the handle fills in asynchronously and fires a change. |
 
+## Implementation status (this session)
+
+**Done & tested** (opt-in, non-breaking — default is still a full replica):
+
+- **P3a — interest sets + filtered delivery.** `Subscription.partial` +
+  `interest`. The filter is applied in all three send paths: `add_subscriber`
+  (initial push), `fanout`/`publish_changes` (ongoing ops), and `publish_create`
+  (new-object broadcasts). `subscribe(ctx, partial = true, roots = @[...])`.
+- **P3b — fetch protocol.** `REQUEST` message + `EdContext.fetch(id)`; the
+  authority adds the id to that subscriber's interest and `publish_create`s it.
+- **Gap fixes:** post-subscribe creations are filtered (not just the initial
+  push); a partial client's **own** created objects auto-join its interest on the
+  authority, so its writes get return-to-source/convergence.
+
+So a context can now subscribe to a subset, receive only that subset's ops, and
+**explicitly** pull more on demand with `fetch` — the core of partial replicas.
+
+**Logged for tomorrow** (not yet built — the ergonomic layer, and the riskier
+bits I didn't want to rush solo):
+
+- **Transparent materialize-on-access.** Today fetch is *explicit*. The "nested
+  objects don't exist until accessed via the seq" experience needs: a **typed
+  lazy handle** for a non-resident nested `Ed` (turn the `assert object_id in
+  self.ctx` at `initializers.nim` `when O is Ed:` into a placeholder), plus
+  container access (`[]`/`items`) auto-firing a `fetch`. The blocker is a
+  **non-broadcasting placeholder constructor** for an arbitrary `Ed[T,O]` — the
+  current `init`/`defaults` always `publish_create`s. (The parked `EdDynamic`
+  work is the untyped version of this primitive.)
+- **`tick` receive/process split + `blocking:` scope** (decisions 3–4). I kept
+  `tick` untouched this session; the split + silent-materialize is the next piece.
+- **Initial / Fill callbacks + `Change.trigger`** (decision 5).
+
+Recommend reviewing the explicit-fetch core first, then deciding the order of the
+ergonomic layer — materialize-on-access is the headline UX, blocking is what the
+MCP server wants.
+
 ## Decisions log (for review)
 
 Resolved with Scott, or gut-calls made during implementation (flagged ⚙️):

--- a/docs/partial-replicas-spike.md
+++ b/docs/partial-replicas-spike.md
@@ -104,15 +104,27 @@ So a context can now subscribe to a subset, receive only that subset's ops, and
   `tick`, so nothing application-visible happens mid-read (clean reentrancy, and a
   deterministic single-threaded test). (`materialize_tests.nim`)
 
+**Done & tested — remote partial replicas (full network path):**
+
+- **Remote partial subscribe.** `subscribe(address, partial = ..., roots = ...)`;
+  the SUBSCRIBE message carries `(capabilities, partial, roots)` and the authority
+  builds a filtered subscription from it. Mirrors the local subscribe.
+- **Placeholders on initial push.** `from_flatty` for a nested `Ed` ref now
+  placeholders a non-resident child instead of leaving it nil — so a partial
+  replica receiving a **pre-populated** parent (the real enu_mcp `root_units` case)
+  gets correct cardinality, and a full replica that gets a parent before its child
+  fills the placeholder when the child's CREATE arrives.
+- **Remote silent pump.** `parse_remote` extracted (shared by `tick` and the
+  pump — no duplicated wire decode, no `tick` split); the silent pump drains both
+  transports and resolves source eagerly so deferred messages process sub-less.
+- **End-to-end test:** a remote partial replica subscribes over UDP, gets a
+  placeholder for an out-of-interest child, and `blocking:`-materializes it against
+  a threaded authority. Stable across repeated runs. (`materialize_tests.nim`)
+
 **Still open:**
 
-- **Remote silent pump.** The silent pump drains the **local** (cross-thread)
-  transport; the deferral machinery (`pending_msgs`/`pending_fills`/`silent`) is
-  transport-agnostic, but the network receive (reactor parse + per-sub source
-  decode) isn't wired into it yet. enu_mcp's poll loop uses the (working)
-  non-blocking path, so this is the blocking-scope-over-network gap.
-- **`tick` receive/process split** (decision 3) — `tick` itself is untouched; the
-  silent pump sits beside it rather than being a true split.
+- **`tick` receive/process split** (decision 3) — deliberately *not* done;
+  `parse_remote` got the de-duplication win without refactoring `tick`'s hot path.
 - **`Initial` reason** — track-time replay of current contents.
 
 ## Decisions log (for review)

--- a/docs/partial-replicas-spike.md
+++ b/docs/partial-replicas-spike.md
@@ -52,6 +52,48 @@ unknown-type schema part is unneeded, since `O` gives the type.)
 | **Fetch protocol** | New message exchange: subscriber → authority **REQUEST(object_id)**; authority → subscriber the object's `CREATE` + current state, and adds it to that sub's interest set so future ops flow. Mirrors the existing SUBSCRIBE/ACK handshake. |
 | **Materialize-on-access** | The container's access paths (`items`/`[]`) detect a lazy handle and kick off a fetch **once**; the handle fills in asynchronously and fires a change. |
 
+## Decisions log (for review)
+
+Resolved with Scott, or gut-calls made during implementation (flagged ⚙️):
+
+1. **Opt-in, non-breaking.** Partial sync is gated; default stays full-push, so
+   Enu and existing tests are unaffected. Enabled per-subscription (a partial
+   subscribe) and/or a context flag.
+2. **Two consumer modes, both plain sync (no async/chronos).**
+   - *Game loop:* **placeholder-then-fill** — access returns a handle now, fetch
+     in the background, fill fires a change.
+   - *Request/response (MCP server, scripts):* **`blocking:` scope** — accesses
+     inside it wait for materialization. This matches what `agent.query` already
+     does (tick-until-`MCP_DONE`).
+3. **`tick` semantics are unchanged.** Split `tick` internals into **receive**
+   (pump transport → buffer; no side effects) and **process** (apply buffer → fire
+   `changes`, re-broadcast, flush). `tick` = receive + process.
+4. **Blocking fetch = receive + *silent* materialize.** Send the fetch request,
+   pump I/O into the buffer until the response arrives, apply **only that object**
+   silently (no callbacks, no re-broadcast). Everything else — buffered messages,
+   the **Fill** callback for the materialized object, outgoing — waits for the next
+   explicit `tick`. So nothing application-visible happens outside an explicit
+   `tick`; re-entrant blocking access only does I/O.
+5. **Initial / Fill callbacks + `Change.trigger`.** On `track`, optionally replay
+   current contents as synthetic changes (`Initial`); on materialize, replay as
+   `Fill`. `EdValue` fires even for `nil`; an empty collection fires nothing (it
+   has no contents to replay). New `Change.trigger: Normal | Initial | Fill`,
+   orthogonal to `changes: set[ChangeKind]`. Builds on the existing `changes(bool)`
+   initial flag.
+6. ⚙️ **Fetch protocol.** New `MessageKind` `REQUEST` (subscriber → authority,
+   carries the requested `object_id`); the response is a normal `CREATE` for that
+   object (its initializer materializes it), and the authority adds the id to the
+   subscriber's interest set so future ops flow. Mirrors SUBSCRIBE/ACK.
+7. ⚙️ **Interest is grows-only until eviction (Phase 4).** A partial subscriber's
+   interest set only accumulates (roots + fetched ids). No shedding yet, so a long
+   session drifts back toward a full replica — acceptable for a first cut.
+8. ⚙️ **Bootstrap via explicit roots.** A partial subscriber declares root ids it
+   wants; `add_subscriber` pushes those (and, for now, nothing else). The
+   reference graph + fetch-on-access pull the rest.
+9. ⚙️ **Fetch granularity.** Start one-object-per-request; subtree/region fetch
+   (a `Unit` is a ref + several Ed-field objects, so it's really a subtree) is a
+   follow-up optimization — flagged by the MCP `Unit` access pattern.
+
 ## The crux: access is synchronous, fetch is asynchronous
 
 A game loop reads objects synchronously, but a fetch is a round-trip (cross-thread

--- a/docs/partial-replicas-spike.md
+++ b/docs/partial-replicas-spike.md
@@ -1,0 +1,123 @@
+# Partial Replicas — Design Spike
+
+> A context should only hold the objects it actually uses. Nested `Ed` objects
+> (e.g. the `EdTable`s inside an `EdSeq[EdTable]`) shouldn't exist in memory until
+> reached, and should materialize on access. This is Phase 3 of
+> `consistency-and-partial-sync-plan.md`. Eviction (dropping idle objects) is a
+> later phase — it needs a durable backing; plain partial sync does not.
+
+## How sync works today (the things partial replicas must change)
+
+- **Full push on subscribe.** `add_subscriber` (`subscriptions.nim`) iterates
+  **every** object in the context and `publish_create`s it to the new subscriber
+  (minus ones it says it already has). A new subscriber gets the whole world.
+- **Nested `Ed` objects are independent, id-referenced objects.** An
+  `EdSeq[EdTable]`'s elements are separate `Ed` objects in `ctx.objects`, keyed by
+  id; the seq's ops reference them by `change_object_id`, and each element syncs
+  as its own object (its own `CREATE` + ops). So the *entire object graph* syncs
+  eagerly.
+- **Presence is asserted, not fetched.** `change_receiver`'s nested paths require
+  the referenced object to be resident:
+  - `when O is Ed:` → `assert object_id in self.ctx` (`initializers.nim:177`).
+  - `when O is Pair[auto, Ed]:` → looks up the value by `change_object_id`
+    (`initializers.nim:194`).
+  We relaxed *some* missing-object/unknown-type sites to **skip** (the robustness
+  pass); partial sync turns those skips into **materialize/fetch** hooks.
+- **Fanout goes to all subscribers** (`publish_changes` → `fanout` over
+  `self.ctx.subscribers`). No per-object filtering.
+
+## The model: reference-driven lazy materialization
+
+Per the original framing: not explicit interest lists, but **the reference graph**
+drives what's held. A context syncs a few **roots**; nested `Ed` references are
+**lazy handles** (id + type, not resident) until reached; accessing one
+**fetches** it (current state + subscribe to its future ops). Your "interest set"
+is implicitly *what you've reached and not yet dropped*. Fits Enu's graph
+(GameState → units → builds → chunks) and matches the voxel snapshot+delta load.
+
+A handle is **typed** for free: the element type is the container's `O`, so a
+not-yet-materialized `EdSeq[EdTable]` element is a placeholder `EdTable` with a
+known id — no schema needed. (The parked `EdDynamic`/`create_dynamic_placeholder`
+work is the *placeholder-without-broadcast* mechanism to reuse here; only its
+unknown-type schema part is unneeded, since `O` gives the type.)
+
+## The pieces (and where they plug in)
+
+| Piece | What / where |
+|---|---|
+| **Per-subscriber interest set** | A `HashSet[string]` of object ids on each `Subscription` — what that subscriber holds/wants. The authority consults it for both the initial push and ongoing op delivery. |
+| **Roots / bootstrap** | `add_subscriber` pushes only a designated **root set** (explicitly-subscribed/created objects), not all objects. The reference graph discovers the rest. A client needs ≥1 root to start. |
+| **Op delivery filtering** | `fanout` (and `add_subscriber`) send an object's ops only to subscribers whose interest set contains its `object_id`. The hot change for "only sync what you use." |
+| **Lazy handle** | On receiving a container op that references a non-resident nested `Ed` (`change_object_id`), create a typed placeholder (`O` with that id, not broadcast) instead of asserting — the `assert object_id in self.ctx` sites become handle-or-fetch. |
+| **Fetch protocol** | New message exchange: subscriber → authority **REQUEST(object_id)**; authority → subscriber the object's `CREATE` + current state, and adds it to that sub's interest set so future ops flow. Mirrors the existing SUBSCRIBE/ACK handshake. |
+| **Materialize-on-access** | The container's access paths (`items`/`[]`) detect a lazy handle and kick off a fetch **once**; the handle fills in asynchronously and fires a change. |
+
+## The crux: access is synchronous, fetch is asynchronous
+
+A game loop reads objects synchronously, but a fetch is a round-trip (cross-thread
+tick or network RTT). You **cannot block** the main thread on access. Options:
+
+1. **Placeholder-then-fill (recommended).** Access returns the handle immediately
+   (empty/default state) and triggers an async fetch; when it lands, the handle
+   populates and a `track` callback fires. The app sees "empty, then real" — the
+   standard lazy-load pattern, and it matches Enu's existing chunk
+   snapshot/delta loading (a chunk pops in).
+2. **Prefetch a region/depth.** Eagerly fetch objects reachable within N hops of a
+   root (or within a spatial region) so they're usually resident by access time;
+   lazy beyond. Less "pure" but hides latency for hot data.
+3. **Blocking fetch.** Simple, but stalls the caller for an RTT — unacceptable on
+   the main thread.
+
+Recommendation: **(1) as the default**, with **(2)** as an optional prefetch
+policy for hot regions. This is the single most important UX decision — flag for
+Scott.
+
+## What this builds on / doesn't need
+
+- **Builds on:** the relaxed validation (a partial replica already tolerates ops
+  for objects it doesn't hold) and per-object reconciliation/frontier (delivery is
+  already per-object). The parked placeholder mechanism.
+- **Does *not* need:** the durable log (Phase 2). The authority is the full replica
+  and serves subsets from memory. The durable log is required only for **eviction**
+  (dropping objects + guaranteeing re-fetch) and persistence.
+
+## Key decisions to resolve
+
+1. **Async-access model** — placeholder-then-fill vs prefetch-region (above). *The
+   big one.*
+2. **Roots / bootstrap** — what does a fresh partial client get pushed? (Its own
+   objects? A designated shared root the authority always sends?)
+3. **Fetch granularity** — fetch one object per access, or a subtree/region per
+   request (fewer round-trips for graph-y data like a chunk + its deltas)?
+4. **Interest lifetime without eviction** — until eviction exists, does interest
+   only grow (never shed)? If so, a long session converges back toward a full
+   replica. Acceptable as a first step; eviction (Phase 4) sheds it.
+5. **Reference integrity** — an op references object B you don't hold and haven't
+   reached: drop (current), create a handle, or fetch? (Probably *handle* — keep
+   the structure, fetch on access.)
+6. **Authority-side memory** — the authority tracks an interest set per subscriber;
+   for many clients with disjoint interests this is the cost of the feature.
+
+## Proposed implementation phases
+
+- **P3a — Per-subscriber interest + filtered delivery.** Interest set on
+  `Subscription`; `add_subscriber` pushes roots only; `fanout`/`add_subscriber`
+  filter by interest. (Without lazy handles yet — a client explicitly subscribes
+  to a known root set and gets exactly that subgraph if it's pushed transitively.)
+- **P3b — Lazy handles + fetch protocol.** Typed placeholders for non-resident
+  nested `Ed`; REQUEST/response messages; presence asserts → handle-or-fetch.
+- **P3c — Materialize-on-access.** Container access kicks off the fetch
+  (placeholder-then-fill); change fires on populate.
+- **P3d — (later) Prefetch policy** and then **eviction** (Phase 4, needs durable
+  backing).
+
+## Risks / unknowns
+
+- The **async-access API** is the hard part — how the app sees "not loaded yet"
+  without blocking. Get this shape right first.
+- **Reference cycles** and re-entrant fetch (A references B references A).
+- **Interest churn** as a player moves (subscribe/unsubscribe storms); needs
+  hysteresis/regioning eventually.
+- **Bootstrap**: the first root must arrive for the graph to unfold — define how.
+- Cross-thread vs network fetch have different latencies but the same protocol;
+  validate cross-thread first (per the keystone pattern).

--- a/docs/ref-registration.md
+++ b/docs/ref-registration.md
@@ -1,0 +1,109 @@
+# Ref Registration — a runtime footgun worth a louder guard
+
+> Synced `ref object` payloads must be registered with `Ed.register(T)` (the
+> polymorphic registry, `type_registry.nim`). Value types never need it. When a
+> ref is *unregistered*, the failure surfaces late, on a peer, with a misleading
+> error — or silently. This documents the verified behavior and proposes a fix.
+
+## Registration is required for refs only — verified
+
+Empirically (local cross-thread subscription, authority → client; container tid
+registered, varying the ref registry):
+
+| Payload | `Ed.register`? | Result on the receiver |
+|---|---|---|
+| `int`, `string`, `seq[int]` (value types) | n/a | ✅ sync fine, never needs registration |
+| `Animal` (plain ref, **exact** type) | ❌ neither side | 💥 **`IndexDefect` crash** in flatty deserialize |
+| `Dog <: Animal` (subtype) | ❌ neither side | 💥 **`IndexDefect` crash** in flatty deserialize |
+| `Dog <: Animal` (subtype) | ✅ both sides | ✅ preserved as `Dog`, subclass fields intact |
+
+Two takeaways, one expected and one not:
+
+1. **Registration gates *all* synced refs, not just polymorphic ones.** Even an
+   exact-typed, single-class `ref object` crashes the receiver if unregistered —
+   registration isn't a "polymorphism" feature, it's the ref wire contract.
+2. **The unregistered failure is a hard crash, not a graceful skip.** The
+   send side serializes the ref via plain `to_flatty` with `ref_id = 0`
+   (`initializers.nim` build_message, "type not registered" branch); the receiver
+   takes the `ref_id == 0` path and `from_flatty`s the raw buffer against the
+   static type, which mis-frames and indexes off the end →
+   `IndexDefect: index N not in 0 .. N-1` deep in `flatty`.
+
+## Why "not alerting well enough" is the right concern (with a twist)
+
+The original worry was that a missing registration fails *silently*. The reality
+is two different bad modes depending on *who* registered:
+
+- **Neither peer registered** → **loud but cryptic.** It crashes
+  (`IndexDefect` in `flatty.nim`), so it's not silent — but the message points at
+  a buffer index, not at "you forgot `Ed.register(Dog)`." And it fires at runtime
+  on whichever peer deserializes first, far from the `add` that caused it. On the
+  **local/cross-thread path** there's no guard: `process_message`
+  (`subscriptions.nim:856`) runs the channel message directly, so the Defect
+  propagates and takes down the thread. (The **remote** path has a
+  `try/except CatchableError, Defect` around the wire decode at
+  `subscriptions.nim:889-893`, so a network peer swallows it — a third,
+  inconsistent behavior.)
+- **Producer registered, consumer didn't** → **silent drop.** The producer sends
+  a real `ref_id`; the consumer's `lookup_type` misses and hits the
+  `debug "skipping change for unknown ref type"` skip (`initializers.nim:214`).
+  No crash, no user-visible signal — the change just vanishes. *This* is the
+  genuinely silent one.
+
+So across the three transports/orderings you get crash, swallow, or silent drop —
+none of which says "register this type." That inconsistency is the bug to file,
+independent of whether we automate registration.
+
+### Proposed: a louder, earlier, type-named guard
+
+Cheap, non-breaking improvements, roughly in order of value:
+
+1. **Name the type at the failure site.** Where a ref is serialized unregistered
+   (build_message, currently `debug "type not registered"`) and where an unknown
+   `ref_id` is skipped (initializers.nim:214), log at **warning/error** with the
+   type name / `ref_id`, not `debug`. One line turns "cryptic IndexDefect later"
+   into "Dog is not registered — call `Ed.register(Dog)`."
+2. **Frame unregistered refs so receive fails cleanly.** Have the unregistered
+   send path write the same is-registered framing the custom ref `from_flatty`
+   (`subscriptions.nim:100-135`) expects, so a missing type is a detected
+   "unknown ref" skip everywhere instead of an `IndexDefect` on the local path.
+   Makes the three transports behave consistently (skip, not crash).
+3. **Optional debug assertion.** Under `-d:ed_strict` (or the existing trace
+   flag), `assert`/`fail` with a type-named message when serializing an
+   unregistered ref, so it trips in tests at the offending `add`, not later on a
+   peer.
+
+## The deeper fix: declaration-site (host-site) registration
+
+The manual manifest (`enu/src/types.nim:473-477`: `Ed.register(Player/Build/…)`)
+already closes the gap — every peer that imports the type module registers the
+hierarchy, so the runtime registry is correct. Its only weakness is that it's
+**hand-maintained and forgettable**: add a 5th `ref object of Unit`, forget the
+`Ed.register` line, and you get one of the three failure modes above.
+
+**Declaration-site registration** removes the footgun: declare a syncable ref via
+an Ed macro/pragma at its definition ("host") site, which both defines the type
+*and* registers it (adds to a compile-time `CacheSeq`; a bootstrap step emits
+`register_type` for each entry). Any peer that compiles the declaration registers
+it automatically — still fully static, no runtime schema exchange, but you can't
+declare a synced subtype without registering it.
+
+Note this buys **no new capability** over the manual manifest — it produces the
+identical registry — it only makes the registration **underivable-by-omission**.
+So it's a low-priority ergonomic hardening: worth it once the ref hierarchy grows
+fast enough (or spreads across enough modules) that "forgot the register line"
+becomes a recurring risk; the **louder guard above is the higher-value, smaller
+change** and should land first regardless.
+
+## Caveats on the verification
+
+- The crash/skip rows are runtime-verified on a single-process, cross-thread local
+  subscription. The "producer-registered/consumer-not → silent drop" row is
+  **code-confirmed** (initializers.nim:214) but not runtime-reproduced, because the
+  ref registry is process-global and can't be made asymmetric within one process.
+- Harness gotcha discovered while verifying: `Ed.bootstrap` snapshots the
+  compile-time `INITIALIZERS` list **at its expansion point**, so a type must be
+  instantiated *before* `Ed.bootstrap` (e.g. in an imported module, as enu does)
+  for its **container** tid to register. Types instantiated *after* bootstrap in
+  the same module silently never sync — a separate, related "registration timing"
+  sharp edge worth a doc note of its own.

--- a/docs/static-type-usage-spike.md
+++ b/docs/static-type-usage-spike.md
@@ -1,0 +1,194 @@
+# Static Type-Usage Spike — "what types does a consumer actually use?"
+
+> Research spike answering: can Ed statically identify which `Ed[T,O]` types a
+> consumer (e.g. `enu_mcp`) *actually accesses*, so a partial replica can declare
+> interest by **capability** automatically — instead of the coarse "I have a tid
+> for it" signal? Short answer: **yes, and it's meaningfully tighter.**
+
+## The problem with "tid exists"
+
+The obvious capability signal is "the set of types I have an initializer for"
+(`INITIALIZERS` CacheSeq → a `tid` per type). A partial replica could advertise
+those tids and the authority would only send objects whose type it can
+materialize. But **instantiation over-includes**: a generic `init`/`defaults`
+gets compiled if it's *reachable*, not if it's *used*.
+
+`enu_mcp` is the case in point. It builds `Shared` via `init_ed_fields`, which
+transitively instantiates the voxel **edit tables**
+(`Ed[Table[EditKey, SnapshotData], …]`, `Ed[Table[EditKey, EdSeq[DeltaUpdate]], …]`)
+— so `enu_mcp` *has tids* for them and would advertise interest in the voxel
+firehose, even though **no reachable code path in `enu_mcp` ever reads a voxel
+edit**. The chunk tables (`Vector3`-keyed) aren't even instantiated; the edit
+tables are, purely incidentally. "tid exists" can't tell incidental
+instantiation from real use.
+
+## The idea: instrument the *read* API, not construction
+
+A generic **accessor** proc is also only instantiated when called. If we tag every
+public read accessor with a compile-time registration, the set of types whose
+accessors got instantiated is the set of types **some compiled code reads** —
+a "uses" signal independent of "constructs."
+
+The read surface of `Ed` is small and centralized (`zens/operations.nim`,
+`zens/tracking.nim`):
+
+| Accessor | Reads |
+|---|---|
+| `value*[T,O]` | the whole value of an `EdValue`/register |
+| `items*`, `pairs*` | iterate a seq/set/table |
+| `` `[]`* `` | index a seq/table |
+| `contains*`, `len*` | membership / cardinality |
+
+Spike instrumentation: a `static: echo "ACCESS:: ", $Ed[…]` on `value`,
+`items` (×2), `pairs`, and both `` `[]` `` overloads, then
+`nim check bin/enu_mcp.nim` and collect the distinct lines. (Temporary; reverted.)
+
+## Empirical result (enu_mcp)
+
+| Signal | Count | Includes voxel edit tables? |
+|---|---|---|
+| **Instantiated** (has a tid) | 17 | **YES** (incidental, via `Shared.init_ed_fields`) |
+| **Accessed** (read API called) | 25 | **NO** |
+
+The headline: **the accessed set excludes the voxel edit tables.** The thing we
+wanted gone — the incidental, potentially-huge voxel interest — is gone, for free,
+because `enu_mcp` constructs those tables but never iterates/indexes/reads them.
+
+### The 25 is not a subset of the 17 — and that's the interesting part
+
+"Accessed" is *not* "instantiated minus the unused." It's a **different
+projection**. Eight types are accessed-but-not-instantiated in `enu_mcp`:
+
+```
+Ed[types.Config]  Ed[types.Player]  Ed[types.Sign]  Ed[types.Tools]
+Ed[system.bool]   Ed[system.int64]  Ed[godotcoretypes.AABB]
+Ed[seq[string]]   Ed[seq[tuple[id,normal]]]  Ed[seq[LocalStateFlags]] …
+```
+
+These are read by procs in imported model modules (`states`, `players`, `units`)
+that `enu_mcp` compiles but that never **construct** those objects on a reachable
+path. So:
+
+- **Instantiated** = "types my compiled code can *construct*" → includes
+  incidental construction (the edit tables via `init_ed_fields`).
+- **Accessed** = "types my compiled code can *read*" → includes reads in
+  imported-but-unreached procs (Config/Player/…), excludes construct-only types
+  (the edit tables).
+
+### …but accessed *alone* is unsound — you can't materialize 7 of those 8
+
+The accessed-not-instantiated types are a **trap**, not free interest. The
+registry that lets a context *receive* an object — `type_initializers[tid]` — is
+populated **only** by `create_initializer` (`initializers.nim:15`), which runs on
+the **construction** path (`defaults`, line 58). Reading never touches it. So
+"accessed but not instantiated" means, by construction, the read accessor compiled
+but `create_initializer` did **not** → the type is **not in `INITIALIZERS`**, gets
+**no registry entry**, and has **no usable tid**. If the authority sent a `CREATE`
+for a `Config`, the client would hit the unknown-type path and drop it. The
+accessor code reading those types is **dead** at runtime — nothing on a reachable
+path constructs or receives one, so there's no object to read.
+
+(Airtight, not just empirical: a registered type's nested Ed fields get their
+`defaults` instantiated *inside* the parent's initializer, so they'd be in the
+instantiated set too. Config isn't → genuinely unregistered.)
+
+So the two projections each admit a *different, disqualifying* failure mode:
+
+- **Instantiated** = "types I can *materialize*" → over-includes **construct-only**
+  types (the edit tables: registered but never read → pure waste to sync).
+- **Accessed** = "types I can *read*" → over-includes **read-in-dead-code** types
+  (Config/Player/…: read in unreached procs but **unmaterializable** → broken to
+  request).
+
+### The sound signal is the intersection
+
+What partial-replica interest actually wants is **instantiated ∧ accessed** —
+"types I can *both* materialize *and* will read":
+
+| | Materializable | Read | Interest |
+|---|:---:|:---:|:---:|
+| voxel edit tables | ✓ | ✗ | **no** — never read it |
+| Config / Player / Sign / Tools | ✗ | ✓ | **no** — *can't* materialize it |
+| Unit, Shared, McpQuery, … | ✓ | ✓ | **yes** |
+
+Intersection eliminates *both* failure modes at once. This corrects an earlier
+draft of this doc that treated intersection as needless tightening and the
+accessed-only extras as "harmless small singletons" — they're not harmless, they're
+**unmaterializable**, so intersection is required for **soundness**, not just
+precision.
+
+## Caveats (what "accessed" does *not* give you)
+
+1. **It's an over-approximation of reachable use.** Accessor instantiation fires
+   for any *compiled* read, including reads in imported procs that `enu_mcp`'s
+   `main` never calls (that's why Config/Player/Sign/Tools show up — read somewhere
+   in the `states`/`players` modules). It is **not** "read on a live path from
+   main." For the **accessed** projection this over-inclusion is what produces the
+   unmaterializable types above; the **intersection** with instantiated removes
+   them, since you can't construct what you never compile a constructor for.
+   Eliminating the residual dead-code over-inclusion entirely would need
+   whole-program call-graph analysis (below) — not worth it once intersection has
+   removed the disqualifying cases.
+2. **Reads must go through the public accessors.** Ed values are encapsulated
+   (you read via `.value`/`.items`/`[]`), so in practice this holds. Code that
+   reaches into `.tracked` directly would bypass the signal — but that's Ed
+   internals, not consumer code.
+3. **Ed-internal reads don't pollute it.** The reconciliation/serialization paths
+   move bytes (`change_receiver`, flatty) without calling the public typed
+   accessors, so internal machinery touching the edit tables does **not** register
+   them as accessed. Confirmed empirically — zero edit-table reads in the accessed
+   set despite the tables being live, synced internals.
+4. **Static, not per-object.** It tells you *types*, not *which instances*. It's a
+   **capability/type-interest** filter (drop whole voxel type) — orthogonal to the
+   per-object `interest` set in `partial-replicas-spike.md` (which object ids).
+   They compose: type filter trims the firehose categorically; object interest
+   trims within a kept type.
+
+## The menu of approaches considered
+
+| Approach | What | Verdict |
+|---|---|---|
+| **tid exists** (instantiated) | Advertise the `INITIALIZERS` tids | Baseline. Over-includes **construct-only** types (the edit tables) → syncs the voxel firehose. What we're trying to beat. |
+| **Accessed-only** | A CacheSeq populated by the public read accessors; "accessed types" → type-interest | **Unsound on its own.** Over-includes **unmaterializable** types (Config/Player/…: read in dead code, no registered initializer) → requests objects the client can't construct. Excludes the firehose, but trades one bad failure mode for another. |
+| **Intersection** (instantiated ∧ accessed) | Types both materializable *and* read | **Recommended.** The only projection with neither failure mode: drops construct-only types (firehose) *and* unmaterializable reads. Two CacheSeqs (reuse `INITIALIZERS` + add `ACCESSED_TYPES`), intersect their tids at bootstrap. |
+| **Whole-program call-graph** | Macro/analysis pass: only reads reachable from `main` | Most precise, but heavy and fragile against Nim's generic/dispatch model. Not worth it for a few small over-included singletons. |
+| **Effect-system tagging** | Annotate procs with the Ed types they touch; propagate as effects | Compiler-enforced and precise, but **manual** — defeats "automatic." A documentation/lint tool, not an interest source. |
+| **Runtime access-report** | Instrument live accesses; report the types actually touched at runtime | Complementary, not competing. Catches dynamic reality the static pass can't, and is the natural feed for **eviction** (Phase 4). Pair it with the static signal. |
+
+## Recommendation — design it into Ed
+
+Add an **`ACCESSED_TYPES` CacheSeq**, populated the same way `INITIALIZERS` is, but
+from the public read accessors (`value`, `items`, `pairs`, `[]`, optionally
+`contains`/`len`). At bootstrap, **intersect** its tids with the already-registered
+`INITIALIZERS` tids → `Ed.interest_tids` (the `hash($T)` of each type that is both
+materializable and read). Then:
+
+- A partial/capability-filtered subscriber advertises `interest_types =
+  Ed.interest_tids` **automatically** — "send me only types I can build *and* will
+  read." The authority drops objects whose `type_id` isn't in that set before it
+  ever consults per-object interest.
+- This is strictly better than "tid exists" and requires no annotation from the
+  consumer — `enu_mcp` gets voxel-free sync *by virtue of not reading voxels*,
+  which is exactly the invariant the user wanted to encode — while the intersection
+  guarantees every advertised type is one the client can actually materialize.
+
+Compose with the existing per-object `interest` (object ids) from the partial
+replicas work: **type-interest** is the categorical/capability cut (cheap, static,
+kills the firehose); **object-interest** is the fine cut (which instances). And
+keep the **runtime access-report** on the roadmap as the dynamic counterpart that
+feeds eviction.
+
+### Open questions before building
+
+1. Which accessors to tag — reads only (`value`/`items`/`pairs`/`[]`), or also
+   `contains`/`len`? (Reads-only is the cleanest "I consume the contents" signal;
+   `len`/`contains` is "I probe existence" — arguably still interest.)
+2. Wire it into the handshake: does the subscriber send `accessed_tids` at
+   subscribe time (authority filters), or does the authority send a type
+   manifest and the subscriber replies with the subset it can read? (The former
+   is simpler and matches `transport-and-schema-compatibility.md`'s capability
+   handshake.)
+3. Same-build subtlety (`enu_mcp`): it *does* have tids for the edit tables (same
+   source tree), so a pure tid handshake wouldn't help — which is exactly why the
+   **accessed** signal, not the **instantiated** one, is the right thing to put on
+   the wire.

--- a/src/ed/components/private/tracking.nim
+++ b/src/ed/components/private/tracking.nim
@@ -13,15 +13,33 @@ proc `-`*[T](a, b: seq[T]): seq[T] =
 template `&`*[T](a, b: set[T]): set[T] =
   a + b
 
-proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) =
+proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) {.gcsafe.} =
   private_access EdObject[T, O]
   private_access EdBase
 
-  if changes.len > 0:
-    let callbacks = self.changed_callbacks.dup
-    for zid, callback in callbacks.pairs:
-      if zid in self.changed_callbacks and zid notin self.paused_eids:
-        callback(changes)
+  if changes.len == 0:
+    return
+
+  # Tag changes produced while filling a placeholder so callbacks can tell a
+  # materialize-on-access fill from an ordinary mutation.
+  if self.ctx != nil and self.ctx.filling:
+    for c in changes:
+      c.reason = Fill
+
+  # Silent (blocking) materialize: nothing application-visible fires mid-fetch —
+  # defer the callbacks to the next explicit tick (preserves tick-boundary
+  # semantics and clean reentrancy). The value is already applied, so the
+  # blocking read still returns real data.
+  if self.ctx != nil and self.ctx.silent:
+    let deferred = changes
+    self.ctx.pending_fills.add proc() {.gcsafe.} =
+      self.trigger_callbacks(deferred)
+    return
+
+  let callbacks = self.changed_callbacks.dup
+  for zid, callback in callbacks.pairs:
+    if zid in self.changed_callbacks and zid notin self.paused_eids:
+      callback(changes)
 
 proc link_child*[K, V](
     self: EdTable[K, V], child, obj: Pair[K, V], field_name = ""

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -519,6 +519,20 @@ proc fetch*(self: EdContext, object_id: string) =
     self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
 
+proc flush_key_requests(self: EdContext) =
+  ## Send the per-key fetches buffered since the last tick — one REQUEST per
+  ## table, carrying the batch of serialized keys in `obj`. The authority replies
+  ## with an ADD op per found key (see the REQUEST handler).
+  if self.pending_key_requests.len == 0:
+    return
+  let pending = self.pending_key_requests
+  self.pending_key_requests.clear
+  for object_id, keys in pending:
+    let msg = Message(kind: REQUEST, object_id: object_id, obj: keys.to_flatty)
+    for sub in self.subscribers:
+      self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  self.tick_reactor
+
 proc subscribe*(
     self: EdContext,
     address: string,
@@ -737,14 +751,26 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       if s.ctx_id in source:
         s.interest.incl msg.object_id
   elif msg.kind == REQUEST:
-    # A partial subscriber wants this object. Add it to that subscriber's
-    # interest (so future ops follow) and send it now via publish_create. The
-    # requester is whoever the message came from — match by ctx id in `source`.
+    # A partial subscriber wants data. Two forms:
+    #  - whole-object (`obj` empty): add the object to interest and publish_create
+    #    it (existing behavior — future ops then follow).
+    #  - per-key (`obj` = a batch of serialized table keys): reply with just those
+    #    entries (an ADD op each), without adding the whole table to interest.
+    # The requester is whoever the message came from — match by ctx id in `source`.
     for s in self.subscribers:
-      if s.ctx_id in source:
+      if s.ctx_id notin source:
+        continue
+      if msg.object_id notin self:
+        continue
+      if msg.obj.len > 0:
+        let obj = self.objects[msg.object_id]
+        for key_bin in msg.obj.from_flatty(seq[string]):
+          let reply = obj.publish_key(obj, key_bin)
+          if reply.found:
+            self.send(s, reply.msg, OperationContext(), DEFAULT_FLAGS)
+      else:
         s.interest.incl msg.object_id
-        if msg.object_id in self:
-          self.objects[msg.object_id].publish_create(s)
+        self.objects[msg.object_id].publish_create(s)
   elif msg.kind != BLANK:
     if msg.object_id notin self:
       # :( this should throw an error
@@ -883,6 +909,7 @@ proc tick*(
       get_mono_time() + min_duration
 
   self.flush_buffers
+  self.flush_key_requests # send this frame's batched per-key fetches
 
   # Replay whatever a silent (blocking) materialize deferred — at this tick
   # boundary, before new traffic: first the messages it buffered (apply + fire

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -490,6 +490,17 @@ proc subscribe*(
     # Reverse direction (us → authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false)
 
+proc fetch*(self: EdContext, object_id: string) =
+  ## Ask the authority for `object_id`. It's materialized on a later tick
+  ## (placeholder-then-fill); the authority adds it to our interest so future
+  ## ops follow. No-op if we already hold it.
+  if object_id in self:
+    return
+  var msg = Message(kind: REQUEST, object_id: object_id)
+  for sub in self.subscribers:
+    self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  self.tick_reactor
+
 proc subscribe*(
     self: EdContext,
     address: string,
@@ -691,6 +702,15 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         ),
       )
       # :(
+  elif msg.kind == REQUEST:
+    # A partial subscriber wants this object. Add it to that subscriber's
+    # interest (so future ops follow) and send it now via publish_create. The
+    # requester is whoever the message came from — match by ctx id in `source`.
+    for s in self.subscribers:
+      if s.ctx_id in source:
+        s.interest.incl msg.object_id
+        if msg.object_id in self:
+          self.objects[msg.object_id].publish_create(s)
   elif msg.kind != BLANK:
     if msg.object_id notin self:
       # :( this should throw an error

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -702,6 +702,11 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         ),
       )
       # :(
+    # The creator is interested in its own object: make sure its canonical ops
+    # flow back. Matters for partial subscribers; a no-op for full ones.
+    for s in self.subscribers:
+      if s.ctx_id in source:
+        s.interest.incl msg.object_id
   elif msg.kind == REQUEST:
     # A partial subscriber wants this object. Add it to that subscriber's
     # interest (so future ops follow) and send it now via publish_create. The

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -273,6 +273,8 @@ proc fanout(
     source.incl self.id
   var body, body_no_overwrite: string
   for sub in targets:
+    if sub.partial and msg.object_id notin sub.interest:
+      continue  # partial subscriber: only ops for objects it's interested in
     if sub.kind == LOCAL:
       self.send(sub, msg, op_ctx, flags)
     elif sub.kind == REMOTE and SYNC_REMOTE in flags:
@@ -424,6 +426,8 @@ proc add_subscriber*(
   debug "adding subscriber", sub
   self.subscribers.add sub
   for id in self.objects.keys.to_seq.reversed:
+    if sub.partial and id notin sub.interest:
+      continue  # partial subscriber: only push objects it's interested in
     if id notin remote_objects or push_all:
       debug "sending object on subscribe",
         from_ctx = self.id, to_ctx = sub.ctx_id, ed_id = id
@@ -449,8 +453,16 @@ proc process_value_initializers(self: EdContext) =
     initializer()
   self.value_initializers = @[]
 
-proc subscribe*(self: EdContext, ctx: EdContext, bidirectional = true) =
-  ## Subscribe to another local context for cross-thread sync.
+proc subscribe*(
+    self: EdContext,
+    ctx: EdContext,
+    bidirectional = true,
+    partial = false,
+    roots: seq[string] = @[],
+) =
+  ## Subscribe to another local context for cross-thread sync. When `partial`,
+  ## we only receive objects in `roots` (and ids we later fetch) — the
+  ## authority→us direction is filtered; our own writes still flow to it.
   privileged
   debug "local subscribe", ctx = self.id
   self.pack_objects
@@ -459,7 +471,13 @@ proc subscribe*(self: EdContext, ctx: EdContext, bidirectional = true) =
     remote_objects.incl id
   self.subscribing = true
   ctx.add_subscriber(
-    Subscription(kind: LOCAL, chan: self.chan, ctx_id: self.id),
+    Subscription(
+      kind: LOCAL,
+      chan: self.chan,
+      ctx_id: self.id,
+      partial: partial,
+      interest: roots.toHashSet,
+    ),
     push_all = bidirectional,
     remote_objects,
   )
@@ -469,6 +487,7 @@ proc subscribe*(self: EdContext, ctx: EdContext, bidirectional = true) =
   self.process_value_initializers
 
   if bidirectional:
+    # Reverse direction (us → authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false)
 
 proc subscribe*(

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -109,6 +109,12 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
       # :(
       if info.object_id in flatty_ctx:
         value = value.type()(flatty_ctx.objects[info.object_id])
+      else:
+        # A nested Ed reference we don't hold (a partial replica receiving a
+        # pre-populated parent, or a parent that arrived before its child).
+        # Stand it in with a placeholder rather than leaving the ref nil; reading
+        # it later materializes it (or its own CREATE fills it when it arrives).
+        value = value.type.init_placeholder(flatty_ctx, info.object_id)
   else:
     var is_registered: bool
     s.from_flatty(i, is_registered)
@@ -517,9 +523,14 @@ proc subscribe*(
     self: EdContext,
     address: string,
     bidirectional = true,
+    partial = false,
+    roots: seq[string] = @[],
     callback: proc() {.gcsafe.} = nil,
 ) =
-  ## Subscribe to a remote context for network sync. Address format: "host" or "host:port".
+  ## Subscribe to a remote context for network sync. Address format: "host" or
+  ## "host:port". When `partial`, the authority only sends objects in `roots`
+  ## (and ids fetched later); the reference graph + materialize-on-access pull the
+  ## rest. Mirrors the local `subscribe(partial = ..., roots = ...)`.
   var address = address
   var port = 9632
 
@@ -538,9 +549,11 @@ proc subscribe*(
     port = parts[1].parse_int
 
   let connection = self.reactor.connect(address, port)
-  # Advertise the type-ids we can materialize so the authority never sends us an
-  # object we can't construct (capability handshake; see ref-registration.md).
-  let capabilities = toSeq(type_initializers.keys).to_flatty
+  # The SUBSCRIBE carries, in `obj`, the subscriber's handshake: the type-ids it
+  # can materialize (capability filter; see ref-registration.md) plus its
+  # partial-replica interest (partial flag + root ids). The authority applies all
+  # three to the subscription it creates for us.
+  let handshake = (toSeq(type_initializers.keys), partial, roots).to_flatty
   self.send(
     Subscription(
       kind: REMOTE,
@@ -548,7 +561,7 @@ proc subscribe*(
       connection: connection,
       last_sent_time: epoch_time(),
     ),
-    Message(kind: SUBSCRIBE, obj: capabilities),
+    Message(kind: SUBSCRIBE, obj: handshake),
   )
 
   var ctx_id = ""
@@ -983,19 +996,26 @@ proc tick*(
               old_ctx_id = sub.ctx_id, new_ctx_id = source_str
             self.unsubscribe(sub)
 
+          # Handshake (capabilities, partial, roots) rides in the SUBSCRIBE `obj`.
+          # Empty (older peer) = unfiltered, full replica.
+          var caps: HashSet[int]
+          var is_partial = false
+          var interest: HashSet[string]
+          if msg.obj.len > 0:
+            let (cap_ids, p, roots) =
+              msg.obj.from_flatty((seq[int], bool, seq[string]))
+            caps = cap_ids.to_hash_set
+            is_partial = p
+            interest = roots.to_hash_set
+
           var new_sub = Subscription(
             kind: REMOTE,
             connection: raw_msg.conn,
             ctx_id: source_str,
             last_sent_time: epoch_time(),
-            # Capability handshake: the SUBSCRIBE carries the subscriber's
-            # materializable type-ids in `obj`. We filter all sends to it by
-            # this set. Empty (older peer) = unfiltered, full replica.
-            capabilities:
-              if msg.obj.len > 0:
-                msg.obj.from_flatty(seq[int]).to_hash_set
-              else:
-                init_hash_set[int](),
+            capabilities: caps,
+            partial: is_partial,
+            interest: interest,
           )
           # Register all mappings from the subscribe message
           new_sub.register_mappings(msg.id_mappings)

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -796,6 +796,30 @@ proc track*[T, O](
 proc untrack_on_destroy*(self: ref EdBase, zid: EID) =
   self.bound_eids.add(zid)
 
+proc parse_remote(
+    self: EdContext, raw_msg: netty.Message
+): tuple[ok: bool, msg: Message] {.gcsafe.} =
+  ## Decode one raw remote packet into a Message (source short-ids + mappings
+  ## attached, body uncompressed). ok = false for keepalive pings and unparseable
+  ## bytes — a version-skewed peer or stray packet on the same port is dropped,
+  ## not fatal. Shared by `tick` and the silent materialize pump so the wire
+  ## decode lives in exactly one place.
+  if raw_msg.data == "PING":
+    return (false, Message())
+  try:
+    # Wire format: a small per-subscriber header (source short-ids + new
+    # mappings) followed by the shared, compressed body (see send_remote).
+    let (enc_source, mappings, body) =
+      raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
+    var msg = body.uncompress.from_flatty(Message, self)
+    msg.source = enc_source
+    msg.id_mappings = mappings
+    return (true, msg)
+  except CatchableError, Defect:
+    warn "dropping unparseable remote message",
+      bytes = raw_msg.data.len, peer = $raw_msg.conn.address
+    return (false, Message())
+
 proc tick*(
     self: EdContext,
     messages = int.high,
@@ -904,27 +928,10 @@ proc tick*(
 
       for raw_msg in messages:
         inc count
-        # Handle keepalive pings - just ignore them (receiving updates lastActiveTime in netty)
-        if raw_msg.data == "PING":
+        let parsed = self.parse_remote(raw_msg)
+        if not parsed.ok: # keepalive ping or unparseable — already handled
           continue
-        # Parse boundary for untrusted bytes: a version-skewed peer or stray
-        # packet (e.g. another process on the same port) can't be parsed with
-        # our envelope. Drop it instead of crashing — don't let one bad packet
-        # take down the process. Scoped to (de)serialization so it doesn't mask
-        # logic bugs in process_message.
-        var msg: Message
-        try:
-          # Wire format: a small per-subscriber header (source short-ids + new
-          # mappings) followed by the shared, compressed body (see send_remote).
-          let (enc_source, mappings, body) =
-            raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
-          msg = body.uncompress.from_flatty(Message, self)
-          msg.source = enc_source
-          msg.id_mappings = mappings
-        except CatchableError, Defect:
-          warn "dropping unparseable remote message",
-            bytes = raw_msg.data.len, peer = $raw_msg.conn.address
-          continue
+        var msg = parsed.msg
         when defined(zen_debug_messages):
           inc self.messages_received
           self.obj_bytes_received += msg.obj.len
@@ -1026,11 +1033,8 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   ## callback are deferred to the next explicit `tick`, so nothing
   ## application-visible happens mid-read (clean reentrancy). Bounded by a deadline
   ## so a gone authority can't hang the caller; it then falls back to the empty
-  ## placeholder, same as the non-blocking path.
-  ##
-  ## The silent pump currently drains the **local** (cross-thread) transport;
-  ## remote (network) silent materialize is a follow-up (the deferral machinery is
-  ## transport-agnostic — only the receive step needs the remote parse).
+  ## placeholder, same as the non-blocking path. Drains both the local
+  ## (cross-thread) and remote (network) transports.
   privileged
   if id notin self or not self.objects[id].placeholder:
     return
@@ -1038,16 +1042,40 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   if not self.blocking:
     return
 
+  template triage(candidate: Message) =
+    # Apply only the target object's CREATE (silently — its callback is
+    # deferred); buffer everything else for the next tick. SUBSCRIBE can't be
+    # replayed sub-less, but a blocking *client* shouldn't receive one.
+    if candidate.object_id == id and candidate.kind == CREATE:
+      self.process_message(candidate)
+    elif candidate.kind != SUBSCRIBE:
+      self.pending_msgs.add candidate
+
   let deadline = get_mono_time() + init_duration(seconds = 5)
   self.silent = true
   while id in self and self.objects[id].placeholder and
       get_mono_time() < deadline:
+    # Local transport.
     var m: Message
     while self.chan.try_recv(m):
-      if m.object_id == id and m.kind == CREATE:
-        self.process_message(m) # applies the value; its Fill callback is deferred
-      else:
-        self.pending_msgs.add m # everything else waits for the next tick
+      triage(m)
+    # Remote transport — reuse the same wire decode as tick, then resolve the
+    # source eagerly so a deferred message processes correctly sub-less later.
+    if ?self.reactor:
+      self.tick_reactor
+      let raws = self.remote_messages
+      self.remote_messages = @[]
+      for raw_msg in raws:
+        let parsed = self.parse_remote(raw_msg)
+        if not parsed.ok:
+          continue
+        var rmsg = parsed.msg
+        for s in self.subscribers:
+          if s.kind == REMOTE and s.connection == raw_msg.conn:
+            s.register_mappings(rmsg.id_mappings)
+            rmsg.source_set = s.decode_source(rmsg.source)
+            break
+        triage(rmsg)
   self.silent = false
 
 proc find_bare_return(n: NimNode): NimNode =

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -275,6 +275,12 @@ proc fanout(
   for sub in targets:
     if sub.partial and msg.object_id notin sub.interest:
       continue  # partial subscriber: only ops for objects it's interested in
+    if sub.capabilities.len > 0 and msg.type_id != 0 and
+        msg.type_id notin sub.capabilities:
+      # Peer can't materialize this type — never send its ops. type_id == 0
+      # (DESTROY / control) isn't type-gated; it's a no-op on a peer that never
+      # got the CREATE, and must reach a peer that did.
+      continue
     if sub.kind == LOCAL:
       self.send(sub, msg, op_ctx, flags)
     elif sub.kind == REMOTE and SYNC_REMOTE in flags:
@@ -447,6 +453,10 @@ proc unsubscribe*(self: EdContext, sub: Subscription) =
   self.subscribers.delete self.subscribers.find(sub)
   self.unsubscribed.add sub.ctx_id
 
+# Defined after `tick` (which it pumps); forward-declared so `subscribe` can wire
+# it onto each subscribing context.
+proc materialize_impl(self: EdContext, id: string) {.gcsafe.}
+
 proc process_value_initializers(self: EdContext) =
   debug "running deferred initializers", ctx = self.id
   for initializer in self.value_initializers:
@@ -465,6 +475,7 @@ proc subscribe*(
   ## authority→us direction is filtered; our own writes still flow to it.
   privileged
   debug "local subscribe", ctx = self.id
+  self.materialize = materialize_impl # enable materialize-on-access
   self.pack_objects
   var remote_objects: HashSet[string]
   for id in self.objects.keys:
@@ -493,8 +504,9 @@ proc subscribe*(
 proc fetch*(self: EdContext, object_id: string) =
   ## Ask the authority for `object_id`. It's materialized on a later tick
   ## (placeholder-then-fill); the authority adds it to our interest so future
-  ## ops follow. No-op if we already hold it.
-  if object_id in self:
+  ## ops follow. No-op if we already hold it *loaded* — a placeholder (held but
+  ## not materialized) still needs fetching.
+  if object_id in self and not self.objects[object_id].placeholder:
     return
   var msg = Message(kind: REQUEST, object_id: object_id)
   for sub in self.subscribers:
@@ -512,6 +524,7 @@ proc subscribe*(
   var port = 9632
 
   debug "remote subscribe", address
+  self.materialize = materialize_impl # enable materialize-on-access
   if not ?self.reactor:
     self.reactor = new_reactor()
   self.subscribing = true
@@ -525,6 +538,9 @@ proc subscribe*(
     port = parts[1].parse_int
 
   let connection = self.reactor.connect(address, port)
+  # Advertise the type-ids we can materialize so the authority never sends us an
+  # object we can't construct (capability handshake; see ref-registration.md).
+  let capabilities = toSeq(type_initializers.keys).to_flatty
   self.send(
     Subscription(
       kind: REMOTE,
@@ -532,7 +548,7 @@ proc subscribe*(
       connection: connection,
       last_sent_time: epoch_time(),
     ),
-    Message(kind: SUBSCRIBE),
+    Message(kind: SUBSCRIBE, obj: capabilities),
   )
 
   var ctx_id = ""
@@ -830,6 +846,21 @@ proc tick*(
       get_mono_time() + min_duration
 
   self.flush_buffers
+
+  # Replay whatever a silent (blocking) materialize deferred — at this tick
+  # boundary, before new traffic: first the messages it buffered (apply + fire
+  # their callbacks), then the Fill callbacks for the object it materialized.
+  if self.pending_msgs.len > 0:
+    let deferred = self.pending_msgs
+    self.pending_msgs = @[]
+    for m in deferred:
+      self.process_message(m)
+  if self.pending_fills.len > 0:
+    let fills = self.pending_fills
+    self.pending_fills = @[]
+    for f in fills:
+      f()
+
   while true:
     if poll:
       # Drain the available batch, then coalesce superseded register updates:
@@ -950,6 +981,14 @@ proc tick*(
             connection: raw_msg.conn,
             ctx_id: source_str,
             last_sent_time: epoch_time(),
+            # Capability handshake: the SUBSCRIBE carries the subscriber's
+            # materializable type-ids in `obj`. We filter all sends to it by
+            # this set. Empty (older peer) = unfiltered, full replica.
+            capabilities:
+              if msg.obj.len > 0:
+                msg.obj.from_flatty(seq[int]).to_hash_set
+              else:
+                init_hash_set[int](),
           )
           # Register all mappings from the subscribe message
           new_sub.register_mappings(msg.id_mappings)
@@ -978,6 +1017,38 @@ proc tick*(
     if poll == false or
         ((count > 0 or not blocking) and get_mono_time() > recv_until):
       break
+
+proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
+  ## Wired onto a context at subscribe time and called by the read accessors when
+  ## they touch a placeholder (see operations.touch_placeholder). Kicks a fetch;
+  ## when in a `blocking` scope, pumps I/O and **silently** materializes just this
+  ## object — every other received message and even this object's own Fill
+  ## callback are deferred to the next explicit `tick`, so nothing
+  ## application-visible happens mid-read (clean reentrancy). Bounded by a deadline
+  ## so a gone authority can't hang the caller; it then falls back to the empty
+  ## placeholder, same as the non-blocking path.
+  ##
+  ## The silent pump currently drains the **local** (cross-thread) transport;
+  ## remote (network) silent materialize is a follow-up (the deferral machinery is
+  ## transport-agnostic — only the receive step needs the remote parse).
+  privileged
+  if id notin self or not self.objects[id].placeholder:
+    return
+  self.fetch(id)
+  if not self.blocking:
+    return
+
+  let deadline = get_mono_time() + init_duration(seconds = 5)
+  self.silent = true
+  while id in self and self.objects[id].placeholder and
+      get_mono_time() < deadline:
+    var m: Message
+    while self.chan.try_recv(m):
+      if m.object_id == id and m.kind == CREATE:
+        self.process_message(m) # applies the value; its Fill callback is deferred
+      else:
+        self.pending_msgs.add m # everything else waits for the next tick
+  self.silent = false
 
 proc find_bare_return(n: NimNode): NimNode =
   if n.kind == nnkReturnStmt:

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -106,6 +106,11 @@ type
 
   Subscription* = ref object
     ctx_id*: string
+    # Partial replicas: when `partial`, this subscriber only receives objects in
+    # `interest` (its roots + ids it has fetched). Default (not partial) gets
+    # everything — the existing full-replica behavior.
+    partial*: bool
+    interest*: HashSet[string]
     # Short ID mappings for this connection. Outgoing and incoming are
     # *separate* namespaces — each peer independently allocates short IDs
     # in messages it sends. Sharing the table would let our own outgoing

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -30,6 +30,7 @@ type
     TOUCH
     SUBSCRIBE
     PACKED
+    REQUEST  # partial replica asking the authority for an object by id
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -165,6 +165,10 @@ type
     silent*: bool         # silent (blocking) materialize: defer callbacks to next tick
     pending_msgs*: seq[Message]            # received-but-deferred during a silent pump
     pending_fills*: seq[proc() {.gcsafe.}] # Fill callbacks deferred to the next tick
+    # Per-key fetch requests buffered between ticks (table object_id -> serialized
+    # keys). A frame's worth of request() calls collapse into one REQUEST per
+    # table, flushed on the next tick.
+    pending_key_requests*: Table[string, seq[string]]
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]
@@ -230,6 +234,15 @@ type
 
     change_receiver:
       proc(self: ref EdBase, msg: Message, op_ctx: OperationContext) {.gcsafe.}
+
+    # Per-key fetch (partial EdTable). Given a serialized key, build the ADD op
+    # carrying that key's current value, so a partial subscriber can pull one
+    # entry without the whole table. `found = false` if the key isn't present.
+    # nil for non-table containers.
+    publish_key:
+      proc(self: ref EdBase, key_bin: string): tuple[found: bool, msg: Message] {.
+        gcsafe
+      .}
 
     ctx*: EdContext
 

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -21,6 +21,13 @@ type
     TOUCHED   ## Object was touched without modification
     CLOSED    ## Object was destroyed
 
+  ChangeReason* = enum
+    ## Why a change fired, orthogonal to `ChangeKind`. (Unrelated to
+    ## `Change.triggered_by`, which is the upstream changes that caused this one.)
+    Normal    ## An ordinary mutation
+    Initial   ## Replay of existing contents at `track` time (reserved)
+    Fill      ## A placeholder materialized (partial-replica fetch landed)
+
   MessageKind* = enum
     BLANK
     CREATE
@@ -34,6 +41,7 @@ type
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]
+    reason*: ChangeReason
     field_name*: string
     triggered_by*: seq[BaseChange]
     triggered_by_type*: string
@@ -112,6 +120,12 @@ type
     # everything — the existing full-replica behavior.
     partial*: bool
     interest*: HashSet[string]
+    # Capability filter: the set of container type-ids this subscriber can
+    # materialize (its registered `type_initializers`). The authority skips any
+    # object whose `type_id` isn't here, so a peer never receives an object it
+    # can't construct (which would crash/drop on deserialize). Empty = unfiltered
+    # (no handshake / same-build peer) — preserves the full-replica default.
+    capabilities*: HashSet[int]
     # Short ID mappings for this connection. Outgoing and incoming are
     # *separate* namespaces — each peer independently allocates short IDs
     # in messages it sends. Sharing the table would let our own outgoing
@@ -141,6 +155,16 @@ type
     applied_lsn*: int64   # highest global LSN applied (frontier)
     op_id_counter*: int64 # next op id to assign to a write we originate
     latest_op_id*: Table[string, int64]  # object_id -> our highest op id (own-op reconciliation)
+    # Materialize-on-access (partial replicas). `materialize` is wired up at
+    # subscribe time (it needs fetch/tick) and called by the read accessors when
+    # they touch a placeholder. When `blocking`, that call pumps I/O until the
+    # object fills; otherwise it kicks a fetch and returns the empty placeholder.
+    materialize*: proc(self: EdContext, id: string) {.gcsafe.}
+    blocking*: bool
+    filling*: bool        # set while a placeholder fill applies → tags Fill changes
+    silent*: bool         # silent (blocking) materialize: defer callbacks to next tick
+    pending_msgs*: seq[Message]            # received-but-deferred during a silent pump
+    pending_fills*: seq[proc() {.gcsafe.}] # Fill callbacks deferred to the next tick
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]
@@ -187,6 +211,11 @@ type
     ## Base type for all `Ed` containers. Not used directly.
     id*: string
     destroyed*: bool
+    # Partial replicas: a placeholder is a non-broadcasting stand-in for a
+    # not-yet-materialized object (its contents are empty until fetched). Reading
+    # it triggers a fetch; when the real state arrives the bit clears and a Fill
+    # change fires. Default false = a normal, fully-loaded object.
+    placeholder*: bool
     link_eid: EID
     paused_eids: set[EID]
     bound_eids: seq[EID]

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -36,6 +36,17 @@ proc pack_objects*(self: EdContext) =
     self.objects = table
     self.objects_need_packing = false
 
+template blocking*(self: EdContext, body: untyped) =
+  ## Within this scope, a read that touches an unmaterialized placeholder blocks
+  ## (pumps I/O) until it fills, instead of returning empty and fetching async.
+  ## Just manages the `blocking` flag — you can set `self.blocking` directly too.
+  let prev = self.blocking
+  self.blocking = true
+  try:
+    body
+  finally:
+    self.blocking = prev
+
 proc contains*(self: EdContext, id: string): bool =
   id in self.objects and self.objects[id] != nil
 

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -254,6 +254,23 @@ proc defaults[T, O](
     else:
       fail "Can't handle message " & $msg.kind
 
+  self.publish_key = proc(
+      self: ref EdBase, key_bin: string
+  ): tuple[found: bool, msg: Message] {.gcsafe.} =
+    # Per-key fetch: build the ADD op for one entry so a partial subscriber can
+    # pull it without the whole table. Only meaningful for table containers.
+    when O is Pair:
+      let self = Ed[T, O](self)
+      type K = generic_params(O.default.type).get(0)
+      {.gcsafe.}:
+        let key = key_bin.from_flatty(K, self.ctx)
+      if key in self.tracked:
+        let pair = O(key: key, value: self.tracked[key])
+        let change = Change[O](changes: {ADDED}, item: pair)
+        result = (found: true, msg: self.build_message(self, change, self.id, ""))
+    else:
+      discard
+
   assert self.ctx == nil
   self.ctx = ctx
 

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -110,7 +110,8 @@ proc defaults[T, O](
       ctx.send_msg(sub)
     if broadcast:
       for sub in ctx.subscribers:
-        if sub.ctx_id notin op_ctx.source:
+        if sub.ctx_id notin op_ctx.source and
+            not (sub.partial and id notin sub.interest):
           ctx.send_msg(sub)
     ctx.tick_reactor
 

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -34,7 +34,10 @@ proc create_initializer[T, O](self: Ed[T, O]) =
             debug "restoring received object", id
             var value = bin.from_flatty(T, ctx)
             let item = Ed[T, O](ctx[id])
+            ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+            item.placeholder = false # fill: real state arrived
             `value=`(item, value, op_ctx = op_ctx)
+            ctx.filling = false
           else:
             if id notin ctx:
               discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
@@ -44,13 +47,24 @@ proc create_initializer[T, O](self: Ed[T, O]) =
               {.gcsafe.}:
                 let value = bin.from_flatty(T, ctx)
               let item = Ed[T, O](ctx[id])
+              ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+              item.placeholder = false # fill: real state arrived
               `value=`(item, value, op_ctx = op_ctx)
+              ctx.filling = false
             ctx.value_initializers.add(initializer)
         elif id notin ctx:
           discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
+        else:
+          # Empty-body CREATE for an object we were holding as a placeholder:
+          # it exists for real now, just with no value yet.
+          Ed[T, O](ctx[id]).placeholder = false
 
 proc defaults[T, O](
-    self: Ed[T, O], ctx: EdContext, id: string, op_ctx: OperationContext
+    self: Ed[T, O],
+    ctx: EdContext,
+    id: string,
+    op_ctx: OperationContext,
+    broadcast = true,
 ): Ed[T, O] =
   privileged
   log_defaults
@@ -90,21 +104,24 @@ proc defaults[T, O](
     template send_msg(src_ctx, sub) =
       const ed_type_id = self.type.tid
 
-      var msg = Message(
-        kind: CREATE,
-        obj: bin,
-        flags: flags,
-        type_id: ed_type_id,
-        object_id: id,
-        # source is set by send() based on subscription type
-      )
+      # Capability filter: don't send an object to a peer that can't materialize
+      # its type. Empty `capabilities` = unfiltered (same-build / no handshake).
+      if sub.capabilities.len == 0 or ed_type_id in sub.capabilities:
+        var msg = Message(
+          kind: CREATE,
+          obj: bin,
+          flags: flags,
+          type_id: ed_type_id,
+          object_id: id,
+          # source is set by send() based on subscription type
+        )
 
-      when defined(ed_trace):
-        msg.trace = get_stack_trace()
+        when defined(ed_trace):
+          msg.trace = get_stack_trace()
 
-      src_ctx.send(
-        sub, msg, op_ctx, flags = self.flags & {SYNC_ALL_NO_OVERWRITE}
-      )
+        src_ctx.send(
+          sub, msg, op_ctx, flags = self.flags & {SYNC_ALL_NO_OVERWRITE}
+        )
 
     if sub.kind != BLANK:
       ctx.send_msg(sub)
@@ -175,7 +192,11 @@ proc defaults[T, O](
 
     when O is Ed:
       let object_id = msg.change_object_id
-      assert object_id in self.ctx
+      if object_id notin self.ctx:
+        # Nested object not materialized yet — stand in with a non-broadcasting
+        # placeholder so the container op applies and cardinality is correct.
+        # Reading the placeholder later triggers a fetch (materialize-on-access).
+        discard O.init_placeholder(self.ctx, object_id)
       let item = O(self.ctx.objects[object_id])
     elif O is Pair[auto, Ed]:
       # Workaround for compile issue. This should be `O`, not `O.default.type`.
@@ -189,9 +210,12 @@ proc defaults[T, O](
         debug "skipping change for missing object", object_id = msg.object_id
         return
 
-      if msg.change_object_id notin self.ctx and msg.kind == UNASSIGN:
-        debug "can't find ", obj = msg.change_object_id
-        return
+      if msg.change_object_id notin self.ctx:
+        if msg.kind == UNASSIGN:
+          debug "can't find ", obj = msg.change_object_id
+          return
+        # Value object not materialized yet — placeholder it (see above).
+        discard V.init_placeholder(self.ctx, msg.change_object_id)
       let value = V(self.ctx.objects[msg.change_object_id])
       {.gcsafe.}:
         let item = O(key: msg.obj.from_flatty(K, self.ctx), value: value)
@@ -233,8 +257,20 @@ proc defaults[T, O](
   assert self.ctx == nil
   self.ctx = ctx
 
-  self.publish_create(broadcast = true, op_ctx = op_ctx)
+  if broadcast:
+    self.publish_create(broadcast = true, op_ctx = op_ctx)
   self
+
+proc init_placeholder*[T, O](
+    _: typedesc[Ed[T, O]], ctx: EdContext, id: string
+): Ed[T, O] =
+  ## A non-broadcasting stand-in for a not-yet-materialized object. Registered in
+  ## `ctx.objects` under `id` and marked `placeholder`; no CREATE goes out.
+  ## Reading it triggers a fetch; the real state fills it in later.
+  # `op_ctx` is only consulted by defaults' broadcast, which we skip.
+  result = Ed[T, O](flags: DEFAULT_FLAGS, placeholder: true).defaults(
+    ctx, id, OperationContext(), broadcast = false
+  )
 
 proc init*(
     T: type Ed,

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -58,20 +58,36 @@ proc `value=`*[T, O](self: Ed[T, O], value: T, op_ctx = OperationContext()) =
     mutate(op_ctx):
       self.tracked = value
 
+proc loaded*(self: ref EdBase): bool =
+  ## False while this object is an unmaterialized placeholder (a partial replica
+  ## holds the reference but not the contents yet). Lets a caller distinguish
+  ## "exists but not loaded" from "exists and is genuinely empty".
+  not self.placeholder
+
+template touch_placeholder(self: untyped) =
+  ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
+  ## context to materialize it (kick a fetch; block until filled when
+  ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
+  if self.placeholder and self.ctx.materialize != nil:
+    self.ctx.materialize(self.ctx, self.id)
+
 proc value*[T, O](self: Ed[T, O]): T =
   ## Get the container's current value.
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked
 
 proc `[]`*[K, V](self: Ed[Table[K, V], Pair[K, V]], index: K): V =
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked[index]
 
 proc `[]`*[T](self: EdSeq[T], index: SomeOrdinal | BackwardsIndex): T =
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked[index]
 
 proc `[]=`*[K, V](
@@ -293,17 +309,20 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
 iterator items*[T](self: EdSet[T] | EdSeq[T]): T =
   privileged
   assert self.valid
+  self.touch_placeholder
   for item in self.tracked.items:
     yield item
 
 iterator items*[K, V](self: EdTable[K, V]): Pair[K, V] =
   privileged
   assert self.valid
+  self.touch_placeholder
   for key, value in self.tracked.pairs:
     yield Pair[K, V](key: key, value: value)
 
 iterator pairs*[K, V](self: EdTable[K, V]): (K, V) =
   privileged
   assert self.valid
+  self.touch_placeholder
   for pair in self.tracked.pairs:
     yield pair

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -1,4 +1,5 @@
 import std/[typetraits, macros, macrocache, tables]
+import pkg/flatty
 import ed/[core, components/private/tracking, types {.all.}]
 import ./[contexts, validations, private]
 
@@ -83,6 +84,42 @@ proc `[]`*[K, V](self: Ed[Table[K, V], Pair[K, V]], index: K): V =
   assert self.valid
   self.touch_placeholder
   self.tracked[index]
+
+proc loaded*[K, V](self: EdTable[K, V], key: K): bool =
+  ## Whether this key's value is materialized locally. Distinct from
+  ## `key in self` (shape: whether the key exists at all, once shape sync lands).
+  privileged
+  assert self.valid
+  key in self.tracked
+
+proc request*[K, V](self: EdTable[K, V], key: K) =
+  ## Queue a per-key fetch from the authority. Batched and sent on the next
+  ## `tick` (a frame's worth of requests collapse into one message per table);
+  ## the value arrives as an ADDED change, so existing `track`/`watch` handlers
+  ## render it. No-op if the key is already loaded.
+  privileged
+  assert self.valid
+  if key notin self.tracked:
+    self.ctx.pending_key_requests.mgetOrPut(self.id, @[]).add key.to_flatty
+
+proc request*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+  for key in keys:
+    self.request(key)
+
+proc release*[K, V](self: EdTable[K, V], key: K) =
+  ## Drop a locally-materialized entry to free memory (eviction). Local only —
+  ## fires a REMOVED change (so watches un-render) but does NOT delete on the
+  ## authority; `request(key)` re-fetches it. No-op if not loaded.
+  privileged
+  assert self.valid
+  if key in self.tracked:
+    let pair = Pair[K, V](key: key, value: self.tracked[key])
+    self.tracked.del key
+    self.trigger_callbacks(@[Change[Pair[K, V]](changes: {REMOVED}, item: pair)])
+
+proc release*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+  for key in keys:
+    self.release(key)
 
 proc `[]`*[T](self: EdSeq[T], index: SomeOrdinal | BackwardsIndex): T =
   privileged

--- a/tests/capability_tests.nim
+++ b/tests/capability_tests.nim
@@ -1,0 +1,44 @@
+import std/[unittest, sets]
+import ed
+import ed/zens/contexts
+import ed/utils/misc
+
+proc run*() =
+  suite "capability handshake":
+    test "authority skips objects the subscriber can't materialize":
+      var authority = EdContext.init(id = "cap_auth", is_authority = true)
+      var client = EdContext.init(id = "cap_client")
+      client.subscribe(authority)
+
+      # Model a different-build remote peer: in-process both share
+      # `type_initializers`, so restrict the subscription by hand to a single
+      # type it "can handle". (The wire handshake populates this automatically
+      # for real remote subscribers.)
+      authority.subscribers[0].capabilities = [Ed[int, int].tid].to_hash_set
+
+      var i = EdValue[int].init(ctx = authority, id = "cap_int")
+      i.value = 7
+      var s = EdValue[string].init(ctx = authority, id = "cap_str")
+      s.value = "hi"
+      client.tick()
+
+      check "cap_int" in client # capable type delivered
+      check "cap_str" notin client # incapable type filtered out
+      check EdValue[int](client["cap_int"]).value == 7
+
+      # Ongoing ops respect it too: a later write to the filtered object never
+      # arrives (and never crashes the client trying to deserialize it).
+      s.value = "world"
+      client.tick()
+      check "cap_str" notin client
+
+    test "empty capabilities = unfiltered (default full replica)":
+      var authority = EdContext.init(id = "cap_auth2", is_authority = true)
+      var client = EdContext.init(id = "cap_client2")
+      client.subscribe(authority) # local subscribe leaves capabilities empty
+
+      var i = EdValue[int].init(ctx = authority, id = "cap_int2")
+      var s = EdValue[string].init(ctx = authority, id = "cap_str2")
+      client.tick()
+      check "cap_int2" in client
+      check "cap_str2" in client

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -1,4 +1,4 @@
-import std/[unittest, sets, atomics, os]
+import std/[unittest, sets, atomics, os, tables]
 import ed
 import ed/zens/contexts
 import test_util
@@ -183,6 +183,62 @@ proc run*() =
       check got == "materialized"
       check client["child"].loaded
       client.close
+
+    test "per-key fetch: pull individual table entries, batched, as ADDED":
+      var authority = EdContext.init(id = "pk_auth", is_authority = true)
+      var client = EdContext.init(id = "pk_client")
+      # A seq of tables; the client takes the seq as a root, so each table comes
+      # in as an empty placeholder.
+      var parent = EdSeq[EdTable[int, string]].init(ctx = authority, id = "parent")
+      var child = EdTable[int, string].init(ctx = authority, id = "child")
+      child[1] = "one"
+      child[2] = "two"
+      child[3] = "three"
+      parent += child
+
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      let table = EdTable[int, string](client["child"])
+      check "child" in client
+      check not table.loaded(1) # nothing pulled yet
+
+      # Watch records arrivals as ADDED (the pattern enu's renderer uses).
+      var arrived: seq[(int, string)]
+      table.changes:
+        if added:
+          arrived.add (change.item.key, change.item.value)
+
+      # Two requests in one frame → one batched REQUEST on the next tick.
+      table.request(1)
+      table.request(3)
+      client.tick() # flush_key_requests sends the batch
+      authority.tick() # authority replies with entries 1 and 3
+      client.tick() # client applies the ADD ops
+
+      check table.loaded(1)
+      check table.loaded(3)
+      check not table.loaded(2) # never requested → not pulled
+      check table[1] == "one"
+      check table[3] == "three"
+      check arrived.len == 2 # both fills fired as ADDED changes
+      check (1, "one") in arrived
+      check (3, "three") in arrived
+
+      # release evicts locally (loaded -> false) without deleting on the authority.
+      var removed_keys: seq[int]
+      table.changes:
+        if removed:
+          removed_keys.add change.item.key
+      table.release(1)
+      check not table.loaded(1) # dropped locally
+      check removed_keys == @[1] # fired REMOVED so watches un-render
+      check EdTable[int, string](authority["child"]).loaded(1) # still on authority
+      table.request(1) # re-fetch works
+      client.tick()
+      authority.tick()
+      client.tick()
+      check table.loaded(1)
+      check table[1] == "one"
 
     test "blocking scope toggles the flag and restores it":
       var ctx = EdContext.init(id = "mb_ctx")

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -1,6 +1,28 @@
-import std/[unittest, sets]
+import std/[unittest, sets, atomics, os]
 import ed
 import ed/zens/contexts
+import test_util
+
+# A listening authority on its own thread, ticking continuously — the role Enu
+# plays for the MCP server (separate process, independent tick loop), and what a
+# blocking remote materialize needs to respond to it.
+var rmat_running: Atomic[bool]
+var rmat_ready: Atomic[bool]
+var rmat_thread: Thread[string]
+
+proc rmat_server_loop(address: string) {.thread.} =
+  let server =
+    EdContext.init(id = "rmat-server", is_authority = true, listen_address = address)
+  Ed.thread_ctx = server
+  var parent = EdSeq[EdValue[string]].init(id = "parent", ctx = server)
+  var child = EdValue[string].init(id = "child", ctx = server)
+  child.value = "materialized"
+  parent += child # parent is pre-populated before any client connects
+  rmat_ready.store(true)
+  while rmat_running.load:
+    server.tick
+    sleep 5
+  server.close
 
 proc run*() =
   suite "materialize on access":
@@ -126,6 +148,41 @@ proc run*() =
       check other_fired
       check EdValue[int](client["other"]).value == 99
       check child_fill_reason == Fill
+
+    test "remote partial replica blocking-materializes a placeholder":
+      let address = free_addr()
+      rmat_ready.store(false)
+      rmat_running.store(true)
+      create_thread(rmat_thread, rmat_server_loop, address)
+      while not rmat_ready.load:
+        sleep 5
+      defer:
+        rmat_running.store(false)
+        join_thread(rmat_thread)
+
+      var client = EdContext.init(id = "rmat-client")
+      # Partial subscribe over the network: interested only in the parent.
+      client.subscribe(address, partial = true, roots = @["parent"])
+
+      # The pre-populated parent arrives; its out-of-interest child is a
+      # placeholder (created in from_flatty). Wait briefly for it (UDP).
+      var tries = 0
+      while "child" notin client and tries < 200:
+        client.tick()
+        sleep 5
+        inc tries
+      check "parent" in client
+      check "child" in client
+      check not client["child"].loaded # placeholder, contents not pulled yet
+
+      # A blocking read materializes it over the network — the server thread
+      # answers the fetch while we pump.
+      var got = ""
+      client.blocking:
+        got = EdValue[string](client["child"]).value
+      check got == "materialized"
+      check client["child"].loaded
+      client.close
 
     test "blocking scope toggles the flag and restores it":
       var ctx = EdContext.init(id = "mb_ctx")

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -1,0 +1,140 @@
+import std/[unittest, sets]
+import ed
+import ed/zens/contexts
+
+proc run*() =
+  suite "materialize on access":
+    test "placeholder stands in for an out-of-interest nested object":
+      var authority = EdContext.init(id = "m_auth", is_authority = true)
+      var client = EdContext.init(id = "m_client")
+
+      # Parent collection of nested Ed values.
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+
+      # Client is interested only in the parent, not its children.
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      check "parent" in client
+
+      # Author a child and add it to the parent. The child's CREATE is filtered
+      # (not in interest), but the parent's ADD op — which references the child —
+      # is delivered, so the client must stand in with a placeholder.
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+
+      check "child" in client # placeholder materialized into the object pool
+      check EdSeq[EdValue[string]](client["parent"]).len == 1 # cardinality correct
+      check not client["child"].loaded # exists, but not loaded
+      check EdValue[string](client["child"]).value == "" # empty until filled
+
+      # Explicit fetch materializes it (access-triggered fetch is the next slice).
+      client.fetch("child")
+      authority.tick() # authority answers the REQUEST
+      client.tick() # client fills the placeholder
+      check client["child"].loaded # fill cleared the bit
+      check EdValue[string](client["child"]).value == "hi"
+
+    test "reading a placeholder auto-triggers the fetch (no explicit fetch)":
+      var authority = EdContext.init(id = "ma_auth", is_authority = true)
+      var client = EdContext.init(id = "ma_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+      check not client["child"].loaded
+
+      # Just *reading* the placeholder's value kicks the fetch (non-blocking:
+      # returns empty now). No client.fetch() call here.
+      check EdValue[string](client["child"]).value == ""
+      authority.tick() # authority answers the access-triggered REQUEST
+      client.tick() # fill arrives
+      check client["child"].loaded
+      check EdValue[string](client["child"]).value == "hi"
+
+    test "a fill fires a change tagged reason == Fill":
+      var authority = EdContext.init(id = "mf_auth", is_authority = true)
+      var client = EdContext.init(id = "mf_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+      check not client["child"].loaded
+
+      var fill_reason = Normal
+      EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
+        for c in cs:
+          if MODIFIED in c.changes:
+            fill_reason = c.reason
+
+      client.fetch("child")
+      authority.tick()
+      client.tick() # fill applies here → callback fires, tagged Fill
+      check client["child"].loaded
+      check fill_reason == Fill
+
+    test "blocking materialize is silent: only the target fills, rest defers":
+      var authority = EdContext.init(id = "ms_auth", is_authority = true)
+      var client = EdContext.init(id = "ms_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      var other = EdValue[int].init(ctx = authority, id = "other")
+      client.subscribe(authority, partial = true, roots = @["parent", "other"])
+      client.tick()
+
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick() # placeholder for child
+      check not client["child"].loaded
+
+      var other_fired = false
+      EdValue[int](client["other"]).track proc(cs: seq[Change[int]]) =
+        other_fired = true
+      var child_fill_reason = Normal
+      EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
+        for c in cs:
+          if MODIFIED in c.changes:
+            child_fill_reason = c.reason
+
+      # Queue two messages into the client's channel WITHOUT processing them:
+      # an unrelated change to `other`, and (via fetch) the child's CREATE.
+      other.value = 99
+      client.fetch("child")
+      authority.tick() # authority queues child's CREATE onto the client's chan
+
+      # Blocking read materializes ONLY child; everything else is deferred.
+      var got = "before"
+      client.blocking:
+        got = EdValue[string](client["child"]).value
+
+      check got == "hi" # blocking read returned the real value
+      check client["child"].loaded
+      check not other_fired # unrelated message was deferred, not applied
+      check EdValue[int](client["other"]).value == 0 # ...and its value untouched
+      check not (child_fill_reason == Fill) # even the Fill callback deferred
+
+      # The next explicit tick replays everything at the tick boundary.
+      client.tick()
+      check other_fired
+      check EdValue[int](client["other"]).value == 99
+      check child_fill_reason == Fill
+
+    test "blocking scope toggles the flag and restores it":
+      var ctx = EdContext.init(id = "mb_ctx")
+      check not ctx.blocking
+      ctx.blocking:
+        check ctx.blocking # set inside the scope
+      check not ctx.blocking # restored after
+      # Nested / manual management still composes.
+      ctx.blocking = true
+      ctx.blocking:
+        check ctx.blocking
+      check ctx.blocking # restored to the manual value, not forced off

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -28,6 +28,31 @@ proc run*() =
       check EdValue[int](client["obj_x"]).value == 10
       check "obj_y" notin client
 
+    test "fetch materializes an out-of-interest object and starts syncing it":
+      var authority = EdContext.init(id = "f_authority", is_authority = true)
+      var client = EdContext.init(id = "f_client")
+
+      var x = EdValue[int].init(ctx = authority, id = "f_x")
+      var y = EdValue[int].init(ctx = authority, id = "f_y")
+      x.value = 1
+      y.value = 2
+
+      client.subscribe(authority, partial = true, roots = @["f_x"])
+      client.tick()
+      check "f_y" notin client
+
+      # Fetch f_y on demand.
+      client.fetch("f_y")
+      authority.tick() # authority handles REQUEST, sends f_y's CREATE
+      client.tick() # client materializes f_y
+      check "f_y" in client
+      check EdValue[int](client["f_y"]).value == 2
+
+      # f_y now syncs (it joined the interest set).
+      y.value = 20
+      client.tick()
+      check EdValue[int](client["f_y"]).value == 20
+
     test "non-partial subscriber still gets everything (default unchanged)":
       var authority = EdContext.init(id = "p_authority2", is_authority = true)
       var client = EdContext.init(id = "p_client2")

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -53,6 +53,41 @@ proc run*() =
       client.tick()
       check EdValue[int](client["f_y"]).value == 20
 
+    test "objects created after subscribe respect partial interest":
+      var authority = EdContext.init(id = "pc_auth", is_authority = true)
+      var client = EdContext.init(id = "pc_client")
+      client.subscribe(authority, partial = true, roots = @["pc_root"])
+      client.tick()
+
+      # Created after the subscribe — the broadcast CREATE must still be filtered.
+      var root = EdValue[int].init(ctx = authority, id = "pc_root")
+      var other = EdValue[int].init(ctx = authority, id = "pc_other")
+      client.tick()
+      check "pc_root" in client # in interest
+      check "pc_other" notin client # filtered
+
+    test "a partial client's own object syncs back from the authority":
+      var authority = EdContext.init(id = "po_auth", is_authority = true)
+      var client = EdContext.init(id = "po_client")
+      client.subscribe(authority, partial = true, roots = @[])
+      client.tick()
+
+      # Client creates its own object; the authority should pick it up and
+      # return its canonical ops (auto-interest on create-from-subscriber).
+      var mine = EdValue[int].init(ctx = client, id = "po_mine")
+      mine.value = 5
+      authority.tick()
+      client.tick()
+      check "po_mine" in authority
+      check EdValue[int](authority["po_mine"]).value == 5
+
+      # Return-to-source works for the partial client's own object.
+      EdValue[int](client["po_mine"]).value = 7
+      authority.tick()
+      client.tick()
+      check EdValue[int](authority["po_mine"]).value == 7
+      check EdValue[int](client["po_mine"]).value == 7
+
     test "non-partial subscriber still gets everything (default unchanged)":
       var authority = EdContext.init(id = "p_authority2", is_authority = true)
       var client = EdContext.init(id = "p_client2")

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -1,0 +1,41 @@
+import std/unittest
+import ed
+import ed/zens/contexts
+
+proc run*() =
+  suite "partial replicas":
+    test "partial subscriber only receives its interest set":
+      var authority = EdContext.init(id = "p_authority", is_authority = true)
+      var client = EdContext.init(id = "p_client")
+
+      var x = EdValue[int].init(ctx = authority, id = "obj_x")
+      var y = EdValue[int].init(ctx = authority, id = "obj_y")
+      x.value = 1
+      y.value = 2
+
+      # Interested only in obj_x.
+      client.subscribe(authority, partial = true, roots = @["obj_x"])
+      client.tick()
+
+      check "obj_x" in client # pushed (in interest)
+      check "obj_y" notin client # filtered out
+      check EdValue[int](client["obj_x"]).value == 1
+
+      # Ongoing ops: only obj_x's changes reach the client.
+      x.value = 10
+      y.value = 20
+      client.tick()
+      check EdValue[int](client["obj_x"]).value == 10
+      check "obj_y" notin client
+
+    test "non-partial subscriber still gets everything (default unchanged)":
+      var authority = EdContext.init(id = "p_authority2", is_authority = true)
+      var client = EdContext.init(id = "p_client2")
+
+      var x = EdValue[int].init(ctx = authority, id = "obj_x2")
+      var y = EdValue[int].init(ctx = authority, id = "obj_y2")
+
+      client.subscribe(authority) # full
+      client.tick()
+      check "obj_x2" in client
+      check "obj_y2" in client

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,7 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
-  lsn_tests, client_tests, partial_tests
+  lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests
 
 Ed.bootstrap
 
@@ -17,3 +17,5 @@ memory_tests.run()
 lsn_tests.run()
 client_tests.run()
 partial_tests.run()
+capability_tests.run()
+materialize_tests.run()

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,7 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
-  lsn_tests, client_tests
+  lsn_tests, client_tests, partial_tests
 
 Ed.bootstrap
 
@@ -16,3 +16,4 @@ error_handling_tests.run()
 memory_tests.run()
 lsn_tests.run()
 client_tests.run()
+partial_tests.run()


### PR DESCRIPTION
Opt-in, non-breaking partial-replica support for Ed. Default behavior (no partial subscribe, empty capabilities, no placeholders) is byte-identical to a full replica — the pre-existing suite confirms it. **90 tests pass, 0 fail.**

## What's here

**Interest sets + filtered delivery (P3a/P3b)**
- `Subscription.partial` + `interest`; `subscribe(partial = true, roots = @[...])` (local *and* remote). Filtered in `add_subscriber`, `fanout`, `publish_create`.
- `REQUEST` message + `EdContext.fetch(id)`; a partial client's own creates auto-join its interest.

**TID capability handshake**
- A subscriber advertises its materializable type-ids on `SUBSCRIBE`; the authority skips any object whose type it can't construct (prevents the unregistered-ref crash/drop in `docs/ref-registration.md`). `type_id == 0` (DESTROY/control) exempt. Empty = unfiltered.

**Materialize-on-access**
- Non-resident nested `Ed` refs become non-broadcasting placeholders (`EdBase.placeholder` + `Ed.init_placeholder`) — both incrementally (deserialize of an ADD) and on initial push (`from_flatty` of a pre-populated parent). `loaded` predicate distinguishes "unloaded" from "empty".
- Reading a placeholder (`value`/`items`/`pairs`/`[]`) triggers a fetch via a per-context `materialize` proc field. Non-blocking returns empty and fills on a later tick.
- `blocking:` scope **silently** materializes only the target — every non-target message and the target's own callback defer to the next explicit tick (`ctx.silent`/`pending_msgs`/`pending_fills`). Drains both local and network transports; `parse_remote` is shared with `tick` (no duplicated wire decode, no `tick` split).

**Change tagging**
- `Change.reason: ChangeReason` (`Normal | Initial | Fill`); a placeholder fill is tagged `Fill`. Named `reason` (not `trigger`) to avoid confusion with `triggered_by`.

## Tests
`capability_tests` + `materialize_tests`: placeholder stand-in, access-triggered fetch, Fill tagging, silent blocking (deferral), blocking-scope flag, and an **end-to-end remote partial replica blocking-materializing over UDP** against a threaded authority (stable across repeated runs).

## Known gaps (tracked in `docs/partial-replicas-spike.md`)
- `tick` receive/process split (decision 3) — deliberately skipped; `parse_remote` got the de-duplication win without refactoring the hot path.
- `Initial` reason — track-time replay, reserved/not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)