### PR TITLE
feat(partial): opt-in partial replicas — interest, fetch, capability, materialize

### DIFF
--- a/docs/partial-replicas.md
+++ b/docs/partial-replicas.md
@@ -1,0 +1,85 @@
+# Partial Replicas
+
+A context should hold only the objects it uses. Nested `Ed` objects (the
+`EdTable`s inside an `EdSeq[EdTable]`, etc.) don't exist in memory until reached,
+and materialize on access. Opt-in and non-breaking: the default is still a full
+replica (full push on subscribe, every op fanned out), byte-identical to before.
+
+## Model — reference-driven lazy materialization
+
+A partial subscriber declares a few **root** ids; the authority pushes only those.
+The reference graph discovers the rest: a container op that references a
+non-resident nested `Ed` (`change_object_id`) mints a typed **placeholder** (an
+empty stand-in with the right id and type — `O` gives the type for free, no schema
+needed) instead of asserting presence. Reading a placeholder **fetches** it. A
+subscriber's interest set is implicitly "what it has reached and not yet dropped."
+
+The pieces:
+
+- **Per-subscriber interest** (`Subscription.partial` + `interest: HashSet[string]`).
+  The authority filters every send path against it — initial push
+  (`add_subscriber`), ongoing ops (`fanout`/`publish_changes`), and new-object
+  broadcasts (`publish_create`). A partial client's *own* created objects auto-join
+  its interest so its writes get return-to-source/convergence. DESTROY bypasses the
+  filter (a peer may hold self-minted placeholder ids the authority never learned).
+- **Fetch protocol.** `REQUEST(object_id)` → the authority adds the id to that
+  sub's interest and `publish_create`s it; future ops then follow. `EdContext.fetch`
+  drives it. Mirrors the SUBSCRIBE/ACK handshake.
+- **Placeholder primitive.** `EdBodyBase.placeholder` + the `loaded` predicate
+  (distinguishes "exists but not loaded" from "exists and genuinely empty");
+  `Ed.init_placeholder` is the non-broadcasting constructor. A fill clears the bit
+  in every restore path and on `from_flatty` of a pre-populated parent (so a
+  partial replica receiving a populated parent gets correct cardinality, and a full
+  replica that sees a parent before its child fills the placeholder when the child's
+  CREATE lands).
+- **Materialize-on-access.** `EdContext.materialize` (wired at subscribe time —
+  it needs `fetch`/`tick`) is called by the read accessors via `touch_placeholder`.
+
+## Capability handshake
+
+A subscriber advertises its materializable type-ids (its registered
+`type_initializers`) on SUBSCRIBE; the authority skips any object whose `type_id`
+it isn't in `capabilities`, so a peer **never receives an object it can't
+construct** (which would crash or silently corrupt on deserialize — flatty is
+positional). `type_id == 0` (DESTROY/control) is exempt. An empty set means
+unfiltered — a same-build/local peer or one with no handshake — preserving the
+full-replica default.
+
+This depends on the rule that **synced `ref object` payloads must be registered**
+with `Ed.register(T)` (value types never need it). An unregistered ref fails late,
+on a peer, with a misleading error or silently; the handshake turns that into a
+clean "I can't hold this type, don't send it." *(Future: derive capabilities from
+the types a consumer actually accesses, not just every tid it can construct — a
+tighter interest signal; research only.)*
+
+## The crux: access is synchronous, fetch is asynchronous
+
+A read happens now; a fetch is a round-trip (cross-thread tick or network RTT).
+The two consumer modes (see `SyncMode`):
+
+- **`PARTIAL_ASYNC` — placeholder-then-fill (game loop).** Access returns the empty
+  placeholder immediately and kicks a fetch; when it lands the placeholder fills and
+  a change fires (tagged `Fill`, via the `ctx.filling` flag read in
+  `trigger_callbacks`). The standard lazy-load pattern; matches enu's chunk
+  snapshot/delta loading.
+- **`PARTIAL` — blocking (request/response: MCP, scripts).** A read inside a
+  `blocking` scope pumps `tick` until the object fills, **bounded by a 5s deadline**
+  so a gone authority can't hang the caller (then it falls back to the empty
+  placeholder).
+
+**Silent materialize** keeps the blocking read clean: it applies *only* the fetched
+object, silently — `ctx.silent` makes `trigger_callbacks` defer to
+`ctx.pending_fills`, and the pump buffers every non-target message to
+`ctx.pending_msgs`. Both replay at the start of the next explicit `tick`, so nothing
+application-visible happens mid-read (clean reentrancy; deterministic single-thread
+tests). `parse_remote` is shared by `tick` and the pump, so the wire decode lives in
+one place (no `tick` receive/process split was needed).
+
+## Notes
+
+- Interest is **grows-only** here (roots + fetched ids accumulate); eviction —
+  which sheds it — is a later layer (it needs the per-key/eviction machinery, not a
+  durable log; the authority serves subsets from memory).
+- Builds on the relaxed validation (a replica already tolerates ops for objects it
+  doesn't hold) and the per-object reconciliation frontier (delivery is already
+  per-object). See `consistency.md`.

--- a/src/ed/components/private/tracking.nim
+++ b/src/ed/components/private/tracking.nim
@@ -13,15 +13,33 @@ proc `-`*[T](a, b: seq[T]): seq[T] =
 template `&`*[T](a, b: set[T]): set[T] =
   a + b
 
-proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) =
+proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) {.gcsafe.} =
   private_access EdObject[T, O]
   private_access EdBase
 
