### PR TITLE
feat(lifecycle): Lifetime, cursor back-refs, ref_pool→ORC, ownership; remove old free system

### DIFF
--- a/docs/object-lifecycle.md
+++ b/docs/object-lifecycle.md
@@ -1,0 +1,79 @@
+# Object Lifecycle — Lifetimes, Ownership, Teardown
+
+How Ed tears objects down without manual `zid`/`free` choreography. This is the
+"80%" layer; the proxy/body split that builds on it is in `proxy-body.md`.
+
+## Two hard constraints
+
+1. **The registry is a strong-ref root.** `ctx.objects[id]` strong-refs every
+   container, so a container's refcount never naturally hits zero while registered
+   — `=destroy` won't fire on its own. So a destructor can't be the *trigger* for
+   canonical-object teardown; removal from the registry is always explicit
+   (`destroy`/`DESTROY`). Destructors are used only for the thread-local, scope-
+   bound leaf (callbacks, registry-index cleanup).
+2. **Objects are thread-local to their context.** Sync copies *values*, not refs,
+   so an instance lives on one thread; ORC's non-atomic refcount is sound only
+   because of this. A stray Ed ref crossing threads is already unsound.
+
+## The pieces
+
+- **`Lifetime`** — a standalone set of teardown actions (untrack closures),
+  *not* welded to the object. An owner (a Unit, a scope) holds one and `finish`es
+  it on teardown, so everything bound to it cleans up at once — no manual `zid`.
+  Standalone on purpose: under the proxy/body split it becomes the proxy's cleanup
+  set with no call-site change. `track` consults a thread-local `current_lifetime`
+  (set by the `own` scope) and auto-binds.
+
+- **`{.cursor.}` back-references.** Structural back-refs (`EdRef.ctx`,
+  `EdBodyBase.ctx`, the body→proxy link) are non-owning cursors, so they don't
+  count toward the refcount and a cascade frees a subtree promptly instead of
+  waiting on ORC's cycle collector. Forward refs (collection → entries) stay strong
+  and *are* the ownership. Safe because the context strictly outlives its objects
+  and teardown that reads `ctx` is explicit, on the home thread. Validated under
+  AddressSanitizer (`tests/asan.sh`).
+
+- **`ref_pool` → ORC.** Registered refs (Units) are held by collections + the app,
+  never by the container registry — so ORC's refcount already *is* the "is anyone
+  still referencing this" count the old `CountedRef` maintained by hand (with a 10s
+  grace timer). That manual count and grace are gone: `ref_pool` is now a non-owning
+  (cursor) index, and memory is ORC-owned. Every registered type inherits `EdRef`,
+  which carries a `RefHandle` whose `=destroy` records the now-dead instance for
+  removal from `ref_pool`.
+
+  **The RefHandle discipline (load-bearing).** The handle's `=destroy` must never
+  dereference its `EdContext`: at teardown the context can be reclaimed in the
+  *same* ORC cycle-collection batch as the ref, so touching it is a use-after-free
+  (caught by ASan). Instead it appends the dead `ref_id` to a pending list keyed by
+  the context's per-instance **uid** (a value, not a reference) — `pending_dead_refs`
+  — and each context prunes its own dead ids (`prune_dead_refs`) *before any
+  `ref_pool` identity read* and on tick. The uid (not `id`, which is reused across
+  contexts; not `Ed.thread_ctx`, which is wrong under multiple contexts per thread)
+  is what lets a freed ref find the right pool without a live reference.
+
+  *Precondition:* every live registered ref must be reachable from a strong graph
+  root that is *not* `ref_pool`. A ref held only by `ref_pool` would free
+  prematurely; one held by nothing leaks/UAFs. Name an owner for any floating ref.
+
+## Synced ownership + cascading destroy
+
+Containers and refs can be **owned**, so an owner tears down everything it owns in
+*any* context — including one that didn't construct it (the server cleaning up an
+MCP-created bot after the client drops).
+
+- A container created inside an `own` scope records `owner_id` (baked into the
+  container, synced on its CREATE envelope) and is indexed in `EdContext.owned_by`
+  (owner id → owned ids). `own` comes in two forms: `self.own:` (by the owner
+  object, also sets the callback `Lifetime`) and `id.own:` (by an id you already
+  hold — for construction, before the owner exists).
+- `OWNS_MEMBERS` collections register their `EdRef` members under the collection's
+  owner via `ref_count`, so membership drives ownership (removal un-registers).
+  `set_owner` does the same for standalone refs — keyed by the `ref_pool` key
+  (`tid:id`), matching how `destroy_owned` resolves members, or the ref escapes the
+  cascade.
+- `destroy_owned(owner_id)` tears down owned refs (via their `destroy` method) then
+  owned containers (via the same `change_receiver` path a received DESTROY takes).
+  The owner's `lifetime.finish` handles its callbacks separately — ownership drives
+  *container* teardown, the Lifetime drives *callbacks*.
+
+The result: enu's hand-written `destroy_impl` choreography collapses to roughly an
+`on_destroy` hook for app-only refs plus `self.destroy`.

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -122,6 +122,9 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
       var val: FlatRef
       flatty.from_flatty(s, i, val)
 
+      # Prune reclaimed instances before the dedup read so the cursor we reuse
+      # can't be dangling (see prune_dead_refs / RefHandle).
+      flatty_ctx.prune_dead_refs()
       if val.ref_id in flatty_ctx.ref_pool:
         value = value.type()(flatty_ctx.ref_pool[val.ref_id].obj)
       else:
@@ -144,6 +147,15 @@ proc to_flatty*(s: var string, x: proc) =
   discard
 
 proc from_flatty*(s: string, i: var int, p: proc) =
+  discard
+
+proc to_flatty*(s: var string, x: Lifetime) =
+  ## A Lifetime is thread-local handle state (a set of cleanup closures), never
+  ## part of the synced value. Skip it — flatty can't serialize `seq[proc]`, and
+  ## the receiver mints its own. Mirrors the `proc` override above.
+  discard
+
+proc from_flatty*(s: string, i: var int, x: var Lifetime) =
   discard
 
 proc to_flatty*(s: var string, p: ptr) =
@@ -182,6 +194,17 @@ proc flush_buffers*(self: EdContext) =
       for msg in buffer:
         sub.send_or_buffer(msg, true)
 
+template ed_compress(s: string): string =
+  ## Pass-through under `-d:ed_no_compress` — supersnappy's snappy fast-path
+  ## over-reads within an allocation, which trips AddressSanitizer (it's a benign
+  ## third-party over-read, not our bug). The sanitizer build defines the flag so
+  ## ASan can focus on Ed's own memory behaviour; in-process sync uses one build,
+  ## so both sides agree on the (un)compressed wire format.
+  when defined(ed_no_compress): s else: s.compress
+
+template ed_uncompress(s: string): string =
+  when defined(ed_no_compress): s else: s.uncompress
+
 proc remote_body(msg: Message, no_overwrite: bool): string =
   ## The shared, compressed wire body for a remote message — identical across
   ## subscribers (source / id_mappings travel per-subscriber, outside it), so a
@@ -191,7 +214,7 @@ proc remote_body(msg: Message, no_overwrite: bool): string =
   body_msg.id_mappings = @[]
   if no_overwrite:
     body_msg.obj = ""