-  if changes.len > 0:
-    let callbacks = self.changed_callbacks.dup
-    for zid, callback in callbacks.pairs:
-      if zid in self.changed_callbacks and zid notin self.paused_eids:
-        callback(changes)
+  if changes.len == 0:
+    return
+
+  # Tag changes produced while filling a placeholder so callbacks can tell a
+  # materialize-on-access fill from an ordinary mutation.
+  if self.ctx != nil and self.ctx.filling:
+    for c in changes:
+      c.reason = Fill
+
+  # Silent (blocking) materialize: nothing application-visible fires mid-fetch —
+  # defer the callbacks to the next explicit tick (preserves tick-boundary
+  # semantics and clean reentrancy). The value is already applied, so the
+  # blocking read still returns real data.
+  if self.ctx != nil and self.ctx.silent:
+    let deferred = changes
+    self.ctx.pending_fills.add proc() {.gcsafe.} =
+      self.trigger_callbacks(deferred)
+    return
+
+  let callbacks = self.changed_callbacks.dup
+  for zid, callback in callbacks.pairs:
+    if zid in self.changed_callbacks and zid notin self.paused_eids:
+      callback(changes)
 
 proc link_child*[K, V](
     self: EdTable[K, V], child, obj: Pair[K, V], field_name = ""

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -109,6 +109,12 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
       # :(
       if info.object_id in flatty_ctx:
         value = value.type()(flatty_ctx.objects[info.object_id])
+      else:
+        # A nested Ed reference we don't hold (a partial replica receiving a
+        # pre-populated parent, or a parent that arrived before its child).
+        # Stand it in with a placeholder rather than leaving the ref nil; reading
+        # it later materializes it (or its own CREATE fills it when it arrives).
+        value = value.type.init_placeholder(flatty_ctx, info.object_id)
   else:
     var is_registered: bool
     s.from_flatty(i, is_registered)
@@ -273,6 +279,14 @@ proc fanout(
     source.incl self.id
   var body, body_no_overwrite: string
   for sub in targets:
+    if sub.partial and msg.object_id notin sub.interest:
+      continue  # partial subscriber: only ops for objects it's interested in
+    if sub.capabilities.len > 0 and msg.type_id != 0 and
+        msg.type_id notin sub.capabilities:
+      # Peer can't materialize this type — never send its ops. type_id == 0
+      # (DESTROY / control) isn't type-gated; it's a no-op on a peer that never
+      # got the CREATE, and must reach a peer that did.
+      continue
     if sub.kind == LOCAL:
       self.send(sub, msg, op_ctx, flags)
     elif sub.kind == REMOTE and SYNC_REMOTE in flags:
@@ -424,6 +438,8 @@ proc add_subscriber*(
   debug "adding subscriber", sub
   self.subscribers.add sub
   for id in self.objects.keys.to_seq.reversed:
+    if sub.partial and id notin sub.interest:
+      continue  # partial subscriber: only push objects it's interested in
     if id notin remote_objects or push_all:
       debug "sending object on subscribe",
         from_ctx = self.id, to_ctx = sub.ctx_id, ed_id = id
@@ -443,23 +459,42 @@ proc unsubscribe*(self: EdContext, sub: Subscription) =
   self.subscribers.delete self.subscribers.find(sub)
   self.unsubscribed.add sub.ctx_id
 
+# Defined after `tick` (which it pumps); forward-declared so `subscribe` can wire
+# it onto each subscribing context.
+proc materialize_impl(self: EdContext, id: string) {.gcsafe.}
+
 proc process_value_initializers(self: EdContext) =
   debug "running deferred initializers", ctx = self.id
   for initializer in self.value_initializers:
     initializer()
   self.value_initializers = @[]
 
-proc subscribe*(self: EdContext, ctx: EdContext, bidirectional = true) =
-  ## Subscribe to another local context for cross-thread sync.
+proc subscribe*(
+    self: EdContext,
+    ctx: EdContext,
+    bidirectional = true,
+    partial = false,
+    roots: seq[string] = @[],
+) =
+  ## Subscribe to another local context for cross-thread sync. When `partial`,
+  ## we only receive objects in `roots` (and ids we later fetch) — the
+  ## authority→us direction is filtered; our own writes still flow to it.
   privileged
   debug "local subscribe", ctx = self.id
+  self.materialize = materialize_impl # enable materialize-on-access
   self.pack_objects
   var remote_objects: HashSet[string]
   for id in self.objects.keys:
     remote_objects.incl id
   self.subscribing = true
   ctx.add_subscriber(
-    Subscription(kind: LOCAL, chan: self.chan, ctx_id: self.id),
+    Subscription(
+      kind: LOCAL,
+      chan: self.chan,
+      ctx_id: self.id,
+      partial: partial,
+      interest: roots.toHashSet,
+    ),
     push_all = bidirectional,
     remote_objects,
   )
@@ -469,19 +504,52 @@ proc subscribe*(self: EdContext, ctx: EdContext, bidirectional = true) =
   self.process_value_initializers
 
   if bidirectional:
+    # Reverse direction (us → authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false)
+
+proc fetch*(self: EdContext, object_id: string) =
+  ## Ask the authority for `object_id`. It's materialized on a later tick
+  ## (placeholder-then-fill); the authority adds it to our interest so future
+  ## ops follow. No-op if we already hold it *loaded* — a placeholder (held but
+  ## not materialized) still needs fetching.
+  if object_id in self and not self.objects[object_id].placeholder:
+    return
+  var msg = Message(kind: REQUEST, object_id: object_id)
+  for sub in self.subscribers:
+    self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  self.tick_reactor
+
+proc flush_key_requests(self: EdContext) =
+  ## Send the per-key fetches buffered since the last tick — one REQUEST per
+  ## table, carrying the batch of serialized keys in `obj`. The authority replies
+  ## with an ADD op per found key (see the REQUEST handler).
+  if self.pending_key_requests.len == 0:
+    return
+  let pending = self.pending_key_requests
+  self.pending_key_requests.clear
+  for object_id, keys in pending:
+    let msg = Message(kind: REQUEST, object_id: object_id, obj: keys.to_flatty)
+    for sub in self.subscribers:
+      self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  self.tick_reactor
 
 proc subscribe*(
     self: EdContext,
     address: string,
     bidirectional = true,
+    partial = false,
+    roots: seq[string] = @[],
     callback: proc() {.gcsafe.} = nil,
 ) =
-  ## Subscribe to a remote context for network sync. Address format: "host" or "host:port".
+  ## Subscribe to a remote context for network sync. Address format: "host" or
+  ## "host:port". When `partial`, the authority only sends objects in `roots`
+  ## (and ids fetched later); the reference graph + materialize-on-access pull the
+  ## rest. Mirrors the local `subscribe(partial = ..., roots = ...)`.
   var address = address
   var port = 9632
 
   debug "remote subscribe", address
+  self.materialize = materialize_impl # enable materialize-on-access
   if not ?self.reactor:
     self.reactor = new_reactor()
   self.subscribing = true
@@ -495,6 +563,11 @@ proc subscribe*(
     port = parts[1].parse_int
 
   let connection = self.reactor.connect(address, port)
+  # The SUBSCRIBE carries, in `obj`, the subscriber's handshake: the type-ids it
+  # can materialize (capability filter; see ref-registration.md) plus its
+  # partial-replica interest (partial flag + root ids). The authority applies all
+  # three to the subscription it creates for us.
+  let handshake = (toSeq(type_initializers.keys), partial, roots).to_flatty
   self.send(
     Subscription(
       kind: REMOTE,
@@ -502,7 +575,7 @@ proc subscribe*(
       connection: connection,
       last_sent_time: epoch_time(),
     ),
-    Message(kind: SUBSCRIBE),
+    Message(kind: SUBSCRIBE, obj: handshake),
   )
 
   var ctx_id = ""
@@ -672,6 +745,32 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         ),
       )
       # :(
+    # The creator is interested in its own object: make sure its canonical ops
+    # flow back. Matters for partial subscribers; a no-op for full ones.
+    for s in self.subscribers:
+      if s.ctx_id in source:
+        s.interest.incl msg.object_id
+  elif msg.kind == REQUEST:
+    # A partial subscriber wants data. Two forms:
+    #  - whole-object (`obj` empty): add the object to interest and publish_create
+    #    it (existing behavior — future ops then follow).
+    #  - per-key (`obj` = a batch of serialized table keys): reply with just those
+    #    entries (an ADD op each), without adding the whole table to interest.
+    # The requester is whoever the message came from — match by ctx id in `source`.
+    for s in self.subscribers:
+      if s.ctx_id notin source:
+        continue
+      if msg.object_id notin self:
+        continue
+      if msg.obj.len > 0:
+        let obj = self.objects[msg.object_id]
+        for key_bin in msg.obj.from_flatty(seq[string]):
+          let reply = obj.publish_key(obj, key_bin)
+          if reply.found:
+            self.send(s, reply.msg, OperationContext(), DEFAULT_FLAGS)
+      else:
+        s.interest.incl msg.object_id
+        self.objects[msg.object_id].publish_create(s)
   elif msg.kind != BLANK:
     if msg.object_id notin self:
       # :( this should throw an error
@@ -736,6 +835,30 @@ proc track*[T, O](
 proc untrack_on_destroy*(self: ref EdBase, zid: EID) =
   self.bound_eids.add(zid)
 
+proc parse_remote(
+    self: EdContext, raw_msg: netty.Message
+): tuple[ok: bool, msg: Message] {.gcsafe.} =
+  ## Decode one raw remote packet into a Message (source short-ids + mappings
+  ## attached, body uncompressed). ok = false for keepalive pings and unparseable
+  ## bytes — a version-skewed peer or stray packet on the same port is dropped,
+  ## not fatal. Shared by `tick` and the silent materialize pump so the wire
+  ## decode lives in exactly one place.
+  if raw_msg.data == "PING":
+    return (false, Message())
+  try:
+    # Wire format: a small per-subscriber header (source short-ids + new
+    # mappings) followed by the shared, compressed body (see send_remote).
+    let (enc_source, mappings, body) =
+      raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
+    var msg = body.uncompress.from_flatty(Message, self)
+    msg.source = enc_source
+    msg.id_mappings = mappings
+    return (true, msg)
+  except CatchableError, Defect:
+    warn "dropping unparseable remote message",
+      bytes = raw_msg.data.len, peer = $raw_msg.conn.address
+    return (false, Message())
+
 proc tick*(
     self: EdContext,
     messages = int.high,
@@ -786,6 +909,22 @@ proc tick*(
       get_mono_time() + min_duration
 
   self.flush_buffers
+  self.flush_key_requests # send this frame's batched per-key fetches
+
+  # Replay whatever a silent (blocking) materialize deferred — at this tick
+  # boundary, before new traffic: first the messages it buffered (apply + fire
+  # their callbacks), then the Fill callbacks for the object it materialized.
+  if self.pending_msgs.len > 0:
+    let deferred = self.pending_msgs
+    self.pending_msgs = @[]
+    for m in deferred:
+      self.process_message(m)
+  if self.pending_fills.len > 0:
+    let fills = self.pending_fills
+    self.pending_fills = @[]
+    for f in fills:
+      f()
+
   while true:
     if poll:
       # Drain the available batch, then coalesce superseded register updates:
@@ -829,27 +968,10 @@ proc tick*(
 
       for raw_msg in messages:
         inc count
-        # Handle keepalive pings - just ignore them (receiving updates lastActiveTime in netty)
-        if raw_msg.data == "PING":
+        let parsed = self.parse_remote(raw_msg)
+        if not parsed.ok: # keepalive ping or unparseable — already handled
           continue
-        # Parse boundary for untrusted bytes: a version-skewed peer or stray
-        # packet (e.g. another process on the same port) can't be parsed with
-        # our envelope. Drop it instead of crashing — don't let one bad packet
-        # take down the process. Scoped to (de)serialization so it doesn't mask
-        # logic bugs in process_message.
-        var msg: Message
-        try:
-          # Wire format: a small per-subscriber header (source short-ids + new
-          # mappings) followed by the shared, compressed body (see send_remote).
-          let (enc_source, mappings, body) =
-            raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
-          msg = body.uncompress.from_flatty(Message, self)
-          msg.source = enc_source
-          msg.id_mappings = mappings
-        except CatchableError, Defect:
-          warn "dropping unparseable remote message",
-            bytes = raw_msg.data.len, peer = $raw_msg.conn.address
-          continue
+        var msg = parsed.msg
         when defined(ed_debug_messages):
           inc self.messages_received
           self.obj_bytes_received += msg.obj.len
@@ -901,11 +1023,26 @@ proc tick*(
               old_ctx_id = sub.ctx_id, new_ctx_id = source_str
             self.unsubscribe(sub)
 
+          # Handshake (capabilities, partial, roots) rides in the SUBSCRIBE `obj`.
+          # Empty (older peer) = unfiltered, full replica.
+          var caps: HashSet[int]
+          var is_partial = false
+          var interest: HashSet[string]
+          if msg.obj.len > 0:
+            let (cap_ids, p, roots) =
+              msg.obj.from_flatty((seq[int], bool, seq[string]))
+            caps = cap_ids.to_hash_set
+            is_partial = p
+            interest = roots.to_hash_set
+
           var new_sub = Subscription(
             kind: REMOTE,
             connection: raw_msg.conn,
             ctx_id: source_str,
             last_sent_time: epoch_time(),
+            capabilities: caps,
+            partial: is_partial,
+            interest: interest,
           )
           # Register all mappings from the subscribe message
           new_sub.register_mappings(msg.id_mappings)
@@ -934,6 +1071,59 @@ proc tick*(
     if poll == false or
         ((count > 0 or not blocking) and get_mono_time() > recv_until):
       break
+
+proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
+  ## Wired onto a context at subscribe time and called by the read accessors when
+  ## they touch a placeholder (see operations.touch_placeholder). Kicks a fetch;
+  ## when in a `blocking` scope, pumps I/O and **silently** materializes just this
+  ## object — every other received message and even this object's own Fill
+  ## callback are deferred to the next explicit `tick`, so nothing
+  ## application-visible happens mid-read (clean reentrancy). Bounded by a deadline
+  ## so a gone authority can't hang the caller; it then falls back to the empty
+  ## placeholder, same as the non-blocking path. Drains both the local
+  ## (cross-thread) and remote (network) transports.
+  privileged
+  if id notin self or not self.objects[id].placeholder:
+    return
+  self.fetch(id)
+  if not self.blocking:
+    return
+
+  template triage(candidate: Message) =
+    # Apply only the target object's CREATE (silently — its callback is
+    # deferred); buffer everything else for the next tick. SUBSCRIBE can't be
+    # replayed sub-less, but a blocking *client* shouldn't receive one.
+    if candidate.object_id == id and candidate.kind == CREATE:
+      self.process_message(candidate)
+    elif candidate.kind != SUBSCRIBE:
+      self.pending_msgs.add candidate
+
+  let deadline = get_mono_time() + init_duration(seconds = 5)
+  self.silent = true
+  while id in self and self.objects[id].placeholder and
+      get_mono_time() < deadline:
+    # Local transport.
+    var m: Message
+    while self.chan.try_recv(m):
+      triage(m)
+    # Remote transport — reuse the same wire decode as tick, then resolve the
+    # source eagerly so a deferred message processes correctly sub-less later.
+    if ?self.reactor:
+      self.tick_reactor
+      let raws = self.remote_messages
+      self.remote_messages = @[]
+      for raw_msg in raws:
+        let parsed = self.parse_remote(raw_msg)
+        if not parsed.ok:
+          continue
+        var rmsg = parsed.msg
+        for s in self.subscribers:
+          if s.kind == REMOTE and s.connection == raw_msg.conn:
+            s.register_mappings(rmsg.id_mappings)
+            rmsg.source_set = s.decode_source(rmsg.source)
+            break
+        triage(rmsg)
+  self.silent = false
 
 proc find_bare_return(n: NimNode): NimNode =
   if n.kind == nnkReturnStmt:

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -21,6 +21,13 @@ type
     TOUCHED   ## Object was touched without modification
     CLOSED    ## Object was destroyed
 
+  ChangeReason* = enum
+    ## Why a change fired, orthogonal to `ChangeKind`. (Unrelated to
+    ## `Change.triggered_by`, which is the upstream changes that caused this one.)
+    Normal    ## An ordinary mutation
+    Initial   ## Replay of existing contents at `track` time (reserved)
+    Fill      ## A placeholder materialized (partial-replica fetch landed)
+
   MessageKind* = enum
     BLANK
     CREATE
@@ -30,9 +37,11 @@ type
     TOUCH
     SUBSCRIBE
     PACKED
+    REQUEST  # partial replica asking the authority for an object by id
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]
+    reason*: ChangeReason
     field_name*: string
     triggered_by*: seq[BaseChange]
     triggered_by_type*: string
@@ -106,6 +115,17 @@ type
 
   Subscription* = ref object
     ctx_id*: string
+    # Partial replicas: when `partial`, this subscriber only receives objects in
+    # `interest` (its roots + ids it has fetched). Default (not partial) gets
+    # everything — the existing full-replica behavior.
+    partial*: bool
+    interest*: HashSet[string]
+    # Capability filter: the set of container type-ids this subscriber can
+    # materialize (its registered `type_initializers`). The authority skips any
+    # object whose `type_id` isn't here, so a peer never receives an object it
+    # can't construct (which would crash/drop on deserialize). Empty = unfiltered
+    # (no handshake / same-build peer) — preserves the full-replica default.
+    capabilities*: HashSet[int]
     # Short ID mappings for this connection. Outgoing and incoming are
     # *separate* namespaces — each peer independently allocates short IDs
     # in messages it sends. Sharing the table would let our own outgoing
@@ -135,6 +155,20 @@ type
     applied_lsn*: int64   # highest global LSN applied (frontier)
     op_id_counter*: int64 # next op id to assign to a write we originate
     latest_op_id*: Table[string, int64]  # object_id -> our highest op id (own-op reconciliation)
+    # Materialize-on-access (partial replicas). `materialize` is wired up at
+    # subscribe time (it needs fetch/tick) and called by the read accessors when
+    # they touch a placeholder. When `blocking`, that call pumps I/O until the
+    # object fills; otherwise it kicks a fetch and returns the empty placeholder.
+    materialize*: proc(self: EdContext, id: string) {.gcsafe.}
+    blocking*: bool
+    filling*: bool        # set while a placeholder fill applies → tags Fill changes
+    silent*: bool         # silent (blocking) materialize: defer callbacks to next tick
+    pending_msgs*: seq[Message]            # received-but-deferred during a silent pump
+    pending_fills*: seq[proc() {.gcsafe.}] # Fill callbacks deferred to the next tick
+    # Per-key fetch requests buffered between ticks (table object_id -> serialized
+    # keys). A frame's worth of request() calls collapse into one REQUEST per
+    # table, flushed on the next tick.
+    pending_key_requests*: Table[string, seq[string]]
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]
@@ -181,6 +215,11 @@ type
     ## Base type for all `Ed` containers. Not used directly.
     id*: string
     destroyed*: bool
+    # Partial replicas: a placeholder is a non-broadcasting stand-in for a
+    # not-yet-materialized object (its contents are empty until fetched). Reading
+    # it triggers a fetch; when the real state arrives the bit clears and a Fill
+    # change fires. Default false = a normal, fully-loaded object.
+    placeholder*: bool
     link_eid: EID
     paused_eids: set[EID]
     bound_eids: seq[EID]
@@ -195,6 +234,15 @@ type
 
     change_receiver:
       proc(self: ref EdBase, msg: Message, op_ctx: OperationContext) {.gcsafe.}
+
+    # Per-key fetch (partial EdTable). Given a serialized key, build the ADD op
+    # carrying that key's current value, so a partial subscriber can pull one
+    # entry without the whole table. `found = false` if the key isn't present.
+    # nil for non-table containers.
+    publish_key:
+      proc(self: ref EdBase, key_bin: string): tuple[found: bool, msg: Message] {.
+        gcsafe
+      .}
 
     ctx*: EdContext
 

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -36,6 +36,17 @@ proc pack_objects*(self: EdContext) =
     self.objects = table
     self.objects_need_packing = false
 
+template blocking*(self: EdContext, body: untyped) =
+  ## Within this scope, a read that touches an unmaterialized placeholder blocks
+  ## (pumps I/O) until it fills, instead of returning empty and fetching async.
+  ## Just manages the `blocking` flag — you can set `self.blocking` directly too.
+  let prev = self.blocking
+  self.blocking = true
+  try:
+    body
+  finally:
+    self.blocking = prev
+
 proc contains*(self: EdContext, id: string): bool =
   id in self.objects and self.objects[id] != nil
 

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -34,7 +34,10 @@ proc create_initializer[T, O](self: Ed[T, O]) =
             debug "restoring received object", id
             var value = bin.from_flatty(T, ctx)
             let item = Ed[T, O](ctx[id])
+            ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+            item.placeholder = false # fill: real state arrived
             `value=`(item, value, op_ctx = op_ctx)
+            ctx.filling = false
           else:
             if id notin ctx:
               discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
@@ -44,13 +47,24 @@ proc create_initializer[T, O](self: Ed[T, O]) =
               {.gcsafe.}:
                 let value = bin.from_flatty(T, ctx)
               let item = Ed[T, O](ctx[id])
+              ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+              item.placeholder = false # fill: real state arrived
               `value=`(item, value, op_ctx = op_ctx)
+              ctx.filling = false
             ctx.value_initializers.add(initializer)
         elif id notin ctx:
           discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
+        else:
+          # Empty-body CREATE for an object we were holding as a placeholder:
+          # it exists for real now, just with no value yet.
+          Ed[T, O](ctx[id]).placeholder = false
 
 proc defaults[T, O](
-    self: Ed[T, O], ctx: EdContext, id: string, op_ctx: OperationContext
+    self: Ed[T, O],
+    ctx: EdContext,
+    id: string,
+    op_ctx: OperationContext,
+    broadcast = true,
 ): Ed[T, O] =
   privileged
   log_defaults
@@ -90,27 +104,31 @@ proc defaults[T, O](
     template send_msg(src_ctx, sub) =
       const ed_type_id = self.type.tid
 
-      var msg = Message(
-        kind: CREATE,
-        obj: bin,
-        flags: flags,
-        type_id: ed_type_id,
-        object_id: id,
-        # source is set by send() based on subscription type
-      )
+      # Capability filter: don't send an object to a peer that can't materialize
+      # its type. Empty `capabilities` = unfiltered (same-build / no handshake).
+      if sub.capabilities.len == 0 or ed_type_id in sub.capabilities:
+        var msg = Message(
+          kind: CREATE,
+          obj: bin,
+          flags: flags,
+          type_id: ed_type_id,
+          object_id: id,
+          # source is set by send() based on subscription type
+        )
 
-      when defined(ed_trace):
-        msg.trace = get_stack_trace()
+        when defined(ed_trace):
+          msg.trace = get_stack_trace()
 
-      src_ctx.send(
-        sub, msg, op_ctx, flags = self.flags & {SYNC_ALL_NO_OVERWRITE}
-      )
+        src_ctx.send(
+          sub, msg, op_ctx, flags = self.flags & {SYNC_ALL_NO_OVERWRITE}
+        )
 
     if sub.kind != BLANK:
       ctx.send_msg(sub)
     if broadcast:
       for sub in ctx.subscribers:
-        if sub.ctx_id notin op_ctx.source:
+        if sub.ctx_id notin op_ctx.source and
+            not (sub.partial and id notin sub.interest):
           ctx.send_msg(sub)
     ctx.tick_reactor
 
@@ -174,7 +192,11 @@ proc defaults[T, O](
 
     when O is Ed:
       let object_id = msg.change_object_id
-      assert object_id in self.ctx
+      if object_id notin self.ctx:
+        # Nested object not materialized yet — stand in with a non-broadcasting
+        # placeholder so the container op applies and cardinality is correct.
+        # Reading the placeholder later triggers a fetch (materialize-on-access).
+        discard O.init_placeholder(self.ctx, object_id)
       let item = O(self.ctx.objects[object_id])
     elif O is Pair[auto, Ed]:
       # Workaround for compile issue. This should be `O`, not `O.default.type`.
@@ -188,9 +210,12 @@ proc defaults[T, O](
         debug "skipping change for missing object", object_id = msg.object_id
         return
 
-      if msg.change_object_id notin self.ctx and msg.kind == UNASSIGN:
-        debug "can't find ", obj = msg.change_object_id
-        return
+      if msg.change_object_id notin self.ctx:
+        if msg.kind == UNASSIGN:
+          debug "can't find ", obj = msg.change_object_id
+          return
+        # Value object not materialized yet — placeholder it (see above).
+        discard V.init_placeholder(self.ctx, msg.change_object_id)
       let value = V(self.ctx.objects[msg.change_object_id])
       {.gcsafe.}:
         let item = O(key: msg.obj.from_flatty(K, self.ctx), value: value)
@@ -229,11 +254,40 @@ proc defaults[T, O](
     else:
       fail "Can't handle message " & $msg.kind
 
+  self.publish_key = proc(
+      self: ref EdBase, key_bin: string
+  ): tuple[found: bool, msg: Message] {.gcsafe.} =
+    # Per-key fetch: build the ADD op for one entry so a partial subscriber can
+    # pull it without the whole table. Only meaningful for table containers.
+    when O is Pair:
+      let self = Ed[T, O](self)
+      type K = generic_params(O.default.type).get(0)
+      {.gcsafe.}:
+        let key = key_bin.from_flatty(K, self.ctx)
+      if key in self.tracked:
+        let pair = O(key: key, value: self.tracked[key])
+        let change = Change[O](changes: {ADDED}, item: pair)
+        result = (found: true, msg: self.build_message(self, change, self.id, ""))
+    else:
+      discard
+
   assert self.ctx == nil
   self.ctx = ctx
 
-  self.publish_create(broadcast = true, op_ctx = op_ctx)
+  if broadcast:
+    self.publish_create(broadcast = true, op_ctx = op_ctx)
   self
+
+proc init_placeholder*[T, O](
+    _: typedesc[Ed[T, O]], ctx: EdContext, id: string
+): Ed[T, O] =
+  ## A non-broadcasting stand-in for a not-yet-materialized object. Registered in
+  ## `ctx.objects` under `id` and marked `placeholder`; no CREATE goes out.
+  ## Reading it triggers a fetch; the real state fills it in later.
+  # `op_ctx` is only consulted by defaults' broadcast, which we skip.
+  result = Ed[T, O](flags: DEFAULT_FLAGS, placeholder: true).defaults(
+    ctx, id, OperationContext(), broadcast = false
+  )
 
 proc init*(
     T: type Ed,

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -1,4 +1,5 @@
 import std/[typetraits, macros, macrocache, tables]
+import pkg/flatty
 import ed/[core, components/private/tracking, types {.all.}]
 import ./[contexts, validations, private]
 
@@ -58,20 +59,72 @@ proc `value=`*[T, O](self: Ed[T, O], value: T, op_ctx = OperationContext()) =
     mutate(op_ctx):
       self.tracked = value
 
+proc loaded*(self: ref EdBase): bool =
+  ## False while this object is an unmaterialized placeholder (a partial replica
+  ## holds the reference but not the contents yet). Lets a caller distinguish
+  ## "exists but not loaded" from "exists and is genuinely empty".
+  not self.placeholder
+
+template touch_placeholder(self: untyped) =
+  ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
+  ## context to materialize it (kick a fetch; block until filled when
+  ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
+  if self.placeholder and self.ctx.materialize != nil:
+    self.ctx.materialize(self.ctx, self.id)
+
 proc value*[T, O](self: Ed[T, O]): T =
   ## Get the container's current value.
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked
 
 proc `[]`*[K, V](self: Ed[Table[K, V], Pair[K, V]], index: K): V =
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked[index]
+
+proc loaded*[K, V](self: EdTable[K, V], key: K): bool =
+  ## Whether this key's value is materialized locally. Distinct from
+  ## `key in self` (shape: whether the key exists at all, once shape sync lands).
+  privileged
+  assert self.valid
+  key in self.tracked
+
+proc request*[K, V](self: EdTable[K, V], key: K) =
+  ## Queue a per-key fetch from the authority. Batched and sent on the next
+  ## `tick` (a frame's worth of requests collapse into one message per table);
+  ## the value arrives as an ADDED change, so existing `track`/`watch` handlers
+  ## render it. No-op if the key is already loaded.
+  privileged
+  assert self.valid
+  if key notin self.tracked:
+    self.ctx.pending_key_requests.mgetOrPut(self.id, @[]).add key.to_flatty
+
+proc request*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+  for key in keys:
+    self.request(key)
+
+proc release*[K, V](self: EdTable[K, V], key: K) =
+  ## Drop a locally-materialized entry to free memory (eviction). Local only —
+  ## fires a REMOVED change (so watches un-render) but does NOT delete on the
+  ## authority; `request(key)` re-fetches it. No-op if not loaded.
+  privileged
+  assert self.valid
+  if key in self.tracked:
+    let pair = Pair[K, V](key: key, value: self.tracked[key])
+    self.tracked.del key
+    self.trigger_callbacks(@[Change[Pair[K, V]](changes: {REMOVED}, item: pair)])
+
+proc release*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+  for key in keys:
+    self.release(key)
 
 proc `[]`*[T](self: EdSeq[T], index: SomeOrdinal | BackwardsIndex): T =
   privileged
   assert self.valid
+  self.touch_placeholder
   self.tracked[index]
 
 proc `[]=`*[K, V](
@@ -293,17 +346,20 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
 iterator items*[T](self: EdSet[T] | EdSeq[T]): T =
   privileged
   assert self.valid
+  self.touch_placeholder
   for item in self.tracked.items:
     yield item
 
 iterator items*[K, V](self: EdTable[K, V]): Pair[K, V] =
   privileged
   assert self.valid
+  self.touch_placeholder
   for key, value in self.tracked.pairs:
     yield Pair[K, V](key: key, value: value)
 
 iterator pairs*[K, V](self: EdTable[K, V]): (K, V) =
   privileged
   assert self.valid
+  self.touch_placeholder
   for pair in self.tracked.pairs:
     yield pair

--- a/tests/capability_tests.nim
+++ b/tests/capability_tests.nim
@@ -1,0 +1,44 @@
+import std/[unittest, sets]
+import ed
+import ed/zens/contexts
+import ed/utils/misc
+
+proc run*() =
+  suite "capability handshake":
+    test "authority skips objects the subscriber can't materialize":
+      var authority = EdContext.init(id = "cap_auth", is_authority = true)
+      var client = EdContext.init(id = "cap_client")
+      client.subscribe(authority)
+
+      # Model a different-build remote peer: in-process both share
+      # `type_initializers`, so restrict the subscription by hand to a single
+      # type it "can handle". (The wire handshake populates this automatically
+      # for real remote subscribers.)
+      authority.subscribers[0].capabilities = [Ed[int, int].tid].to_hash_set
+
+      var i = EdValue[int].init(ctx = authority, id = "cap_int")
+      i.value = 7
+      var s = EdValue[string].init(ctx = authority, id = "cap_str")
+      s.value = "hi"
+      client.tick()
+
+      check "cap_int" in client # capable type delivered
+      check "cap_str" notin client # incapable type filtered out
+      check EdValue[int](client["cap_int"]).value == 7
+
+      # Ongoing ops respect it too: a later write to the filtered object never
+      # arrives (and never crashes the client trying to deserialize it).
+      s.value = "world"
+      client.tick()
+      check "cap_str" notin client
+
+    test "empty capabilities = unfiltered (default full replica)":
+      var authority = EdContext.init(id = "cap_auth2", is_authority = true)
+      var client = EdContext.init(id = "cap_client2")
+      client.subscribe(authority) # local subscribe leaves capabilities empty
+
+      var i = EdValue[int].init(ctx = authority, id = "cap_int2")
+      var s = EdValue[string].init(ctx = authority, id = "cap_str2")
+      client.tick()
+      check "cap_int2" in client
+      check "cap_str2" in client

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -1,0 +1,253 @@
+import std/[unittest, sets, atomics, os, tables]
+import ed
+import ed/zens/contexts
+import test_util
+
+# A listening authority on its own thread, ticking continuously — the role Enu
+# plays for the MCP server (separate process, independent tick loop), and what a
+# blocking remote materialize needs to respond to it.
+var rmat_running: Atomic[bool]
+var rmat_ready: Atomic[bool]
+var rmat_thread: Thread[string]
+
+proc rmat_server_loop(address: string) {.thread.} =
+  let server =
+    EdContext.init(id = "rmat-server", is_authority = true, listen_address = address)
+  Ed.thread_ctx = server
+  var parent = EdSeq[EdValue[string]].init(id = "parent", ctx = server)
+  var child = EdValue[string].init(id = "child", ctx = server)
+  child.value = "materialized"
+  parent += child # parent is pre-populated before any client connects
+  rmat_ready.store(true)
+  while rmat_running.load:
+    server.tick
+    sleep 5
+  server.close
+
+proc run*() =
+  suite "materialize on access":
+    test "placeholder stands in for an out-of-interest nested object":
+      var authority = EdContext.init(id = "m_auth", is_authority = true)
+      var client = EdContext.init(id = "m_client")
+
+      # Parent collection of nested Ed values.
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+
+      # Client is interested only in the parent, not its children.
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      check "parent" in client
+
+      # Author a child and add it to the parent. The child's CREATE is filtered
+      # (not in interest), but the parent's ADD op — which references the child —
+      # is delivered, so the client must stand in with a placeholder.
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+
+      check "child" in client # placeholder materialized into the object pool
+      check EdSeq[EdValue[string]](client["parent"]).len == 1 # cardinality correct
+      check not client["child"].loaded # exists, but not loaded
+      check EdValue[string](client["child"]).value == "" # empty until filled
+
+      # Explicit fetch materializes it (access-triggered fetch is the next slice).
+      client.fetch("child")
+      authority.tick() # authority answers the REQUEST
+      client.tick() # client fills the placeholder
+      check client["child"].loaded # fill cleared the bit
+      check EdValue[string](client["child"]).value == "hi"
+
+    test "reading a placeholder auto-triggers the fetch (no explicit fetch)":
+      var authority = EdContext.init(id = "ma_auth", is_authority = true)
+      var client = EdContext.init(id = "ma_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+      check not client["child"].loaded
+
+      # Just *reading* the placeholder's value kicks the fetch (non-blocking:
+      # returns empty now). No client.fetch() call here.
+      check EdValue[string](client["child"]).value == ""
+      authority.tick() # authority answers the access-triggered REQUEST
+      client.tick() # fill arrives
+      check client["child"].loaded
+      check EdValue[string](client["child"]).value == "hi"
+
+    test "a fill fires a change tagged reason == Fill":
+      var authority = EdContext.init(id = "mf_auth", is_authority = true)
+      var client = EdContext.init(id = "mf_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick()
+      check not client["child"].loaded
+
+      var fill_reason = Normal
+      EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
+        for c in cs:
+          if MODIFIED in c.changes:
+            fill_reason = c.reason
+
+      client.fetch("child")
+      authority.tick()
+      client.tick() # fill applies here → callback fires, tagged Fill
+      check client["child"].loaded
+      check fill_reason == Fill
+
+    test "blocking materialize is silent: only the target fills, rest defers":
+      var authority = EdContext.init(id = "ms_auth", is_authority = true)
+      var client = EdContext.init(id = "ms_client")
+      var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
+      var other = EdValue[int].init(ctx = authority, id = "other")
+      client.subscribe(authority, partial = true, roots = @["parent", "other"])
+      client.tick()
+
+      var child = EdValue[string].init(ctx = authority, id = "child")
+      child.value = "hi"
+      parent += child
+      client.tick() # placeholder for child
+      check not client["child"].loaded
+
+      var other_fired = false
+      EdValue[int](client["other"]).track proc(cs: seq[Change[int]]) =
+        other_fired = true
+      var child_fill_reason = Normal
+      EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
+        for c in cs:
+          if MODIFIED in c.changes:
+            child_fill_reason = c.reason
+
+      # Queue two messages into the client's channel WITHOUT processing them:
+      # an unrelated change to `other`, and (via fetch) the child's CREATE.
+      other.value = 99
+      client.fetch("child")
+      authority.tick() # authority queues child's CREATE onto the client's chan
+
+      # Blocking read materializes ONLY child; everything else is deferred.
+      var got = "before"
+      client.blocking:
+        got = EdValue[string](client["child"]).value
+
+      check got == "hi" # blocking read returned the real value
+      check client["child"].loaded
+      check not other_fired # unrelated message was deferred, not applied
+      check EdValue[int](client["other"]).value == 0 # ...and its value untouched
+      check not (child_fill_reason == Fill) # even the Fill callback deferred
+
+      # The next explicit tick replays everything at the tick boundary.
+      client.tick()
+      check other_fired
+      check EdValue[int](client["other"]).value == 99
+      check child_fill_reason == Fill
+
+    test "remote partial replica blocking-materializes a placeholder":
+      let address = free_addr()
+      rmat_ready.store(false)
+      rmat_running.store(true)
+      create_thread(rmat_thread, rmat_server_loop, address)
+      while not rmat_ready.load:
+        sleep 5
+      defer:
+        rmat_running.store(false)
+        join_thread(rmat_thread)
+
+      var client = EdContext.init(id = "rmat-client")
+      # Partial subscribe over the network: interested only in the parent.
+      client.subscribe(address, partial = true, roots = @["parent"])
+
+      # The pre-populated parent arrives; its out-of-interest child is a
+      # placeholder (created in from_flatty). Wait briefly for it (UDP).
+      var tries = 0
+      while "child" notin client and tries < 200:
+        client.tick()
+        sleep 5
+        inc tries
+      check "parent" in client
+      check "child" in client
+      check not client["child"].loaded # placeholder, contents not pulled yet
+
+      # A blocking read materializes it over the network — the server thread
+      # answers the fetch while we pump.
+      var got = ""
+      client.blocking:
+        got = EdValue[string](client["child"]).value
+      check got == "materialized"
+      check client["child"].loaded
+      client.close
+
+    test "per-key fetch: pull individual table entries, batched, as ADDED":
+      var authority = EdContext.init(id = "pk_auth", is_authority = true)
+      var client = EdContext.init(id = "pk_client")
+      # A seq of tables; the client takes the seq as a root, so each table comes
+      # in as an empty placeholder.
+      var parent = EdSeq[EdTable[int, string]].init(ctx = authority, id = "parent")
+      var child = EdTable[int, string].init(ctx = authority, id = "child")
+      child[1] = "one"
+      child[2] = "two"
+      child[3] = "three"
+      parent += child
+
+      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.tick()
+      let table = EdTable[int, string](client["child"])
+      check "child" in client
+      check not table.loaded(1) # nothing pulled yet
+
+      # Watch records arrivals as ADDED (the pattern enu's renderer uses).
+      var arrived: seq[(int, string)]
+      table.changes:
+        if added:
+          arrived.add (change.item.key, change.item.value)
+
+      # Two requests in one frame → one batched REQUEST on the next tick.
+      table.request(1)
+      table.request(3)
+      client.tick() # flush_key_requests sends the batch
+      authority.tick() # authority replies with entries 1 and 3
+      client.tick() # client applies the ADD ops
+
+      check table.loaded(1)
+      check table.loaded(3)
+      check not table.loaded(2) # never requested → not pulled
+      check table[1] == "one"
+      check table[3] == "three"
+      check arrived.len == 2 # both fills fired as ADDED changes
+      check (1, "one") in arrived
+      check (3, "three") in arrived
+
+      # release evicts locally (loaded -> false) without deleting on the authority.
+      var removed_keys: seq[int]
+      table.changes:
+        if removed:
+          removed_keys.add change.item.key
+      table.release(1)
+      check not table.loaded(1) # dropped locally
+      check removed_keys == @[1] # fired REMOVED so watches un-render
+      check EdTable[int, string](authority["child"]).loaded(1) # still on authority
+      table.request(1) # re-fetch works
+      client.tick()
+      authority.tick()
+      client.tick()
+      check table.loaded(1)
+      check table[1] == "one"
+
+    test "blocking scope toggles the flag and restores it":
+      var ctx = EdContext.init(id = "mb_ctx")
+      check not ctx.blocking
+      ctx.blocking:
+        check ctx.blocking # set inside the scope
+      check not ctx.blocking # restored after
+      # Nested / manual management still composes.
+      ctx.blocking = true
+      ctx.blocking:
+        check ctx.blocking
+      check ctx.blocking # restored to the manual value, not forced off

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -1,0 +1,101 @@
+import std/unittest
+import ed
+import ed/zens/contexts
+
+proc run*() =
+  suite "partial replicas":
+    test "partial subscriber only receives its interest set":
+      var authority = EdContext.init(id = "p_authority", is_authority = true)
+      var client = EdContext.init(id = "p_client")
+
+      var x = EdValue[int].init(ctx = authority, id = "obj_x")
+      var y = EdValue[int].init(ctx = authority, id = "obj_y")
+      x.value = 1
+      y.value = 2
+
+      # Interested only in obj_x.
+      client.subscribe(authority, partial = true, roots = @["obj_x"])
+      client.tick()
+
+      check "obj_x" in client # pushed (in interest)
+      check "obj_y" notin client # filtered out
+      check EdValue[int](client["obj_x"]).value == 1
+
+      # Ongoing ops: only obj_x's changes reach the client.
+      x.value = 10
+      y.value = 20
+      client.tick()
+      check EdValue[int](client["obj_x"]).value == 10
+      check "obj_y" notin client
+
+    test "fetch materializes an out-of-interest object and starts syncing it":
+      var authority = EdContext.init(id = "f_authority", is_authority = true)
+      var client = EdContext.init(id = "f_client")
+
+      var x = EdValue[int].init(ctx = authority, id = "f_x")
+      var y = EdValue[int].init(ctx = authority, id = "f_y")
+      x.value = 1
+      y.value = 2
+
+      client.subscribe(authority, partial = true, roots = @["f_x"])
+      client.tick()
+      check "f_y" notin client
+
+      # Fetch f_y on demand.
+      client.fetch("f_y")
+      authority.tick() # authority handles REQUEST, sends f_y's CREATE
+      client.tick() # client materializes f_y
+      check "f_y" in client
+      check EdValue[int](client["f_y"]).value == 2
+
+      # f_y now syncs (it joined the interest set).
+      y.value = 20
+      client.tick()
+      check EdValue[int](client["f_y"]).value == 20
+
+    test "objects created after subscribe respect partial interest":
+      var authority = EdContext.init(id = "pc_auth", is_authority = true)
+      var client = EdContext.init(id = "pc_client")
+      client.subscribe(authority, partial = true, roots = @["pc_root"])
+      client.tick()
+
+      # Created after the subscribe — the broadcast CREATE must still be filtered.
+      var root = EdValue[int].init(ctx = authority, id = "pc_root")
+      var other = EdValue[int].init(ctx = authority, id = "pc_other")
+      client.tick()
+      check "pc_root" in client # in interest
+      check "pc_other" notin client # filtered
+
+    test "a partial client's own object syncs back from the authority":
+      var authority = EdContext.init(id = "po_auth", is_authority = true)
+      var client = EdContext.init(id = "po_client")
+      client.subscribe(authority, partial = true, roots = @[])
+      client.tick()
+
+      # Client creates its own object; the authority should pick it up and
+      # return its canonical ops (auto-interest on create-from-subscriber).
+      var mine = EdValue[int].init(ctx = client, id = "po_mine")
+      mine.value = 5
+      authority.tick()
+      client.tick()
+      check "po_mine" in authority
+      check EdValue[int](authority["po_mine"]).value == 5
+
+      # Return-to-source works for the partial client's own object.
+      EdValue[int](client["po_mine"]).value = 7
+      authority.tick()
+      client.tick()
+      check EdValue[int](authority["po_mine"]).value == 7
+      check EdValue[int](client["po_mine"]).value == 7
+
+    test "non-partial subscriber still gets everything (default unchanged)":
+      var authority = EdContext.init(id = "p_authority2", is_authority = true)
+      var client = EdContext.init(id = "p_client2")
+
+      var x = EdValue[int].init(ctx = authority, id = "obj_x2")
+      var y = EdValue[int].init(ctx = authority, id = "obj_y2")
+
+      client.subscribe(authority) # full
+      client.tick()
+      check "obj_x2" in client
+      check "obj_y2" in client

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,7 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
-  lsn_tests, client_tests
+  lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests
 
 Ed.bootstrap
 
@@ -16,3 +16,6 @@ error_handling_tests.run()
 memory_tests.run()
 lsn_tests.run()
 client_tests.run()
+partial_tests.run()
+capability_tests.run()
+materialize_tests.run()


### PR DESCRIPTION
**Stacked on #13.** PR 1 of the partial-replicas / object-lifecycle stack. The foundational partial-replica layer (formerly #11), squashed; spike docs folded into `docs/partial-replicas.md`.

Opt-in and non-breaking — the default is still a full replica, byte-identical to before.

- **Per-subscriber interest + filtered delivery** across `add_subscriber`, `fanout`/`publish_changes`, and `publish_create`. A partial client's own creates auto-join its interest; DESTROY bypasses the filter.
- **Fetch protocol** — `REQUEST` message + `EdContext.fetch`.
- **Capability handshake** — a subscriber advertises its materializable type-ids; the authority never sends an object the peer can't construct (`type_id == 0` exempt; empty = unfiltered).
- **Placeholders + materialize-on-access** — non-resident nested `Ed` refs become typed placeholders; reading one fetches it (placeholder-then-fill, or a bounded 5s blocking pump). Silent materialize defers callbacks to the next tick. `Change.reason` (Update | Fill).
- **Per-key EdTable fetch** — `request`/`loaded`/`release`, batched.

Full suite green (incl. `capability_tests`, `materialize_tests`, `partial_tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)