-  result = body_msg.to_flatty.compress
+  result = body_msg.to_flatty.ed_compress
 
 proc send_remote(
     self: EdContext, sub: Subscription, source: HashSet[string], body: string
@@ -507,14 +530,19 @@ proc subscribe*(
     # Reverse direction (us → authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false)
 
-proc fetch*(self: EdContext, object_id: string) =
+proc fetch*(self: EdContext, object_id: string, deep = false) =
   ## Ask the authority for `object_id`. It's materialized on a later tick
   ## (placeholder-then-fill); the authority adds it to our interest so future
   ## ops follow. No-op if we already hold it *loaded* — a placeholder (held but
   ## not materialized) still needs fetching.
-  if object_id in self and not self.objects[object_id].placeholder:
+  ##
+  ## `deep` also fetches everything the id *owns* (the synced-ownership closure,
+  ## recursively) — so an owner id (a unit, which isn't itself a container) pulls
+  ## its whole owned state in one request. The already-loaded short-circuit is
+  ## skipped for deep fetches: holding the root says nothing about the closure.
+  if not deep and object_id in self and not self.objects[object_id].placeholder:
     return
-  var msg = Message(kind: REQUEST, object_id: object_id)
+  var msg = Message(kind: REQUEST, object_id: object_id, deep: deep)
   for sub in self.subscribers:
     self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
@@ -567,7 +595,10 @@ proc subscribe*(
   # can materialize (capability filter; see ref-registration.md) plus its
   # partial-replica interest (partial flag + root ids). The authority applies all
   # three to the subscription it creates for us.
-  let handshake = (toSeq(type_initializers.keys), partial, roots).to_flatty
+  let type_ids = block:
+    {.gcsafe.}:
+      toSeq(type_initializers.keys)
+  let handshake = (type_ids, partial, roots).to_flatty
   self.send(
     Subscription(
       kind: REMOTE,
@@ -735,16 +766,37 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
 
     {.gcsafe.}:
       let fn = type_initializers[msg.type_id]
-      fn(
-        msg.obj,
-        self,
-        msg.object_id,
-        msg.flags,
-        OperationContext.init(
-          source = source, ctx = self, origin = msg.origin, op_id = msg.op_id
-        ),
-      )
+      # Synced ownership: materialize INSIDE the owner's scope, not after — the
+      # initializer (`defaults`) re-broadcasts the CREATE to our own subscribers
+      # while it runs (a relay: e.g. worker -> node ctx for an object an MCP
+      # client built), so owner_id must be stamped before that re-broadcast or
+      # second-hop contexts receive it unowned.
+      template materialize_it() =
+        fn(
+          msg.obj,
+          self,
+          msg.object_id,
+          msg.flags,
+          OperationContext.init(
+            source = source, ctx = self, origin = msg.origin, op_id = msg.op_id
+          ),
+        )
+
+      if msg.owner_id.len > 0:
+        msg.owner_id.own:
+          materialize_it()
+      else:
+        materialize_it()
       # :(
+    # Safety net for paths where the initializer fills an existing object (a
+    # placeholder) rather than running `defaults` — stamp + index after the fact.
+    # Keyed by owner id, so arrival order vs. the owner doesn't matter.
+    if msg.owner_id.len > 0 and msg.object_id in self.objects and
+        ?self.objects[msg.object_id]:
+      self.objects[msg.object_id].owner_id = msg.owner_id
+      self.owned_by.mgetOrPut(msg.owner_id, initHashSet[string]()).incl(
+        msg.object_id
+      )
     # The creator is interested in its own object: make sure its canonical ops
     # flow back. Matters for partial subscribers; a no-op for full ones.
     for s in self.subscribers:
@@ -760,15 +812,35 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     for s in self.subscribers:
       if s.ctx_id notin source:
         continue
-      if msg.object_id notin self:
-        continue
       if msg.obj.len > 0:
+        if msg.object_id notin self:
+          continue
         let obj = self.objects[msg.object_id]
         for key_bin in msg.obj.from_flatty(seq[string]):
           let reply = obj.publish_key(obj, key_bin)
           if reply.found:
             self.send(s, reply.msg, OperationContext(), DEFAULT_FLAGS)
+      elif msg.deep:
+        # Deep fetch: the id plus its ownership closure. BFS over `owned_by` —
+        # the requested id may be an *owner* (a unit/EdRef id with no container
+        # of its own), so it expands even when it isn't in `objects`. Each owned
+        # container is published and added to interest; if any of those are
+        # themselves owners someday, the walk follows them too.
+        var ids = @[msg.object_id]
+        var i = 0
+        while i < ids.len:
+          let id = ids[i]
+          inc i
+          if id in self:
+            s.interest.incl id
+            self.objects[id].publish_create(s)
+          if id in self.owned_by:
+            for owned_id in self.owned_by[id]:
+              if owned_id notin ids:
+                ids.add owned_id
       else:
+        if msg.object_id notin self:
+          continue
         s.interest.incl msg.object_id
         self.objects[msg.object_id].publish_create(s)
   elif msg.kind != BLANK:
@@ -805,6 +877,17 @@ proc untrack*[T, O](self: Ed[T, O], zid: EID) =
   else:
     error "no change callback for zid", zid = zid
 
+proc bind_lifetime*[T, O](self: Ed[T, O], lifetime: Lifetime, zid: EID) =
+  ## Bind an already-registered callback (`zid`) to `lifetime`, so it untracks
+  ## when the lifetime finishes. Lets sugar that mints its own zid (`changes`,
+  ## enu's `watch`) route teardown through an owner's Lifetime without exposing
+  ## the privileged untrack path. Guarded so a manual untrack first — or the
+  ## owner dying first — is safe and idempotent.
+  privileged
+  lifetime.add proc() {.gcsafe.} =
+    if not self.destroyed and zid in self.changed_callbacks:
+      self.untrack(zid)
+
 proc track*[T, O](
     self: Ed[T, O], callback: proc(changes: seq[Change[O]]) {.gcsafe.}
 ): EID {.discardable.} =
@@ -822,6 +905,14 @@ proc track*[T, O](
     self.untrack(zid)
   result = zid
 
+  # Inside an `own` scope, route this callback's untrack through the owner's
+  # lifetime too, so it's torn down when the owner is destroyed (the typical
+  # case: a subscription on something the owner doesn't itself own). No scope
+  # open → no-op. Idempotent if also bound explicitly.
+  {.gcsafe.}:
+    if not current_lifetime.is_nil:
+      self.bind_lifetime(current_lifetime, zid)
+
 proc track*[T, O](
     self: Ed[T, O], callback: proc(changes: seq[Change[O]], zid: EID) {.gcsafe.}
 ): EID {.discardable.} =
@@ -831,6 +922,18 @@ proc track*[T, O](
     callback(changes, zid)
 
   result = zid
+
+proc track*[T, O](
+    self: Ed[T, O],
+    lifetime: Lifetime,
+    callback: proc(changes: seq[Change[O]]) {.gcsafe.},
+): EID {.discardable.} =
+  ## Like `track`, but the callback's removal is owned by `lifetime`: when the
+  ## owner calls `lifetime.finish` the callback untracks automatically — no
+  ## manual `zid` bookkeeping. (Standalone Lifetime, per the lifecycle redesign;
+  ## becomes the proxy's cleanup set under the future proxy/body split.)
+  result = self.track(callback)
+  self.bind_lifetime(lifetime, result)
 
 proc untrack_on_destroy*(self: ref EdBase, zid: EID) =
   self.bound_eids.add(zid)
@@ -850,7 +953,7 @@ proc parse_remote(
     # mappings) followed by the shared, compressed body (see send_remote).
     let (enc_source, mappings, body) =
       raw_msg.data.from_flatty((seq[uint8], seq[IdMapping], string))
-    var msg = body.uncompress.from_flatty(Message, self)
+    var msg = body.ed_uncompress.from_flatty(Message, self)
     msg.source = enc_source
     msg.id_mappings = mappings
     return (true, msg)

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -930,8 +930,7 @@ proc track*[T, O](
 ): EID {.discardable.} =
   ## Like `track`, but the callback's removal is owned by `lifetime`: when the
   ## owner calls `lifetime.finish` the callback untracks automatically — no
-  ## manual `zid` bookkeeping. (Standalone Lifetime, per the lifecycle redesign;
-  ## becomes the proxy's cleanup set under the future proxy/body split.)
+  ## manual `zid` bookkeeping.
   result = self.track(callback)
   self.bind_lifetime(lifetime, result)
 

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -231,7 +231,7 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
     # REMOVE only unlinks a container from the ref; it never frees. ORC reclaims
     # the instance when its last real reference drops (RefHandle then cleans the
     # pool), giving move-identity for free: a removed-then-readded replica
-    # re-links the same instance across any gap, with no grace timer.
+    # re-links the same instance across any gap.
 
 proc find_ref*[T](self: EdContext, value: var T): bool =
   privileged

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -219,25 +219,19 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
       if id notin self.ref_pool:
         debug "saving ref", id
         self.ref_pool[id] = CountedRef()
-      self.ref_pool[id].references.incl(ed_id)
       self.ref_pool[id].obj = change.item
       # Wire the per-instance cleanup handle the first time we see this instance.
-      # The pool's `obj` hold is non-owning (cursor); this handle is what keeps
-      # it from dangling — when ORC reclaims the instance its RefHandle.=destroy
-      # dels this exact context's `ref_pool` entry. The handle carries the
-      # instance's own ctx, the one thing a bare registered ref can't know under
-      # multiple contexts per thread.
+      # The pool's `obj` hold is non-owning (cursor); this handle keeps it from
+      # dangling — when ORC reclaims the instance its RefHandle.=destroy dels this
+      # context's `ref_pool` entry. The handle carries the instance's own ctx, the
+      # one thing a bare registered ref can't know under multiple contexts/thread.
       let handle_owner = EdRef(item)
       if handle_owner.ref_handle.is_nil:
         handle_owner.ref_handle = RefHandle(ctx_uid: self.uid, ref_id: id)
-    if REMOVED in change.changes:
-      # REMOVE only unlinks — it never frees. A body is freed by ORC when its
-      # last real reference drops (RefHandle then cleans `ref_pool`), or later by
-      # eviction; a container removal just updates the reachability hint. This is
-      # what gives move-identity for free: a removed-then-readded replica re-links
-      # the same instance for any gap, with no grace timer.
-      if id in self.ref_pool:
-        self.ref_pool[id].references.excl(ed_id)
+    # REMOVE only unlinks a container from the ref; it never frees. ORC reclaims
+    # the instance when its last real reference drops (RefHandle then cleans the
+    # pool), giving move-identity for free: a removed-then-readded replica
+    # re-links the same instance across any gap, with no grace timer.
 
 proc find_ref*[T](self: EdContext, value: var T): bool =
   privileged
@@ -254,60 +248,10 @@ proc find_ref*[T](self: EdContext, value: var T): bool =
 when defined(dump_ed_objects):
   import std/[os, algorithm]
 
-proc can_free*(
-    self: EdContext, value: ref RootObj, id: string
-): tuple[freeable: bool, references: seq[string], missing: bool] =
-  privileged
-
-  # "Freeable" now means: registered, and no container still holds it. (The old
-  # model gated on a 10s timer in `freeable_refs`; that grace is gone — see
-  # docs/step4-body-protocol-sketch.md.) Deregistering only drops the cursor
-  # index entry; ORC owns the memory and reclaims when the last holder releases.
-  if id notin self.ref_pool:
-    result.missing = true
-  elif self.ref_pool[id].references.card == 0:
-    result.freeable = true
-  else:
-    result.references = self.ref_pool[id].references.to_seq
-
-proc free_impl(self: EdContext, value: ref RootObj, id: string) =
-  privileged
-
-  debug "freeing ref", id
-  let query = self.can_free(value, id)
-  if not query.freeable:
-    let references = query.references.join(", ")
-    when defined(zen_lax_free):
-      error "Free error", id, references = query.references
-      self.ref_pool.del(id)
-      return
-
-    if not query.missing:
-      fail \"ref `{id}` has {query.references.len} references from " &
-        \"{references}. Can't free."
-    else:
-      fail \"unable to find ref_id `{id}` in ref_pool. Double free?"
-
-  # Deregister the index entry. Memory is ORC-owned, so this doesn't free the
-  # instance — it just forgets it. If the instance is still alive (e.g. an app
-  # handle held it), its later RefHandle.=destroy will `del` again, which is a
-  # harmless no-op on an absent key.
-  self.ref_pool.del(id)
-
-proc free*[T: ref RootObj](self: EdContext, value: T) =
-  self.free_impl(value, value.ref_id)
-
-proc queue_free*[T: ref RootObj](self: EdContext, value: T) =
-  let id = value.ref_id
-  let query = self.can_free(value, id)
-  if query.freeable:
-    # if it's missing we can't free it, but we try anyway so we don't have to 
-    # reproduce the error logic here
-    self.free(value)
-  elif not query.missing:
-    self.free_queue.add(id)
-
 proc free_refs*(self: EdContext) =
+  ## Per-tick ref-pool maintenance: prune entries for instances ORC has
+  ## reclaimed (RefHandle can't touch `ref_pool` itself — see prune_dead_refs).
+  ## Memory is ORC-owned; there is no manual free.
   privileged
 
   when defined(dump_ed_objects):
@@ -321,20 +265,7 @@ proc free_refs*(self: EdContext) =
       write_file(self.id & "-counts", counts)
       self.dump_at = now + init_duration(seconds = 10)
 
-  # Prune entries for instances ORC reclaimed since the last tick (RefHandle
-  # can't touch ref_pool itself — see prune_dead_refs).
   self.prune_dead_refs()
-
-  # Drain any explicitly queued frees. The old 10s-grace sweep over
-  # `freeable_refs` is gone: an unreferenced ref is no longer time-freed here —
-  # ORC reclaims it when its last holder drops, and RefHandle.=destroy records
-  # the index entry for pruning. (`free_queue` survives for the explicit
-  # `queue_free` path, which enu is retiring; once retired this loop is empty.)
-  let queue = self.free_queue
-  self.free_queue.set_len(0)
-  for id in queue:
-    if id in self.ref_pool:
-      self.free_impl(self.ref_pool[id].obj, id)
 
 when is_main_module:
   import ./subscriptions

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -202,6 +202,18 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
   for change in changes:
     if not ?change.item:
       continue
+    # Only registered refs belong in `ref_pool`. It's the serialization identity
+    # index (from_flatty dedup / find_ref), and now a *cursor* index, so an
+    # instance in it must carry a `RefHandle` to clean itself out on free — i.e.
+    # it must be an `EdRef`. Non-registered refs that happen to live in an Ed
+    # container are never looked up and have no cleanup handle, so they must
+    # never enter the pool (their cursor would dangle on free). Widen to the
+    # common base first: `change.item`'s static type may be an unrelated ref
+    # (a sibling of EdRef), which can't be converted to EdRef directly — but the
+    # runtime `of` check + downcast through RootRef is always valid.
+    let item = RootRef(change.item)
+    if not (item of EdRef):
+      continue
     let id = change.item.ref_id
     if ADDED in change.changes:
       if id notin self.ref_pool:
@@ -209,15 +221,30 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
         self.ref_pool[id] = CountedRef()
       self.ref_pool[id].references.incl(ed_id)
       self.ref_pool[id].obj = change.item
+      # Wire the per-instance cleanup handle the first time we see this instance.
+      # The pool's `obj` hold is non-owning (cursor); this handle is what keeps
+      # it from dangling — when ORC reclaims the instance its RefHandle.=destroy
+      # dels this exact context's `ref_pool` entry. The handle carries the
+      # instance's own ctx, the one thing a bare registered ref can't know under
+      # multiple contexts per thread.
+      let handle_owner = EdRef(item)
+      if handle_owner.ref_handle.is_nil:
+        handle_owner.ref_handle = RefHandle(ctx_uid: self.uid, ref_id: id)
     if REMOVED in change.changes:
-      assert id in self.ref_pool
-      self.ref_pool[id].references.excl(ed_id)
-      if self.ref_pool[id].references.card == 0:
-        self.freeable_refs[id] = get_mono_time() + init_duration(seconds = 10)
+      # REMOVE only unlinks — it never frees. A body is freed by ORC when its
+      # last real reference drops (RefHandle then cleans `ref_pool`), or later by
+      # eviction; a container removal just updates the reachability hint. This is
+      # what gives move-identity for free: a removed-then-readded replica re-links
+      # the same instance for any gap, with no grace timer.
+      if id in self.ref_pool:
+        self.ref_pool[id].references.excl(ed_id)
 
 proc find_ref*[T](self: EdContext, value: var T): bool =
   privileged
 
+  # Drop entries for instances ORC already reclaimed before reading `obj` — the
+  # cursor would otherwise dangle (see prune_dead_refs / RefHandle).
+  self.prune_dead_refs()
   if ?value:
     let id = value.ref_id
     if id in self.ref_pool:
@@ -232,13 +259,16 @@ proc can_free*(
 ): tuple[freeable: bool, references: seq[string], missing: bool] =
   privileged
 
-  result.freeable = true
-  if id notin self.freeable_refs:
-    result.freeable = false
-    if id in self.ref_pool:
-      result.references = self.ref_pool[id].references.to_seq
-    else:
-      result.missing = true
+  # "Freeable" now means: registered, and no container still holds it. (The old
+  # model gated on a 10s timer in `freeable_refs`; that grace is gone — see
+  # docs/step4-body-protocol-sketch.md.) Deregistering only drops the cursor
+  # index entry; ORC owns the memory and reclaims when the last holder releases.
+  if id notin self.ref_pool:
+    result.missing = true
+  elif self.ref_pool[id].references.card == 0:
+    result.freeable = true
+  else:
+    result.references = self.ref_pool[id].references.to_seq
 
 proc free_impl(self: EdContext, value: ref RootObj, id: string) =
   privileged
@@ -250,18 +280,19 @@ proc free_impl(self: EdContext, value: ref RootObj, id: string) =
     when defined(zen_lax_free):
       error "Free error", id, references = query.references
       self.ref_pool.del(id)
-      self.freeable_refs.del(id)
       return
 
     if not query.missing:
       fail \"ref `{id}` has {query.references.len} references from " &
         \"{references}. Can't free."
     else:
-      fail \"unable to find ref_id `{id}` in freeable refs. Double free?"
+      fail \"unable to find ref_id `{id}` in ref_pool. Double free?"
 
-  assert self.ref_pool[id].references.card == 0
+  # Deregister the index entry. Memory is ORC-owned, so this doesn't free the
+  # instance — it just forgets it. If the instance is still alive (e.g. an app
+  # handle held it), its later RefHandle.=destroy will `del` again, which is a
+  # harmless no-op on an absent key.
   self.ref_pool.del(id)
-  self.freeable_refs.del(id)
 
 proc free*[T: ref RootObj](self: EdContext, value: T) =
   self.free_impl(value, value.ref_id)
@@ -290,22 +321,20 @@ proc free_refs*(self: EdContext) =
       write_file(self.id & "-counts", counts)
       self.dump_at = now + init_duration(seconds = 10)
 
+  # Prune entries for instances ORC reclaimed since the last tick (RefHandle
+  # can't touch ref_pool itself — see prune_dead_refs).
+  self.prune_dead_refs()
+
+  # Drain any explicitly queued frees. The old 10s-grace sweep over
+  # `freeable_refs` is gone: an unreferenced ref is no longer time-freed here —
+  # ORC reclaims it when its last holder drops, and RefHandle.=destroy records
+  # the index entry for pruning. (`free_queue` survives for the explicit
+  # `queue_free` path, which enu is retiring; once retired this loop is empty.)
   let queue = self.free_queue
   self.free_queue.set_len(0)
   for id in queue:
     if id in self.ref_pool:
       self.free_impl(self.ref_pool[id].obj, id)
-
-  var to_remove: seq[string]
-  for id, free_at in self.freeable_refs:
-    if self.ref_pool[id].references.card == 0 and free_at < get_mono_time():
-      self.ref_pool.del(id)
-      to_remove.add(id)
-    elif self.ref_pool[id].references.card > 0:
-      to_remove.add(id)
-  for id in to_remove:
-    debug "freeing ref", id
-    self.freeable_refs.del(id)
 
 when is_main_module:
   import ./subscriptions

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -154,18 +154,13 @@ type
     value*: V
 
   CountedRef = object
-    # Non-owning index entry: `obj` is a `{.cursor.}`, so `ref_pool` no longer
-    # keeps a registered ref alive (it once did — the old strong hold + 10s
-    # grace). Memory is ORC-owned; the real holders are the containers that
-    # `track` it (strong) plus the app/Godot node. When the last real reference
-    # drops, ORC reclaims the instance and its `RefHandle.=destroy` dels this
-    # entry — so the cursor can never dangle (ref_pool[id] non-nil ⟺ instance
+    # Non-owning index entry: `obj` is a `{.cursor.}`, so `ref_pool` doesn't keep
+    # a registered ref alive. Memory is ORC-owned; the real holders are the
+    # containers that `track` it plus the app/Godot node. When the last real
+    # reference drops, ORC reclaims the instance and its `RefHandle.=destroy` dels
+    # this entry — so the cursor can never dangle (ref_pool[id] non-nil ⟺ instance
     # alive). Requires every registered type to inherit `EdRef`.
     obj* {.cursor.}: ref RootObj
-    # Which Ed containers currently hold this ref. REFRAMED: a reachability hint
-    # only (used by the future evictor), NOT a free trigger — `card == 0` no
-    # longer schedules anything.
-    references*: HashSet[string]
 
   RegisteredType = object
     tid*: int
@@ -267,7 +262,6 @@ type
     dead_connections: seq[Connection]
     unsubscribed*: seq[string]
     metrics_label*: string
-    free_queue*: seq[string]
     last_keepalive_tick*: float64
     bytes_sent*: int
     bytes_received*: int

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -1,9 +1,60 @@
 import ed/[deps]
 import pkg/[serialization, json_serialization]
 
+template ed_ignore*() {.pragma.}
+  ## Mark a field to be ignored during `Ed` serialization.
+
 type
   EID* = uint16
     ## Callback identifier for tracking registered callbacks.
+
+  Lifetime* = ref object
+    ## Owns a set of teardown actions (typically untracking callbacks). An owner
+    ## — a Unit, a scope, and eventually an object proxy — holds a Lifetime and
+    ## `finish`es it on teardown, so everything bound to it cleans up at once with
+    ## no manual `zid` bookkeeping. Standalone on purpose (not welded to EdBase):
+    ## under the future proxy/body split it becomes the proxy's cleanup set with
+    ## no change to call sites.
+    cleanups: seq[proc() {.gcsafe.}]
+    finished: bool
+
+  RefHandle* = ref object
+    ## Per-instance registry-cleanup handle carried by every `EdRef`. When a
+    ## registered ref's last reference drops, ORC destroys its fields and this
+    ## handle's `=destroy` records the (now-dead) instance for removal from its
+    ## context's `ref_pool`. It identifies the context by *value* — a uid, not a
+    ## reference — on purpose: the destructor must never dereference its
+    ## `EdContext`, because at teardown the context can be reclaimed in the *same*
+    ## ORC cycle-collection batch as the ref (a dangling-cursor UAF, caught by
+    ## ASan). So instead of touching `ctx.ref_pool` directly it appends to a
+    ## thread-local pending list (`pending_dead_refs`); each context prunes its
+    ## own dead ids before any identity read and on tick. A bare registered ref
+    ## carries no such handle — and `Ed.thread_ctx` is wrong under multiple
+    ## contexts per thread (load-bearing for sync identity: two contexts hold
+    ## different instances of one ref_id) — which is why the uid lives here.
+    ## `ctx_uid`/`ref_id` stay unset until the instance's first ADD into a
+    ## `ref_pool`; until then `=destroy` is a no-op.
+    ctx_uid*: int  # owning context's per-instance uid (0 = unset). NOT the id.
+    ref_id*: string
+
+  EdRef* = ref object of RootObj
+    ## Base for registered (network-syncable) refs. Carries a `RefHandle` so the
+    ## registry can clean up `ref_pool` when ORC reclaims the instance — keeping
+    ## the registry's non-owning (cursor) hold from dangling, with the Unit's own
+    ## DEFAULT destructor intact (only the trivial `RefHandle` gets a custom
+    ## one, so fields don't leak). enu's `Model` and the test's `RefType`
+    ## inherit this; the eviction-phase proxy/observability hangs off the same
+    ## base.
+    ref_handle*: RefHandle
+    destroyed* {.ed_ignore.}: bool
+      ## Idempotency latch for `destroy`, set at its top. Mirrors
+      ## `EdBase.destroyed` (containers). `ed_ignore`: it's local teardown state,
+      ## never synced (a freshly received ref must arrive un-destroyed).
+    lifetime*: Lifetime
+      ## Owns this ref's teardown actions — external subscriptions, and (via the
+      ## `own` scope) its owned containers. `destroy` runs `lifetime.finish`. Local
+      ## state: it's a ref, so stringify nils it, and the `Lifetime` flatty skip
+      ## covers the rest — never synced.
 
   EdFlags* = enum
     ## Flags controlling `Ed` container behavior.
@@ -24,7 +75,7 @@ type
   ChangeReason* = enum
     ## Why a change fired, orthogonal to `ChangeKind`. (Unrelated to
     ## `Change.triggered_by`, which is the upstream changes that caused this one.)
-    Normal    ## An ordinary mutation
+    Update    ## An ordinary live change — a mutation or touch
     Initial   ## Replay of existing contents at `track` time (reserved)
     Fill      ## A placeholder materialized (partial-replica fetch landed)
 
@@ -62,6 +113,8 @@ type
   Message = object
     kind*: MessageKind
     object_id*: string
+    owner_id*: string  # CREATE only: the EdRef that owns this container (synced
+                       # ownership; "" = unowned). Lets a non-creator destroy it.
     change_object_id*: string
     type_id*: int
     ref_id*: int
@@ -76,6 +129,8 @@ type
     op_id*: int64   # originator-generated id for ack/commit correlation (0 = none)
     origin*: string # ctx id that originated the op (for own-op dedup)
     delta*: bool    # true for collection (non-idempotent) ops, false for registers
+    deep*: bool     # REQUEST only: also send the ownership closure (everything
+                    # the requested id owns via owned_by, recursively)
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -99,7 +154,17 @@ type
     value*: V
 
   CountedRef = object
-    obj*: ref RootObj
+    # Non-owning index entry: `obj` is a `{.cursor.}`, so `ref_pool` no longer
+    # keeps a registered ref alive (it once did — the old strong hold + 10s
+    # grace). Memory is ORC-owned; the real holders are the containers that
+    # `track` it (strong) plus the app/Godot node. When the last real reference
+    # drops, ORC reclaims the instance and its `RefHandle.=destroy` dels this
+    # entry — so the cursor can never dangle (ref_pool[id] non-nil ⟺ instance
+    # alive). Requires every registered type to inherit `EdRef`.
+    obj* {.cursor.}: ref RootObj
+    # Which Ed containers currently hold this ref. REFRAMED: a reachability hint
+    # only (used by the future evictor), NOT a free trigger — `card == 0` no
+    # longer schedules anything.
     references*: HashSet[string]
 
   RegisteredType = object
@@ -148,6 +213,12 @@ type
     ## Central coordination object managing `Ed` container lifecycle, subscriptions,
     ## and message passing between threads/network.
     id*: string
+    # Per-instance unique id (distinct from `id`, which is user-supplied and
+    # reused across contexts). Keys `pending_dead_refs` so a registered ref freed
+    # after its context is gone can't prune a *new* same-`id` context's ref_pool.
+    # Assigned from a thread-local counter at init; refs are freed on their
+    # context's home thread, so the counter and the pending list stay consistent.
+    uid*: int
     # Phase 1: global LSN + appointed leader (docs/consistency.md)
     is_authority*: bool   # this context is the sequencer (leader) for its objects
     leader_id*: string    # ctx_id of the authority (own id when is_authority)
@@ -174,10 +245,15 @@ type
     close_procs: Table[EID, proc() {.gcsafe.}]
     objects*: OrderedTable[string, ref EdBase]
     objects_need_packing*: bool
+    # Ownership index: owner EdRef id -> ids of the containers it owns (whose
+    # `owner_id` points back here). Built as containers are created/materialized,
+    # pruned as they're destroyed. Lets an owner tear down what it owns
+    # (`destroy_owned`) in *any* context — including one that didn't construct it
+    # (e.g. the server cleaning up an MCP-created bot after the client drops).
+    owned_by*: Table[string, HashSet[string]]
     ref_pool: Table[string, CountedRef]
     subscribers*: seq[Subscription]
     chan: Chan[Message]
-    freeable_refs: Table[string, MonoTime]
     last_msg_id: Table[string, int]
     last_received_id: Table[string, int]
     reactor*: Reactor
@@ -214,6 +290,12 @@ type
   EdBase* = object of RootObj
     ## Base type for all `Ed` containers. Not used directly.
     id*: string
+    # The EdRef (by id) that owns this container, or "" if unowned. Set when the
+    # container is created inside an `own` scope, and on materialize from the
+    # synced CREATE envelope, so it's the same in every context. Indexed in
+    # `EdContext.owned_by`; the owner's `destroy_owned` tears these down. Mutable
+    # on purpose — ownership transfer (re-home a live object) will reset it.
+    owner_id*: string
     destroyed*: bool
     # Partial replicas: a placeholder is a non-broadcasting stand-in for a
     # not-yet-materialized object (its contents are empty until fetched). Reading
@@ -244,7 +326,16 @@ type
         gcsafe
       .}
 
-    ctx*: EdContext
+    # Back-reference to the owning context. `{.cursor.}` (non-owning): the
+    # context owns its objects via `objects*` (a strong OrderedTable), so this
+    # is the back-edge of that cycle. Marking it a cursor breaks the
+    # object<->context reference cycle so a freed object/subtree is reclaimed
+    # promptly instead of waiting on ORC's cycle collector. Safe because the
+    # context strictly outlives its objects (it holds the only registry refs;
+    # teardown that touches `self.ctx` — untrack/destroy — is explicit and runs
+    # while the context is alive, and no Ed object has an ORC `=destroy` that
+    # dereferences `ctx`). Validated under AddressSanitizer (tests/asan.sh).
+    ctx* {.cursor.}: EdContext
 
   ChangeCallback[O] = proc(changes: seq[Change[O]]) {.gcsafe.}
 
@@ -270,8 +361,125 @@ type
 const DEFAULT_FLAGS* = {SYNC_LOCAL, SYNC_REMOTE}
   ## Default flags for `Ed` containers: sync both locally and remotely.
 
-template ed_ignore*() {.pragma.}
-  ## Mark a field to be ignored during `Ed` serialization.
+var next_ctx_uid* {.threadvar.}: int
+  ## Thread-local source of `EdContext.uid`. Per-thread is enough: a context is
+  ## created on, ticks on, and frees its refs on, one home thread, and
+  ## `pending_dead_refs` is thread-local too — so uids only ever collide across
+  ## threads, where the separate pending tables keep them apart.
+
+var pending_dead_refs* {.threadvar.}: Table[int, seq[string]]
+  ## ctx uid -> ref_ids whose registered instance ORC has reclaimed. Populated by
+  ## `RefHandle.=destroy`, which must NOT touch its `EdContext` (it may already be
+  ## freed — even within the same cycle-collection batch). Each context drains its
+  ## own uid via `prune_dead_refs` before any `ref_pool` identity read and on tick.
+  ## Entries for a context that dies without draining just linger (bounded; freed
+  ## at thread exit) and can't be misattributed, since the key is the uid.
+
+proc `=destroy`(h: var typeof(RefHandle()[])) =
+  ## Registry cleanup for a registered ref. Runs when ORC reclaims the handle
+  ## (its owning `EdRef`'s last reference dropped). It must not dereference the
+  ## context (see RefHandle), so it only *records* the dead instance for the
+  ## context to prune later. A custom `=destroy` replaces field destruction, so
+  ## `ref_id` is freed by hand (`ctx_uid` is a plain int, nothing to free). No-op
+  ## until the registry sets `ctx_uid`/`ref_id` on the instance's first ADD.
+  if h.ctx_uid != 0 and h.ref_id.len > 0:
+    {.cast(gcsafe).}:
+      pending_dead_refs.mget_or_put(h.ctx_uid, @[]).add(h.ref_id)
+  `=destroy`(h.ref_id)
+
+proc prune_dead_refs*(self: EdContext) =
+  ## Remove from `ref_pool` the entries whose instances ORC has reclaimed (see
+  ## `pending_dead_refs`). Must run before any `ref_pool` identity lookup so a
+  ## dangling cursor is never read, and on tick to keep the pool tidy. Idempotent;
+  ## cheap when nothing is pending.
+  if self.uid in pending_dead_refs:
+    {.cast(gcsafe).}:
+      for ref_id in pending_dead_refs[self.uid]:
+        self.ref_pool.del(ref_id)
+      pending_dead_refs.del(self.uid)
+
+proc to_flatty*(s: var string, x: RefHandle) =
+  ## The registry-cleanup handle is per-context-local state (a context uid + id),
+  ## never part of the synced value — its uid is meaningless in another context.
+  ## Skip it; `ref_count` re-mints the handle on the receiver's first ADD. Defined
+  ## here (with the Message overrides) so it's visible where `type_registry`'s
+  ## `stringify` instantiates flatty. Mirrors the Lifetime/proc skips in
+  ## subscriptions.nim.
+  discard
+
+proc from_flatty*(s: string, i: var int, x: var RefHandle) =
+  discard
+
+proc new_lifetime*(): Lifetime =
+  Lifetime()
+
+proc add*(self: Lifetime, cleanup: proc() {.gcsafe.}) =
+  ## Register a teardown action. If the Lifetime has already finished, the action
+  ## runs immediately (so binding to a dead Lifetime can't leak).
+  if self.finished:
+    cleanup()
+  else:
+    self.cleanups.add cleanup
+
+proc finish*(self: Lifetime) =
+  ## Run every registered teardown action, once. Idempotent.
+  if self.finished:
+    return
+  self.finished = true
+  let cleanups = self.cleanups
+  self.cleanups = @[]
+  for cleanup in cleanups:
+    cleanup()
+
+proc finished*(self: Lifetime): bool =
+  self.finished
+
+var current_lifetime* {.threadvar.}: Lifetime
+  ## The lifetime an open `own` scope binds *callbacks* to (thread-local; nil = no
+  ## scope). `track` consults it: a callback registered inside `self.own:` untracks
+  ## when `self.lifetime.finish` runs. nil outside a scope → no auto-binding.
+
+var current_owner_id* {.threadvar.}: string
+  ## The id of the EdRef an open `own` scope attributes new *containers* to. A
+  ## container created inside the scope records it (`owner_id` + the `owned_by`
+  ## index); the owner's `destroy_owned` then tears those containers down. So
+  ## `lifetime` carries callbacks while container ownership is the baked-in
+  ## `owner_id`. "" outside a scope → containers are unowned.
+
+template own*(owner_id: string, body: untyped) =
+  ## Like `self.own:`, but keyed by an owner *id* you already hold rather than the
+  ## owner object — for construction, where you know the id (it's a parameter) but
+  ## the owner doesn't exist yet. Every Ed container created in the block records
+  ## `owner_id`. Wrap the whole construction (`id.own:`); anything it calls —
+  ## `init_unit`, nested constructors — inherits the scope through the threadvar,
+  ## so their containers are owned too with no scope of their own. No lifetime is
+  ## set (callbacks bind via the EdRef form once the owner exists).
+  let prev_owner_id = current_owner_id
+  current_owner_id = owner_id
+  try:
+    body
+  finally:
+    current_owner_id = prev_owner_id
+
+template own*[T: EdRef](self: T, body: untyped) =
+  ## Within this scope, every Ed container created records `self` as its owner
+  ## (so `self`'s teardown destroys them via `destroy_owned`), and every callback
+  ## tracked binds its untrack to `self.lifetime` (lazily created). Generic on the
+  ## concrete type so `self.id` resolves (EdRef has no `id` of its own). Scopes
+  ## nest by save/restore — innermost wins, control returns to the enclosing owner
+  ## on exit. It's a *dynamic* scope: things constructed in procs called from the
+  ## body attribute here too, so keep blocks tight.
+  if self.lifetime.is_nil:
+    self.lifetime = new_lifetime()
+  let prev_lifetime = current_lifetime
+  let prev_owner_id = current_owner_id
+  current_lifetime = self.lifetime
+  current_owner_id = self.id
+  try:
+    body
+  finally:
+    current_lifetime = prev_lifetime
+    current_owner_id = prev_owner_id
 
 proc write_value*[T](w: var JsonWriter, self: set[T]) =
   write_value(w, self.to_seq)
@@ -286,6 +494,7 @@ proc write_value*(w: var JsonWriter, self: Subscription) =
 proc to_flatty*(s: var string, msg: Message) =
   s.to_flatty msg.kind
   s.to_flatty msg.object_id
+  s.to_flatty msg.owner_id
   s.to_flatty msg.change_object_id
   s.to_flatty msg.type_id
   s.to_flatty msg.ref_id
@@ -299,6 +508,7 @@ proc to_flatty*(s: var string, msg: Message) =
   s.to_flatty msg.op_id
   s.to_flatty msg.origin
   s.to_flatty msg.delta
+  s.to_flatty msg.deep
   when defined(ed_trace):
     s.to_flatty msg.trace
     s.to_flatty msg.id
@@ -307,6 +517,7 @@ proc to_flatty*(s: var string, msg: Message) =
 proc from_flatty*(s: string, i: var int, msg: var Message) =
   s.from_flatty(i, msg.kind)
   s.from_flatty(i, msg.object_id)
+  s.from_flatty(i, msg.owner_id)
   s.from_flatty(i, msg.change_object_id)
   s.from_flatty(i, msg.type_id)
   s.from_flatty(i, msg.ref_id)
@@ -320,6 +531,7 @@ proc from_flatty*(s: string, i: var int, msg: var Message) =
   s.from_flatty(i, msg.op_id)
   s.from_flatty(i, msg.origin)
   s.from_flatty(i, msg.delta)
+  s.from_flatty(i, msg.deep)
   when defined(ed_trace):
     s.from_flatty(i, msg.trace)
     s.from_flatty(i, msg.id)

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -9,52 +9,42 @@ type
     ## Callback identifier for tracking registered callbacks.
 
   Lifetime* = ref object
-    ## Owns a set of teardown actions (typically untracking callbacks). An owner
-    ## — a Unit, a scope, and eventually an object proxy — holds a Lifetime and
-    ## `finish`es it on teardown, so everything bound to it cleans up at once with
-    ## no manual `zid` bookkeeping. Standalone on purpose (not welded to EdBase):
-    ## under the future proxy/body split it becomes the proxy's cleanup set with
-    ## no change to call sites.
+    ## A set of teardown actions (typically untracking callbacks). An owner — a
+    ## Unit or a scope — holds a Lifetime and `finish`es it on teardown, so
+    ## everything bound to it cleans up at once with no manual `zid` bookkeeping.
+    ## Standalone (not part of EdBase) so an owner holds one directly.
     cleanups: seq[proc() {.gcsafe.}]
     finished: bool
 
   RefHandle* = ref object
-    ## Per-instance registry-cleanup handle carried by every `EdRef`. When a
-    ## registered ref's last reference drops, ORC destroys its fields and this
-    ## handle's `=destroy` records the (now-dead) instance for removal from its
-    ## context's `ref_pool`. It identifies the context by *value* — a uid, not a
-    ## reference — on purpose: the destructor must never dereference its
-    ## `EdContext`, because at teardown the context can be reclaimed in the *same*
-    ## ORC cycle-collection batch as the ref (a dangling-cursor UAF, caught by
-    ## ASan). So instead of touching `ctx.ref_pool` directly it appends to a
-    ## thread-local pending list (`pending_dead_refs`); each context prunes its
-    ## own dead ids before any identity read and on tick. A bare registered ref
-    ## carries no such handle — and `Ed.thread_ctx` is wrong under multiple
-    ## contexts per thread (load-bearing for sync identity: two contexts hold
-    ## different instances of one ref_id) — which is why the uid lives here.
-    ## `ctx_uid`/`ref_id` stay unset until the instance's first ADD into a
-    ## `ref_pool`; until then `=destroy` is a no-op.
+    ## Per-instance registry-cleanup handle on every `EdRef`. When a registered
+    ## ref's last reference drops, ORC destroys this handle and its `=destroy`
+    ## records the dead instance for removal from its context's `ref_pool`.
+    ##
+    ## It identifies the context by *value* (a uid, not a reference): the
+    ## destructor must never dereference its `EdContext`, because at teardown the
+    ## context can be reclaimed in the same ORC cycle-collection batch as the ref
+    ## (a dangling-cursor UAF, caught by ASan). So it only appends the dead id to
+    ## `pending_dead_refs`; each context prunes its own dead ids before any
+    ## `ref_pool` identity read and on tick. The uid (not `id`, which is reused
+    ## across contexts) is what lets a freed ref find the right pool with no live
+    ## reference. `ctx_uid`/`ref_id` stay unset until the first `ref_pool` add;
+    ## until then `=destroy` is a no-op.
     ctx_uid*: int  # owning context's per-instance uid (0 = unset). NOT the id.
     ref_id*: string
 
   EdRef* = ref object of RootObj
     ## Base for registered (network-syncable) refs. Carries a `RefHandle` so the
-    ## registry can clean up `ref_pool` when ORC reclaims the instance — keeping
-    ## the registry's non-owning (cursor) hold from dangling, with the Unit's own
-    ## DEFAULT destructor intact (only the trivial `RefHandle` gets a custom
-    ## one, so fields don't leak). enu's `Model` and the test's `RefType`
-    ## inherit this; the eviction-phase proxy/observability hangs off the same
-    ## base.
+    ## registry can clean up `ref_pool` when ORC reclaims the instance, keeping the
+    ## pool's non-owning (cursor) hold from dangling — the subtype's own default
+    ## destructor stays intact (only the trivial `RefHandle` gets a custom one).
     ref_handle*: RefHandle
     destroyed* {.ed_ignore.}: bool
-      ## Idempotency latch for `destroy`, set at its top. Mirrors
-      ## `EdBase.destroyed` (containers). `ed_ignore`: it's local teardown state,
-      ## never synced (a freshly received ref must arrive un-destroyed).
+      ## Idempotency latch for `destroy`, set at its top. `ed_ignore`: local
+      ## teardown state, never synced (a received ref must arrive un-destroyed).
     lifetime*: Lifetime
-      ## Owns this ref's teardown actions — external subscriptions, and (via the
-      ## `own` scope) its owned containers. `destroy` runs `lifetime.finish`. Local
-      ## state: it's a ref, so stringify nils it, and the `Lifetime` flatty skip
-      ## covers the rest — never synced.
+      ## This ref's teardown actions — external subscriptions and (via `own`) its
+      ## owned containers. `destroy` runs `lifetime.finish`. Never synced.
 
   EdFlags* = enum
     ## Flags controlling `Ed` container behavior.
@@ -393,12 +383,9 @@ proc prune_dead_refs*(self: EdContext) =
       pending_dead_refs.del(self.uid)
 
 proc to_flatty*(s: var string, x: RefHandle) =
-  ## The registry-cleanup handle is per-context-local state (a context uid + id),
-  ## never part of the synced value — its uid is meaningless in another context.
-  ## Skip it; `ref_count` re-mints the handle on the receiver's first ADD. Defined
-  ## here (with the Message overrides) so it's visible where `type_registry`'s
-  ## `stringify` instantiates flatty. Mirrors the Lifetime/proc skips in
-  ## subscriptions.nim.
+  ## Per-context-local state (uid + id), never synced — its uid is meaningless in
+  ## another context. Skip it; `ref_count` re-mints the handle on the receiver's
+  ## first ADD.
   discard
 
 proc from_flatty*(s: string, i: var int, x: var RefHandle) =
@@ -441,13 +428,11 @@ var current_owner_id* {.threadvar.}: string
   ## `owner_id`. "" outside a scope → containers are unowned.
 
 template own*(owner_id: string, body: untyped) =
-  ## Like `self.own:`, but keyed by an owner *id* you already hold rather than the
-  ## owner object — for construction, where you know the id (it's a parameter) but
-  ## the owner doesn't exist yet. Every Ed container created in the block records
-  ## `owner_id`. Wrap the whole construction (`id.own:`); anything it calls —
-  ## `init_unit`, nested constructors — inherits the scope through the threadvar,
-  ## so their containers are owned too with no scope of their own. No lifetime is
-  ## set (callbacks bind via the EdRef form once the owner exists).
+  ## Like `self.own:`, but keyed by an owner *id* — for construction, where you
+  ## have the id but the owner object doesn't exist yet. Every Ed container created
+  ## in the block (including by procs it calls — the scope is dynamic) records
+  ## `owner_id`. No lifetime is set; callbacks bind via the `EdRef` form once the
+  ## owner exists.
   let prev_owner_id = current_owner_id
   current_owner_id = owner_id
   try:

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -79,8 +79,10 @@ proc init*(
 
   debug "EdContext initialized", id
 
+  inc next_ctx_uid
   result = EdContext(
     id: id,
+    uid: next_ctx_uid,
     blocking_recv: blocking_recv,
     max_recv_duration: max_recv_duration,
     min_recv_duration: min_recv_duration,

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -90,6 +90,15 @@ proc defaults[T, O](
     ctx.pack_objects
   ctx.objects[self.id] = self
 
+  # If created inside an `own` scope, record the owner: bake its id into the
+  # container and index it, so the owner's `destroy_owned` can tear this down in
+  # any context (container teardown is ownership-driven; the lifetime carries
+  # callbacks). No scope open → unowned.
+  {.gcsafe.}:
+    if current_owner_id.len > 0:
+      self.owner_id = current_owner_id
+      ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(self.id)
+
   self.publish_create = proc(
       sub: Subscription, broadcast: bool, op_ctx = OperationContext()
   ) =
@@ -99,6 +108,7 @@ proc defaults[T, O](
     {.gcsafe.}:
       let bin = self.tracked.to_flatty
     let id = self.id
+    let owner_id = self.owner_id
     let flags = self.flags
 
     template send_msg(src_ctx, sub) =
@@ -113,6 +123,7 @@ proc defaults[T, O](
           flags: flags,
           type_id: ed_type_id,
           object_id: id,
+          owner_id: owner_id,  # synced ownership (see EdBase.owner_id)
           # source is set by send() based on subscription type
         )
 

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -339,9 +339,32 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
   self.ctx.objects[self.id] = nil
   self.ctx.objects_need_packing = true
   self.ctx.latest_op_id.del(self.id)  # drop own-op reconciliation state
+  # Keep the ownership index tidy: drop ourselves from our owner's owned-set.
+  if self.owner_id.len > 0 and self.owner_id in self.ctx.owned_by:
+    self.ctx.owned_by[self.owner_id].excl(self.id)
 
   if publish:
     self.publish_destroy OperationContext(source: [self.ctx.id].toHashSet)
+
+proc destroy_owned*(ctx: EdContext, owner_id: string) =
+  ## Destroy every container owned by `owner_id` (per the `owned_by` index): each
+  ## fires its CLOSED, drops from `ctx.objects`, and broadcasts DESTROY so
+  ## replicas tear down their mirrors. Works in *any* context — including one that
+  ## didn't construct the object — because ownership is synced (the containers'
+  ## `owner_id`), not derived from the constructing context. The owner's
+  ## `lifetime.finish` handles its callbacks separately. The objects are
+  ## type-erased here (`ref EdBase`), so we destroy via each one's
+  ## `change_receiver` (the same path a received DESTROY takes).
+  private_access EdBase
+  if owner_id in ctx.owned_by:
+    # Snapshot: each destroy excls itself from the set we're iterating.
+    let owned = ctx.owned_by[owner_id]
+    for id in owned:
+      if id in ctx.objects and ?ctx.objects[id]:
+        let obj = ctx.objects[id]
+        if not obj.change_receiver.is_nil:
+          obj.change_receiver(obj, Message(kind: DESTROY), OperationContext())
+    ctx.owned_by.del(owner_id)
 
 iterator items*[T](self: EdSet[T] | EdSeq[T]): T =
   privileged

--- a/tests/asan.sh
+++ b/tests/asan.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build + run the Ed test suite under AddressSanitizer — the validation gate for
+# the lifecycle memory work (`{.cursor.}` back-refs, ref_pool -> ORC + =destroy).
+# Apple Silicon runs ASan natively (no VM needed).
+#
+# Catches: use-after-free, heap-buffer-overflow, double-free, stack-use-after-
+# scope. Does NOT catch leaks (macOS has no LeakSanitizer) — see the leak note
+# at the bottom for the Linux path.
+#
+# Flags:
+#   -d:useMalloc       ORC allocates via malloc so ASan tracks Ed's heap.
+#   -d:ed_no_compress  Skip supersnappy — its snappy fast-path over-reads within
+#                      an allocation, which trips ASan (benign third-party, not our
+#                      bug). In-process sync uses one build, so the wire format
+#                      stays consistent across both sides.
+#
+# Baseline (lifecycle-80 branch): CLEAN — 0 ASan errors, all tests pass. After a
+# memory change, any NEW ASan error is a real regression to fix before landing.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+nim c --mm:orc -d:useMalloc -d:ed_no_compress \
+  --passC:"-fsanitize=address -fno-omit-frame-pointer -g" \
+  --passL:"-fsanitize=address" \
+  --hints:off -o:tests_asan tests.nim
+
+ASAN_OPTIONS=detect_leaks=0:abort_on_error=1 timeout -s9 300 ./tests_asan
+
+# --- Leak checking (no LeakSanitizer on macOS) ---------------------------------
+# Run the same build on Linux (Docker/VM) and flip detect_leaks on:
+#     ASAN_OPTIONS=detect_leaks=1 ./tests_asan
+# or Valgrind on Linux:
+#     valgrind --leak-check=full --error-exitcode=1 ./tests
+# Leak checks matter most for the ref_pool -> ORC step (does freeing actually
+# happen); UAF (the cursor hazard) is fully covered by macOS ASan above.

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -728,7 +728,6 @@ proc run*() =
       ctx2.tick
       check dest.len == 0
       check id in ctx2.ref_pool
-      check ctx2.ref_pool[id].references.card == 0
 
       # Re-add across the gap re-links the very same instance — move-identity with
       # no grace window (strictly better than the 10s timer it replaces).
@@ -736,7 +735,6 @@ proc run*() =
       ctx2.tick
       check dest.len == 1
       check dest[0] == orig
-      check ctx2.ref_pool[id].references.card == 1
 
       # Drop every reference to the dest-side body: unlink it from the container
       # and release the local handle. ORC reclaims it and its RefHandle records

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -508,7 +508,7 @@ proc run*() =
 
   test "sync":
     type
-      Thing = ref object of RootObj
+      Thing = ref object of EdRef
         id: string
 
       Tree = ref object
@@ -613,7 +613,7 @@ proc run*() =
       check ctx2.len == 0
 
   test "sync nested":
-    type Unit = ref object of RootObj
+    type Unit = ref object of EdRef
       units: EdSeq[Unit]
       code: EdValue[string]
       id: int
@@ -633,7 +633,7 @@ proc run*() =
       check ru1.units[0].code.ctx == ctx2
 
   test "zentable of tables":
-    type Shared = ref object of RootObj
+    type Shared = ref object of EdRef
       id: string
       edits: EdTable[int, Table[string, string]]
 
@@ -691,58 +691,70 @@ proc run*() =
 
       check shared.chunks[1]["hello"] == "goodbye"
 
-  test "free refs":
-    type RefType = ref object of RootObj
+  test "refs freed when unreferenced":
+    # New lifecycle contract (replaces the old 10s-grace "free refs" test). A
+    # container REMOVE only unlinks — it never schedules a free. A registered
+    # ref's body persists while anything still holds it, so a remove-then-readd
+    # re-links the *same* instance for any gap (move-identity, no timer). The
+    # body is freed only when its last real reference drops: ORC reclaims it and
+    # its RefHandle.=destroy clears the ref_pool entry. The registered type must
+    # inherit EdRef to carry that handle. See docs/step4-body-protocol-sketch.md.
+    type RefType = ref object of EdRef
       id: string
 
     Ed.register(RefType, false)
 
     local_and_remote:
       var src = EdSeq[RefType].init
-
       var obj = RefType(id: "1")
+      let id = obj.ref_id
 
       src += obj
-
       ctx2.tick
       var dest = EdSeq[RefType](ctx2[src])
 
       private_access EdContext
       private_access CountedRef
 
-      check obj.ref_id in ctx1.ref_pool
-      check obj.ref_id in ctx2.ref_pool
-      check obj.ref_id notin ctx2.freeable_refs
+      check id in ctx1.ref_pool
+      check id in ctx2.ref_pool
 
-      let orig_dest_obj = RefType(ctx2.ref_pool[obj.ref_id].obj)
+      # Hold the dest-side instance so it can't be reclaimed across the remove.
+      var orig = RefType(ctx2.ref_pool[id].obj)
+
+      # REMOVE unlinks only: the body persists (still held by `orig`), the
+      # reachability count drops to zero, and nothing is scheduled for free.
       src -= obj
       ctx2.tick
-      check obj.ref_id in ctx2.ref_pool
-      check obj.ref_id in ctx2.freeable_refs
-      check ctx2.ref_pool[obj.ref_id].references.card == 0
-
-      src += obj
-      ctx2.tick
-      check obj.ref_id in ctx2.ref_pool
-      check obj.ref_id in ctx2.freeable_refs
-      check ctx2.ref_pool[obj.ref_id].references.card == 1
-      check dest[0] == orig_dest_obj
-      src -= obj
-      ctx2.tick
-
-      # after a timeout the unreferenced object will be removed
-      # from the dest ref_pool and freeable_refs, and if we add
-      # it back to src a new object will be created in dest
-      ctx2.freeable_refs[obj.ref_id] = MonoTime.low
-      ctx2.tick(blocking = false)
-      check obj.ref_id notin ctx2.ref_pool
-      check obj.ref_id notin ctx2.freeable_refs
       check dest.len == 0
+      check id in ctx2.ref_pool
+      check ctx2.ref_pool[id].references.card == 0
 
+      # Re-add across the gap re-links the very same instance — move-identity with
+      # no grace window (strictly better than the 10s timer it replaces).
       src += obj
       ctx2.tick
-      check dest[0].id == orig_dest_obj.id
-      check dest[0] != orig_dest_obj
+      check dest.len == 1
+      check dest[0] == orig
+      check ctx2.ref_pool[id].references.card == 1
+
+      # Drop every reference to the dest-side body: unlink it from the container
+      # and release the local handle. ORC reclaims it and its RefHandle records
+      # the id for the context to prune (the destructor never touches ref_pool) —
+      # freed exactly when unreferenced, no timer.
+      src -= obj
+      ctx2.tick
+      check dest.len == 0
+      orig = nil
+      ctx2.prune_dead_refs()
+      check id notin ctx2.ref_pool
+
+      # So a later re-add can only materialize a fresh instance.
+      src += obj
+      ctx2.tick
+      check dest.len == 1
+      check dest[0].id == "1"
+      check id in ctx2.ref_pool
 
   test "sync set":
     type Flags = enum
@@ -792,7 +804,7 @@ proc run*() =
 
   test "object with registered ref":
     type
-      RefType2 = ref object of RootObj
+      RefType2 = ref object of EdRef
         id: string
 
       RefType3 = ref object of RefType2
@@ -824,7 +836,7 @@ proc run*() =
         Targeted
         Highlighted
 
-      SyncUnit = ref object of RootRef
+      SyncUnit = ref object of EdRef
         id: int
         parent: SyncUnit
         units: EdSeq[SyncUnit]

--- a/tests/error_handling_tests.nim
+++ b/tests/error_handling_tests.nim
@@ -23,7 +23,7 @@ proc run*() =
   test "reference pool cleanup":
     var ctx = EdContext.init(id = "ref_ctx")
 
-    type RefObject = ref object of RootObj
+    type RefObject = ref object of EdRef
       id: string
       data: int
 
@@ -49,11 +49,11 @@ proc run*() =
     var ctx = EdContext.init(id = "circular_ctx")
 
     type
-      NodeA = ref object of RootObj
+      NodeA = ref object of EdRef
         id: string
         b_ref: EdValue[NodeB]
 
-      NodeB = ref object of RootObj
+      NodeB = ref object of EdRef
         id: string
         a_ref: EdValue[NodeA]
 

--- a/tests/error_handling_tests.nim
+++ b/tests/error_handling_tests.nim
@@ -41,7 +41,7 @@ proc run*() =
     check ref_container.len == 0
 
     # Force reference cleanup
-    ctx.free_refs()
+    ctx.prune_dead_refs()
 
     # Reference should eventually be cleaned up
 

--- a/tests/lifetime_tests.nim
+++ b/tests/lifetime_tests.nim
@@ -1,0 +1,186 @@
+import std/[unittest, sets, tables]
+import ed
+import ed/zens/contexts
+
+type OwnerTest = ref object of EdRef
+  id: string
+  items: EdSeq[int]
+  val: EdValue[int]
+
+proc run*() =
+  suite "lifetime":
+    test "finish untracks callbacks bound to the lifetime":
+      var ctx = EdContext.init(id = "lt_ctx")
+      var v = EdValue[int].init(ctx = ctx, id = "v")
+      let life = new_lifetime()
+
+      var fired = 0
+      v.track(life, proc(changes: seq[Change[int]]) {.gcsafe.} =
+        fired.inc
+      )
+
+      v.value = 1
+      check fired > 0 # fires while tracked
+
+      life.finish()
+      check life.finished
+      let after_finish = fired # finish may itself fire one CLOSED
+
+      v.value = 2
+      v.value = 3
+      check fired == after_finish # silent after finish — callback removed
+
+    test "binding to an already-finished lifetime cleans up immediately":
+      var ctx = EdContext.init(id = "lt_ctx2")
+      var v = EdValue[int].init(ctx = ctx, id = "v2")
+      let life = new_lifetime()
+      life.finish() # finished before any tracking
+
+      var mutations = 0
+      v.track(life, proc(changes: seq[Change[int]]) {.gcsafe.} =
+        for c in changes:
+          if CLOSED notin c.changes:
+            mutations.inc
+      )
+      v.value = 1
+      check mutations == 0 # registered then untracked at once; no mutation seen
+
+    test "finish is idempotent":
+      let life = new_lifetime()
+      var ran = 0
+      life.add proc() {.gcsafe.} =
+        ran.inc
+      life.finish()
+      life.finish()
+      check ran == 1
+
+  suite "own scope":
+    test "own scope records ownership; destroy_owned tears containers down":
+      var ctx = EdContext.init(id = "own_ctx")
+      Ed.thread_ctx = ctx
+      var owner = OwnerTest(id: "owner1")
+      owner.own:
+        owner.items = EdSeq[int].init(ctx = ctx, id = "own_items")
+        owner.val = EdValue[int].init(ctx = ctx, id = "own_val")
+
+      check "own_items" in ctx
+      check "own_val" in ctx
+      check owner.items.owner_id == "owner1"        # ownership baked into the object
+      check "own_items" in ctx.owned_by["owner1"]   # and indexed
+
+      ctx.destroy_owned("owner1")
+      check "own_items" notin ctx                   # destroyed → out of ctx.objects
+      check "own_val" notin ctx
+      check "owner1" notin ctx.owned_by
+
+    test "callbacks tracked in an own scope untrack on finish":
+      var ctx = EdContext.init(id = "own_ctx2")
+      Ed.thread_ctx = ctx
+      var external = EdValue[int].init(ctx = ctx, id = "ext")
+      var owner = OwnerTest(id: "owner2")
+
+      var fired = 0
+      owner.own:
+        external.track proc(changes: seq[Change[int]]) {.gcsafe.} =
+          fired.inc
+
+      external.value = 1
+      check fired > 0                 # fires while tracked
+
+      owner.lifetime.finish()
+      let after = fired
+      external.value = 2
+      check fired == after            # untracked by finish (lifetime = callbacks)
+
+    test "nested own scopes attribute containers to the innermost owner":
+      var ctx = EdContext.init(id = "own_ctx3")
+      Ed.thread_ctx = ctx
+      var outer = OwnerTest(id: "outer")
+      var inner = OwnerTest(id: "inner")
+
+      outer.own:
+        outer.items = EdSeq[int].init(ctx = ctx, id = "outer_items")
+        inner.own:
+          inner.items = EdSeq[int].init(ctx = ctx, id = "inner_items")
+        outer.val = EdValue[int].init(ctx = ctx, id = "outer_val") # back to outer
+
+      check inner.items.owner_id == "inner"
+      check outer.items.owner_id == "outer"
+      check outer.val.owner_id == "outer"
+
+      ctx.destroy_owned("inner")
+      check "inner_items" notin ctx
+      check "outer_items" in ctx      # outer's still alive
+      check "outer_val" in ctx
+
+      ctx.destroy_owned("outer")
+      check "outer_items" notin ctx
+      check "outer_val" notin ctx
+
+    test "id.own: (string form) attributes containers to the id at construction":
+      var ctx = EdContext.init(id = "own_str_ctx")
+      Ed.thread_ctx = ctx
+      let bid = "build_42"
+      bid.own: # owner id known before the owner object exists
+        discard EdSeq[int].init(ctx = ctx, id = "bi_items")
+        discard EdValue[int].init(ctx = ctx, id = "bi_val")
+
+      check EdSeq[int](ctx["bi_items"]).owner_id == "build_42"
+      check "bi_items" in ctx.owned_by["build_42"]
+
+      ctx.destroy_owned("build_42")
+      check "bi_items" notin ctx
+      check "bi_val" notin ctx
+
+    test "owner_id syncs; a non-creator context tears down via the owned index":
+      # The MCP case: one context builds an owned container; another (which never
+      # constructed it) destroys it via the synced ownership.
+      var ctx1 = EdContext.init(id = "own_src", blocking_recv = true)
+      var ctx2 = EdContext.init(id = "own_dst", blocking_recv = true)
+      ctx2.subscribe(ctx1)
+      Ed.thread_ctx = ctx1
+      ctx1.tick(blocking = false)
+
+      var owner = OwnerTest(id: "mcp_bot")
+      owner.own:
+        owner.items = EdSeq[int].init(ctx = ctx1, id = "bot_items")
+      owner.items.add 42 # a change, so it syncs
+
+      ctx2.tick
+
+      check "bot_items" in ctx2
+      check EdSeq[int](ctx2["bot_items"]).owner_id == "mcp_bot" # rode the CREATE
+      check "bot_items" in ctx2.owned_by["mcp_bot"]             # indexed on the replica
+
+      ctx2.destroy_owned("mcp_bot") # ctx2 never built it, but owns the teardown
+      check "bot_items" notin ctx2
+
+    test "ownership survives a relay (creator -> hub -> second hop)":
+      # The enu topology: an MCP client builds a bot, the worker (hub) relays it
+      # to the node ctx. The hub's initializer re-broadcasts the CREATE *while*
+      # materializing, so ownership must be stamped inside that window or the
+      # second hop receives the container unowned.
+      var ctx1 = EdContext.init(id = "relay_src", blocking_recv = true)
+      var ctx2 = EdContext.init(id = "relay_hub", blocking_recv = true)
+      var ctx3 = EdContext.init(id = "relay_dst", blocking_recv = true)
+      ctx2.subscribe(ctx1)
+      ctx3.subscribe(ctx2)
+      Ed.thread_ctx = ctx1
+      ctx1.tick(blocking = false)
+
+      var owner = OwnerTest(id: "relay_bot")
+      owner.own:
+        owner.items = EdSeq[int].init(ctx = ctx1, id = "relay_items")
+      owner.items.add 7
+
+      ctx2.tick
+      ctx3.tick
+
+      check "relay_items" in ctx2
+      check "relay_items" in ctx3
+      check EdSeq[int](ctx2["relay_items"]).owner_id == "relay_bot"
+      check EdSeq[int](ctx3["relay_items"]).owner_id == "relay_bot" # second hop
+      check "relay_items" in ctx3.owned_by["relay_bot"]
+
+      ctx3.destroy_owned("relay_bot")
+      check "relay_items" notin ctx3

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -91,7 +91,7 @@ proc run*() =
       client.tick()
       check not client["child"].loaded
 
-      var fill_reason = Normal
+      var fill_reason = Update
       EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
         for c in cs:
           if MODIFIED in c.changes:
@@ -120,7 +120,7 @@ proc run*() =
       var other_fired = false
       EdValue[int](client["other"]).track proc(cs: seq[Change[int]]) =
         other_fired = true
-      var child_fill_reason = Normal
+      var child_fill_reason = Update
       EdValue[string](client["child"]).track proc(cs: seq[Change[string]]) =
         for c in cs:
           if MODIFIED in c.changes:

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -41,7 +41,7 @@ proc run*() =
     check ref_container.len == 0
     
     # Force reference cleanup
-    ctx.free_refs()
+    ctx.prune_dead_refs()
     
     # Reference should eventually be cleaned up
 

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -23,7 +23,7 @@ proc run*() =
   test "reference pool cleanup":
     var ctx = EdContext.init(id = "ref_ctx")
     
-    type RefObject = ref object of RootObj
+    type RefObject = ref object of EdRef
       id: string
       data: int
       
@@ -49,12 +49,12 @@ proc run*() =
     var ctx = EdContext.init(id = "circular_ctx")
     
     type
-      NodeA = ref object of RootObj
+      NodeA = ref object of EdRef
         id: string
         b_ref: EdValue[NodeB]
-        
-      NodeB = ref object of RootObj
-        id: string  
+
+      NodeB = ref object of EdRef
+        id: string
         a_ref: EdValue[NodeA]
     
     Ed.register(NodeA, false)

--- a/tests/object_tests_types.nim
+++ b/tests/object_tests_types.nim
@@ -3,7 +3,7 @@ import ed
 type
   ZenString* = EdValue[string]
 
-  Beep* = ref object of RootObj
+  Beep* = ref object of EdRef
     id*: string
     name_value*: EdValue[string]
 

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -1,6 +1,11 @@
-import std/unittest
+import std/[unittest, sets, tables]
 import ed
 import ed/zens/contexts
+
+type DeepOwner = ref object of EdRef
+  id: string
+  items: EdSeq[int]
+  val: EdValue[int]
 
 proc run*() =
   suite "partial replicas":
@@ -52,6 +57,37 @@ proc run*() =
       y.value = 20
       client.tick()
       check EdValue[int](client["f_y"]).value == 20
+
+    test "deep fetch pulls an owner's full ownership closure":
+      var authority = EdContext.init(id = "d_auth", is_authority = true)
+      var client = EdContext.init(id = "d_client")
+
+      var bot = DeepOwner(id: "d_bot")
+      bot.own:
+        bot.items = EdSeq[int].init(ctx = authority, id = "d_items")
+        bot.val = EdValue[int].init(ctx = authority, id = "d_val")
+      bot.items.add 3
+
+      client.subscribe(authority, partial = true, roots = @[])
+      client.tick()
+      check "d_items" notin client # out of interest
+      check "d_val" notin client
+
+      # The owner id isn't itself a container — a deep fetch expands its
+      # ownership closure on the authority and sends everything it owns.
+      client.fetch("d_bot", deep = true)
+      authority.tick() # serves the REQUEST: walks owned_by, publishes the closure
+      client.tick() # materializes the owned containers
+      check "d_items" in client
+      check "d_val" in client
+      check EdSeq[int](client["d_items"])[0] == 3
+      check EdSeq[int](client["d_items"]).owner_id == "d_bot" # ownership syncs too
+      check "d_items" in client.owned_by["d_bot"]
+
+      # The closure joined the interest set: future ops follow.
+      bot.items.add 4
+      client.tick()
+      check EdSeq[int](client["d_items"]).len == 2
 
     test "objects created after subscribe respect partial interest":
       var authority = EdContext.init(id = "pc_auth", is_authority = true)

--- a/tests/publish_tests.nim
+++ b/tests/publish_tests.nim
@@ -6,7 +6,7 @@ from std/times import init_duration
 
 proc run*() =
   type
-    Unit = ref object of RootObj
+    Unit = ref object of EdRef
       id: string
 
     Build = ref object of Unit

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -1,7 +1,8 @@
 import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
-  lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests
+  lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests,
+  lifetime_tests
 
 Ed.bootstrap
 
@@ -19,3 +20,4 @@ client_tests.run()
 partial_tests.run()
 capability_tests.run()
 materialize_tests.run()
+lifetime_tests.run()


### PR DESCRIPTION
**Stacked on #14.** PR 2 of the stack — the object-lifecycle "80%" layer (everything before the proxy/body split), plus the removal of the now-dead manual free system. Two commits.

### Lifecycle 80%
- **Standalone `Lifetime`** owns callback teardown — no manual `zid`.
- **`{.cursor.}`** on structural back-refs breaks ownership cycles (validated under ASan).
- **`ref_pool` → ORC**: `ref_pool` is a non-owning cursor index, memory is ORC-owned (10s grace gone), cleaned via each `EdRef`'s `RefHandle` destructor — which never dereferences its context (it records the dead id for prune-before-read, keyed by the context's per-instance uid).
- **Synced ownership**: `owner_id` + `owned_by`, `own` scopes, `destroy_owned` cascade — an owner tears down what it owns in any context.

### Remove the old free system
`free`/`queue_free`/`can_free`/`free_impl`, the `free_queue` field, and `CountedRef.references` (read only by `can_free`) are dead now that ORC owns ref memory. `free_refs` shrinks to a per-tick prune. enu calls none of the removed API; the two ed tests that did now call `prune_dead_refs`.

Full suite + `tests/asan.sh` green (0 ASan errors).

> Intermediate note: `pending_dead_refs` is thread-local here; it becomes process-global in the proxy/body PR (a chronological-cut artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)