### PR TITLE
feat(partial): fetch handles, deep fetch, per-key paging, request chaining

### DIFF
--- a/docs/partial-replicas.md
+++ b/docs/partial-replicas.md
@@ -75,10 +75,39 @@ application-visible happens mid-read (clean reentrancy; deterministic single-thr
 tests). `parse_remote` is shared by `tick` and the pump, so the wire decode lives in
 one place (no `tick` receive/process split was needed).
 
+## Fetch handles, deep fetch, and per-key paging
+
+`EdContext.fetch` returns a `Fetch` handle that resolves on a later tick — `Found`
+(with `obj` linking the container) or `NotFound` (the authority NACKed; it didn't
+exist *at fetch time*, but with `follow` it still arrives if something creates it).
+A **deep** fetch also pulls everything the id *owns* (the synced-ownership closure,
+recursively), so an owner id — a unit, which has no container of its own — pulls
+its whole owned subtree in one request; for `OWNS_MEMBERS` collections the member
+closures are pushed *before* the collection so the receiver's parse links members
+to real containers instead of husks.
+
+**Per-key paging (LAZY tables).** A big table (voxel chunks) is marked `LAZY` and
+arrives as an empty handle; the replica pulls individual entries with `request(key)`
+and drops them with `release(key)` (`loaded(key)` reports per-key residency).
+Requests and releases are batched — a frame's worth collapses into one REQUEST /
+RELEASE per table. A requested key streams its future ops even if it was missing at
+request time (an empty-space chunk someone later builds in). Ed-valued entries (a
+chunk's delta seq) are sent *before* the entry and followed, so their ops stream too
+(per-key deep).
+
+**Request chaining (hubs).** A hub that can't serve a request forwards it upstream
+(becoming the requester there) and remembers who asked; the answer — data or
+NOT_FOUND — relays back hop by hop. Only misses forward, and only the first want per
+id/key does; the authority never forwards (its miss is the real NOT_FOUND), which
+also terminates any forwarding cycle. A hub never serves a request from its *own*
+upstream (its copy is a stale subset). A no-cache partial hub that loses the last
+downstream interest in a key sheds its own copy and chains the release upstream.
+
 ## Notes
 
-- Interest is **grows-only** here (roots + fetched ids accumulate); eviction —
-  which sheds it — is a later layer (it needs the per-key/eviction machinery, not a
+- Whole-object interest is **grows-only** (roots + fetched ids accumulate); per-key
+  interest is sheddable via `release`. Whole-object eviction is a later layer (it
+  needs the per-key/eviction machinery, not a
   durable log; the authority serves subsets from memory).
 - Builds on the relaxed validation (a replica already tolerates ops for objects it
   doesn't hold) and the per-object reconciliation frontier (delivery is already

--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -35,6 +35,15 @@ type EdClient* = ref object
   id*: string
   address*: string
   chan_size*: int
+  partial*: bool
+    ## Subscribe as a partial replica: only the ids in `fetch` (and anything
+    ## fetched later) sync; the rest is filtered at the authority.
+  fetch*: seq[string]
+    ## Ids fetched as part of each (re)subscribe (partial only). They land in
+    ## the registry, so `ctx[id]` works for them afterwards.
+  deep*: bool
+    ## Ask the authority to push OWNS_MEMBERS member closures (a game client
+    ## wants units render-ready; a narrow utility fetches what it touches).
   on_connect*: proc()
     ## (Re)create this client's objects after each (re)connect. Runs with
     ## `Ed.thread_ctx` set to the fresh context. Single-threaded — runs on
@@ -57,7 +66,9 @@ proc connect*(self: EdClient) =
   self.ctx = EdContext.init(chan_size = chan_size, buffer = false, id = self.id)
   Ed.thread_ctx = self.ctx
   try:
-    self.ctx.subscribe(self.address)
+    self.ctx.subscribe(
+      self.address, partial = self.partial, fetch = self.fetch, deep = self.deep
+    )
     if self.on_connect != nil:
       self.on_connect()
   except ConnectionError as e:

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -212,6 +212,7 @@ proc remote_body(msg: Message, no_overwrite: bool): string =
   var body_msg = msg
   body_msg.source = @[]
   body_msg.id_mappings = @[]
+  body_msg.key_bin = "" # sender-side per-key filter tag; not wire data
   if no_overwrite:
     body_msg.obj = ""
   result = body_msg.to_flatty.ed_compress
@@ -346,6 +347,123 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
 
   self.ctx.tick_reactor
 
+proc publish_closure(
+    self: EdContext, s: Subscription, root_id: string, follow = true
+): bool {.discardable.} =
+  ## Serve an ownership closure to `s`: BFS from `root_id` over `owned_by`,
+  ## publishing every container and following member keys (tid:id) into the
+  ## members' own owned sets. Used to serve deep fetches, and to push an
+  ## OWNS_MEMBERS collection's member closures *before* the collection itself —
+  ## so a partial subscriber's parse links member fields to real containers
+  ## instead of minting unregistered husks. Returns whether anything was found.
+  ## With `follow`, everything published joins `s.interest` so future ops flow.
+  privileged
+  var ids = @[root_id]
+  var to_publish: seq[string]
+  var i = 0
+  while i < ids.len:
+    let id = ids[i]
+    inc i
+    if id in self:
+      result = true
+      to_publish.add id
+    if id in self.owned_by:
+      result = true
+      for owned_id in self.owned_by[id]:
+        if owned_id notin ids:
+          ids.add owned_id
+    let colon = id.find(':')
+    if colon > 0:
+      let plain = id[colon + 1 .. ^1]
+      if plain notin ids:
+        ids.add plain
+  # Publish deepest-first (reverse BFS): a subscribing context defers value
+  # restoration and replays it in arrival order, so a collection's restore —
+  # which fires the app's ADDED watchers — must come *after* its members'
+  # containers have their values, or the watchers read empty state. Mirrors
+  # add_subscriber's newest-first iteration, which is what full replicas rely
+  # on for the same reason.
+  for j in countdown(to_publish.high, 0):
+    let id = to_publish[j]
+    let zen = self.objects[id]
+    if LAZY in zen.flags:
+      # Pull-only: send a *handle* (empty-body CREATE — id, type, flags) and
+      # don't follow it. The receiver registers a placeholder and pages
+      # entries with request/release; a whole-table push would defeat LAZY.
+      zen.publish_create(s, contents = false)
+    else:
+      if follow:
+        s.interest.incl id
+      zen.publish_create(s)
+
+proc serve_key_wants(self: EdContext, object_id: string) =
+  ## Serve chained per-key wants that can now be answered — entries for
+  ## `object_id` may have just arrived (see forward_request).
+  privileged
+  if object_id notin self.pending_key_wants or object_id notin self:
+    return
+  let obj = self.objects[object_id]
+  var done: seq[string]
+  for key_bin, waiters in self.pending_key_wants[object_id]:
+    let reply = obj.publish_key(obj, key_bin)
+    if reply.found:
+      for waiter in waiters:
+        # Handle-first (see the REQUEST handler): the waiter may not hold the
+        # container, and an ADD for an unknown object drops silently.
+        if not obj.placeholder:
+          obj.publish_create(waiter, contents = false)
+        # Per-key deep: nested containers (a chunk's delta seq) go first so
+        # the receiver's parse links them — and they're followed, so their
+        # future ops stream.
+        for nested_id in reply.nested:
+          if nested_id in self and not self.objects[nested_id].placeholder:
+            waiter.interest.incl nested_id
+            self.objects[nested_id].publish_create(waiter)
+        self.send(waiter, reply.msg, OperationContext(), DEFAULT_FLAGS)
+      done.add key_bin
+  for key_bin in done:
+    self.pending_key_wants[object_id].del key_bin
+  if self.pending_key_wants[object_id].len == 0:
+    self.pending_key_wants.del object_id
+
+proc request_targets(self: EdContext): seq[Subscription] =
+  ## Who to send a REQUEST to: our upstreams (the contexts we page from).
+  ## Never downstream — a clone's copy of us is stale-by-definition, and
+  ## letting it answer can overwrite fresher local state with its echo.
+  ## No known upstream (a one-way local subscribe never told us) falls back
+  ## to everyone, preserving the old behavior for legacy topologies.
+  for sub in self.subscribers:
+    if sub.ctx_id in self.upstream_ctx_ids:
+      result.add sub
+  if result.len == 0:
+    result = self.subscribers
+
+proc forward_request(self: EdContext, requester: Subscription, msg: Message) =
+  ## Chain a request we can't serve: send it to our upstream(s).
+  ## The forward makes *us* the requester there, so the answer lands here and
+  ## the want-serving hooks relay it back to the original asker. The authority
+  ## never forwards (its miss is a real NOT_FOUND), which also terminates any
+  ## forwarding cycle in a bidirectional pair.
+  var fwd = msg
+  fwd.source = @[]
+  fwd.id_mappings = @[]
+  for sub in self.request_targets:
+    if sub.ctx_id == requester.ctx_id:
+      continue
+    self.send(sub, fwd, OperationContext(), DEFAULT_FLAGS)
+
+proc add_obj_want(self: EdContext, requester: Subscription, msg: Message) =
+  ## Remember + chain a whole-object want. Dedup: only the first want for an
+  ## id forwards upstream; later askers just join the waiters.
+  if msg.object_id in self.pending_obj_wants:
+    for want in self.pending_obj_wants[msg.object_id]:
+      if want.sub.ctx_id == requester.ctx_id:
+        return
+    self.pending_obj_wants[msg.object_id].add (requester, msg.deep, msg.follow)
+  else:
+    self.pending_obj_wants[msg.object_id] = @[(requester, msg.deep, msg.follow)]
+    self.forward_request(requester, msg)
+
 proc pack_messages(msgs: seq[Message]): seq[Message] =
   if msgs.len > 1:
     var packed_msg = Message(
@@ -392,6 +510,22 @@ proc publish_changes*[T, O](
       assert id in self.ctx
       let obj = self.ctx.objects[id]
 
+      # OWNS_MEMBERS + partial: a newly added member must arrive *after* its
+      # ownership closure, or the subscriber's parse mints husks for the
+      # member's container fields. Push the closure to each interested partial
+      # target now — these CREATEs are sent immediately, ahead of the ADD ops
+      # fanned out below.
+      when O is ref:
+        if OWNS_MEMBERS in self.flags:
+          for sub in self.ctx.subscribers:
+            if sub.partial and sub.deep and sub.ctx_id notin op_ctx.source and
+                id in sub.interest:
+              for change in changes:
+                if ADDED in change.changes and ?change.item:
+                  let item = RootRef(change.item)
+                  if item of EdRef:
+                    self.ctx.publish_closure(sub, EdRef(item).id)
+
       for change in changes:
         if [ADDED, REMOVED, CREATED, TOUCHED].any_it(it in change.changes):
           if REMOVED in change.changes and MODIFIED in change.changes:
@@ -406,8 +540,6 @@ proc publish_changes*[T, O](
             else:
               ""
           msgs.add obj.build_message(obj, change, id, trace)
-
-      msgs = pack_messages(msgs)
 
       # Tag each op with its origin (the original writer) so writers can dedup
       # their own returned delta ops. Forwards preserve the incoming origin;
@@ -424,6 +556,36 @@ proc publish_changes*[T, O](
       let originating = op_ctx.op_id == 0
       let out_op_id =
         if originating: self.ctx.next_op_id else: op_ctx.op_id
+
+      # Per-key interest (LAZY tables): a partial subscriber without
+      # whole-object interest still receives ops for keys it has requested —
+      # including a key that was missing at request time (an empty-space chunk
+      # someone later builds in). Filtered per-sub on the pre-pack messages
+      # (each sub's key set differs) and sent unordered (lsn 0), matching
+      # per-key pulls. The canonical fanout below skips these subs — the
+      # object isn't in their `interest`.
+      for sub in self.ctx.subscribers:
+        if sub.partial and id notin sub.interest and
+            id in sub.key_interest and sub.ctx_id notin op_ctx.source:
+          for msg in msgs.mitems:
+            if msg.key_bin.len > 0 and msg.key_bin in sub.key_interest[id]:
+              if sub.capabilities.len > 0 and msg.type_id != 0 and
+                  msg.type_id notin sub.capabilities:
+                continue
+              if msg.kind == ASSIGN and msg.change_object_id.len > 0 and
+                  msg.change_object_id in self.ctx and
+                  msg.change_object_id notin sub.interest:
+                # Ed-valued entry (a chunk's delta seq): send the nested
+                # container ahead of the ADD so the receiver links it, and
+                # follow it so its future ops stream. RELEASE sheds it.
+                sub.interest.incl msg.change_object_id
+                self.ctx.objects[msg.change_object_id].publish_create(sub)
+              var keyed = msg
+              keyed.origin = out_origin
+              keyed.op_id = out_op_id
+              self.ctx.send(sub, keyed, op_ctx, self.flags)
+
+      msgs = pack_messages(msgs)
 
       # Authority stamps each ordered op with its global LSN, once, before
       # fanout so every subscriber receives the same LSN.
@@ -468,6 +630,13 @@ proc add_subscriber*(
         from_ctx = self.id, to_ctx = sub.ctx_id, ed_id = id
 
       let zen = self.objects[id]
+      if sub.partial and sub.deep and OWNS_MEMBERS in zen.flags:
+        # Push the members' closures before the collection itself, so the
+        # subscriber's parse links member fields to real containers (no husks).
+        # Members are indexed under the collection's owner — or under the
+        # collection's own id when it's ownerless (the root units list).
+        let member_owner = if zen.owner_id.len > 0: zen.owner_id else: id
+        self.publish_closure(sub, member_owner)
       zen.publish_create sub
     else:
       debug "not sending object because remote ctx already has it",
@@ -481,6 +650,27 @@ proc unsubscribe*(self: EdContext, sub: Subscription) =
     discard
   self.subscribers.delete self.subscribers.find(sub)
   self.unsubscribed.add sub.ctx_id
+  # Purge the subscriber's chained wants so nothing is served to a dead sub.
+  var empty_ids: seq[string]
+  for id, wants in self.pending_obj_wants.mpairs:
+    wants = wants.filter_it(it.sub.ctx_id != sub.ctx_id)
+    if wants.len == 0:
+      empty_ids.add id
+  for id in empty_ids:
+    self.pending_obj_wants.del id
+  var empty_objs: seq[string]
+  for id, keys in self.pending_key_wants.mpairs:
+    var empty_keys: seq[string]
+    for key_bin, waiters in keys.mpairs:
+      waiters = waiters.filter_it(it.ctx_id != sub.ctx_id)
+      if waiters.len == 0:
+        empty_keys.add key_bin
+    for key_bin in empty_keys:
+      keys.del key_bin
+    if keys.len == 0:
+      empty_objs.add id
+  for id in empty_objs:
+    self.pending_key_wants.del id
 
 # Defined after `tick` (which it pumps); forward-declared so `subscribe` can wire
 # it onto each subscribing context.
@@ -497,14 +687,24 @@ proc subscribe*(
     ctx: EdContext,
     bidirectional = true,
     partial = false,
-    roots: seq[string] = @[],
+    fetch: open_array[string] = [],
+    deep = false,
+    upstream = true,
 ) =
   ## Subscribe to another local context for cross-thread sync. When `partial`,
-  ## we only receive objects in `roots` (and ids we later fetch) — the
-  ## authority→us direction is filtered; our own writes still flow to it.
+  ## we only receive the objects in `fetch` (and ids we `fetch` later) — the
+  ## authority→us direction is filtered; our own writes still flow to it. The
+  ## fetched ids land in the registry, so `ctx[id]` works for them afterwards.
+  ## `ctx` is recorded as our upstream (we're a clone of it — eviction notices
+  ## from it are honored); the internal reverse leg passes `upstream = false`
+  ## because receiving a client's own writes doesn't make it our data source.
   privileged
   debug "local subscribe", ctx = self.id
   self.materialize = materialize_impl # enable materialize-on-access
+  if upstream:
+    self.upstream_ctx_ids.incl ctx.id
+  if partial:
+    self.partial_replica = true
   self.pack_objects
   var remote_objects: HashSet[string]
   for id in self.objects.keys:
@@ -516,7 +716,8 @@ proc subscribe*(
       chan: self.chan,
       ctx_id: self.id,
       partial: partial,
-      interest: roots.toHashSet,
+      deep: deep,
+      interest: fetch.toHashSet,
     ),
     push_all = bidirectional,
     remote_objects,
@@ -528,22 +729,34 @@ proc subscribe*(
 
   if bidirectional:
     # Reverse direction (us → authority) stays full: we push our own writes.
-    ctx.subscribe(self, bidirectional = false)
+    ctx.subscribe(self, bidirectional = false, upstream = false)
 
-proc fetch*(self: EdContext, object_id: string, deep = false) =
-  ## Ask the authority for `object_id`. It's materialized on a later tick
-  ## (placeholder-then-fill); the authority adds it to our interest so future
-  ## ops follow. No-op if we already hold it *loaded* — a placeholder (held but
-  ## not materialized) still needs fetching.
+proc fetch*(
+    self: EdContext, object_id: string, deep = false, follow = true
+): Fetch {.discardable.} =
+  ## Ask the authority for `object_id`. Returns a handle that resolves on a
+  ## later tick: `Found` (with `obj` linking the container) when it arrives, or
+  ## `NotFound` if the authority NACKs. Already holding it loaded resolves
+  ## immediately; fetching an id already in flight returns the same handle.
+  ##
+  ## `follow` (default) registers interest with the authority, so future ops
+  ## follow — and a *missing* id is delivered whenever something creates it
+  ## (the handle still resolves NotFound for "not there right now").
+  ## `follow = false` is a snapshot: current state only, nothing afterwards.
   ##
   ## `deep` also fetches everything the id *owns* (the synced-ownership closure,
   ## recursively) — so an owner id (a unit, which isn't itself a container) pulls
   ## its whole owned state in one request. The already-loaded short-circuit is
   ## skipped for deep fetches: holding the root says nothing about the closure.
   if not deep and object_id in self and not self.objects[object_id].placeholder:
-    return
-  var msg = Message(kind: REQUEST, object_id: object_id, deep: deep)
-  for sub in self.subscribers:
+    return Fetch(id: object_id, state: Found, obj: self.objects[object_id])
+  if object_id in self.fetches and self.fetches[object_id].state == Pending:
+    return self.fetches[object_id]
+  result = Fetch(id: object_id, state: Pending)
+  self.fetches[object_id] = result
+  var msg =
+    Message(kind: REQUEST, object_id: object_id, deep: deep, follow: follow)
+  for sub in self.request_targets:
     self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
 
@@ -557,6 +770,21 @@ proc flush_key_requests(self: EdContext) =
   self.pending_key_requests.clear
   for object_id, keys in pending:
     let msg = Message(kind: REQUEST, object_id: object_id, obj: keys.to_flatty)
+    for sub in self.request_targets:
+      self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  self.tick_reactor
+
+proc flush_key_releases(self: EdContext) =
+  ## Send the per-key releases buffered since the last tick — one RELEASE per
+  ## table, broadcast to every peer. Upstream reads it as an interest retract
+  ## (ops for those keys stop flowing); downstream clones read it as an
+  ## eviction notice and drop the keys too (see the RELEASE handler).
+  if self.pending_key_releases.len == 0:
+    return
+  let pending = self.pending_key_releases
+  self.pending_key_releases.clear
+  for object_id, keys in pending:
+    let msg = Message(kind: RELEASE, object_id: object_id, obj: keys.to_flatty)
     for sub in self.subscribers:
       self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
@@ -566,18 +794,21 @@ proc subscribe*(
     address: string,
     bidirectional = true,
     partial = false,
-    roots: seq[string] = @[],
+    fetch: open_array[string] = [],
+    deep = false,
     callback: proc() {.gcsafe.} = nil,
 ) =
   ## Subscribe to a remote context for network sync. Address format: "host" or
-  ## "host:port". When `partial`, the authority only sends objects in `roots`
+  ## "host:port". When `partial`, the authority only sends the objects in `fetch`
   ## (and ids fetched later); the reference graph + materialize-on-access pull the
-  ## rest. Mirrors the local `subscribe(partial = ..., roots = ...)`.
+  ## rest. Mirrors the local `subscribe(partial = ..., fetch = ...)`.
   var address = address
   var port = 9632
 
   debug "remote subscribe", address
   self.materialize = materialize_impl # enable materialize-on-access
+  if partial:
+    self.partial_replica = true
   if not ?self.reactor:
     self.reactor = new_reactor()
   self.subscribing = true
@@ -598,7 +829,7 @@ proc subscribe*(
   let type_ids = block:
     {.gcsafe.}:
       toSeq(type_initializers.keys)
-  let handshake = (type_ids, partial, roots).to_flatty
+  let handshake = (type_ids, partial, @fetch, deep).to_flatty
   self.send(
     Subscription(
       kind: REMOTE,
@@ -650,6 +881,10 @@ proc subscribe*(
   # Create bidirectional subscription BEFORE processing messages so mappings get registered
   var bi_sub: Subscription = nil
   if bidirectional:
+    # The remote is our upstream: we're a clone of (a subset of) it, so its
+    # eviction notices apply to us. One-way remote subscribes never learn the
+    # peer's ctx_id (no ACK parse), so they can't be eviction targets yet.
+    self.upstream_ctx_ids.incl ctx_id
     bi_sub = Subscription(
       kind: REMOTE,
       connection: connection,
@@ -797,11 +1032,159 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       self.owned_by.mgetOrPut(msg.owner_id, initHashSet[string]()).incl(
         msg.object_id
       )
+    # Resolve fetch handles: the object itself and — for a deep fetch of an
+    # *owner* id — the owner its containers point back to (the owner has no
+    # container of its own, so its handle resolves via the arriving closure).
+    if msg.object_id in self.fetches:
+      let pending_fetch = self.fetches[msg.object_id]
+      pending_fetch.state = Found
+      if msg.object_id in self.objects and ?self.objects[msg.object_id]:
+        pending_fetch.obj = self.objects[msg.object_id]
+      self.fetches.del(msg.object_id)
+    if msg.owner_id.len > 0 and msg.owner_id in self.fetches:
+      self.fetches[msg.owner_id].state = Found
+      self.fetches.del(msg.owner_id)
+    # Serve chained wants (see forward_request): whoever asked while we didn't
+    # have it. Deep wants serve the closure — its CREATEs precede this one
+    # (deepest-first publish); owner-only ids resolve via msg.owner_id.
+    template serve_obj_wants(id: string) =
+      if id in self.pending_obj_wants:
+        let wants = self.pending_obj_wants[id]
+        self.pending_obj_wants.del(id)
+        for want in wants:
+          if want.follow:
+            want.sub.interest.incl id
+          if want.deep:
+            discard self.publish_closure(want.sub, id, follow = want.follow)
+          elif id in self.objects and ?self.objects[id]:
+            self.objects[id].publish_create(want.sub)
+
+    serve_obj_wants(msg.object_id)
+    if msg.owner_id.len > 0:
+      serve_obj_wants(msg.owner_id)
+    # A fill can bring table entries chained key-waiters are waiting on.
+    self.serve_key_wants(msg.object_id)
     # The creator is interested in its own object: make sure its canonical ops
     # flow back. Matters for partial subscribers; a no-op for full ones.
     for s in self.subscribers:
       if s.ctx_id in source:
         s.interest.incl msg.object_id
+  elif msg.kind == NOT_FOUND:
+    # The authority NACKed a fetch: resolve the handle so callers (and the
+    # blocking `ctx[]` pump) learn promptly instead of waiting out a deadline,
+    # and relay the answer to any chained waiters (see forward_request).
+    if msg.obj.len > 0:
+      # Per-key NACK: a missing key is a *normal* answer (an empty-space voxel
+      # chunk). Relay per waiter and clear the wants so nothing dangles.
+      if msg.object_id in self.pending_key_wants:
+        for key_bin in msg.obj.from_flatty(seq[string]):
+          if key_bin in self.pending_key_wants[msg.object_id]:
+            for waiter in self.pending_key_wants[msg.object_id][key_bin]:
+              self.send(
+                waiter,
+                Message(
+                  kind: NOT_FOUND,
+                  object_id: msg.object_id,
+                  obj: @[key_bin].to_flatty,
+                ),
+                OperationContext(),
+                DEFAULT_FLAGS,
+              )
+            self.pending_key_wants[msg.object_id].del key_bin
+        if self.pending_key_wants[msg.object_id].len == 0:
+          self.pending_key_wants.del msg.object_id
+    else:
+      if msg.object_id in self.fetches:
+        self.fetches[msg.object_id].state = NotFound
+        self.fetches.del(msg.object_id)
+      if msg.object_id in self.pending_obj_wants:
+        for want in self.pending_obj_wants[msg.object_id]:
+          self.send(
+            want.sub,
+            Message(kind: NOT_FOUND, object_id: msg.object_id),
+            OperationContext(),
+            DEFAULT_FLAGS,
+          )
+        self.pending_obj_wants.del msg.object_id
+  elif msg.kind == RELEASE:
+    # Per-key paging notice (see `release`). Role decides the meaning:
+    #  - From a subscriber that pages from us: an interest retract — stop
+    #    streaming those keys (and the nested containers that rode in with
+    #    them). Our copy is untouched; we may serve others.
+    #  - From *upstream*: an eviction notice — our data source dropped the
+    #    keys, and we're a clone of it, so they're gone for us too. Evict
+    #    locally (REMOVED fires, watches un-render) and relay downstream.
+    # A full clone of a full source never receives one (full sources don't
+    # release); the authority has no upstream, so it only ever retracts.
+    let keys = msg.obj.from_flatty(seq[string])
+    var retracted = false
+    for s in self.subscribers:
+      if s.ctx_id notin source:
+        continue
+      if msg.object_id in s.key_interest:
+        retracted = true
+        for key_bin in keys:
+          s.key_interest[msg.object_id].excl key_bin
+          # Shed the keys' nested containers (the chunk's delta seq) from the
+          # follow set, so their ops stop streaming as well.
+          if msg.object_id in self:
+            let obj = self.objects[msg.object_id]
+            let reply = obj.publish_key(obj, key_bin)
+            for nested_id in reply.nested:
+              s.interest.excl nested_id
+        if s.key_interest[msg.object_id].len == 0:
+          s.key_interest.del msg.object_id
+        # A release can outrun an in-flight chained request: drop the
+        # subscriber from any pending wants so the late answer isn't served
+        # to someone who no longer wants it (re-materializing a paged-out key).
+        if msg.object_id in self.pending_key_wants:
+          for key_bin in keys:
+            if key_bin in self.pending_key_wants[msg.object_id]:
+              self.pending_key_wants[msg.object_id][key_bin] =
+                self.pending_key_wants[msg.object_id][key_bin].filter_it(
+                  it.ctx_id != s.ctx_id
+                )
+    if retracted and self.partial_replica and not self.is_authority:
+      # Hub shedding — the symmetric counterpart of request chaining. A
+      # partial hub holds paged keys only to serve its subscribers; when the
+      # last interest in a key retracts, drop our copy and chain the release
+      # upstream (the queued broadcast also notifies any remaining downstream
+      # clones, where eviction is an idempotent no-op).
+      for key_bin in keys:
+        var still_wanted = false
+        for s in self.subscribers:
+          if msg.object_id in s.key_interest and
+              key_bin in s.key_interest[msg.object_id]:
+            still_wanted = true
+            break
+        if not still_wanted:
+          if msg.object_id in self:
+            let obj = self.objects[msg.object_id]
+            if obj.evict_key != nil:
+              discard obj.evict_key(obj, key_bin)
+          self.pending_key_releases.mgetOrPut(msg.object_id, @[]).add key_bin
+    if not retracted:
+      var from_upstream = false
+      for src in source:
+        if src in self.upstream_ctx_ids:
+          from_upstream = true
+          break
+      if from_upstream:
+        if msg.object_id in self:
+          let obj = self.objects[msg.object_id]
+          if obj.evict_key != nil:
+            for key_bin in keys:
+              discard obj.evict_key(obj, key_bin)
+        if not self.is_authority:
+          # Relay to our own subscribers (downstream clones); the accumulated
+          # source stops it echoing back the way it came.
+          var fwd_source = source
+          fwd_source.incl self.id
+          for s in self.subscribers:
+            if s.ctx_id notin fwd_source:
+              self.send(
+                s, msg, OperationContext(source: fwd_source), DEFAULT_FLAGS
+              )
   elif msg.kind == REQUEST:
     # A partial subscriber wants data. Two forms:
     #  - whole-object (`obj` empty): add the object to interest and publish_create
@@ -809,44 +1192,135 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     #  - per-key (`obj` = a batch of serialized table keys): reply with just those
     #    entries (an ADD op each), without adding the whole table to interest.
     # The requester is whoever the message came from — match by ctx id in `source`.
+    #
+    # Request chaining: a hub that can't serve a request forwards it to its
+    # upstream(s) (becoming the requester there) and remembers who asked; the
+    # answer — data or NOT_FOUND — relays back down hop by hop. Only misses
+    # forward, and only the first want for an id/key does; the authority never
+    # forwards (its miss is the real NOT_FOUND).
+    #
+    # Never serve a REQUEST from our own upstream: our copy is a stale subset
+    # of theirs, and answering would echo old state back over fresher data.
+    # (Requests are routed upstream-only, so this shouldn't arrive; guard
+    # against legacy senders.)
+    for src in source:
+      if src in self.upstream_ctx_ids:
+        return
     for s in self.subscribers:
       if s.ctx_id notin source:
         continue
       if msg.obj.len > 0:
-        if msg.object_id notin self:
-          continue
-        let obj = self.objects[msg.object_id]
+        # Per-key: serve what we have, chain or NACK the rest. Every requested
+        # key joins the subscriber's key interest — found or missing — so its
+        # future ops stream (a missing chunk pops in when someone builds
+        # there). RELEASE retracts.
         for key_bin in msg.obj.from_flatty(seq[string]):
-          let reply = obj.publish_key(obj, key_bin)
-          if reply.found:
-            self.send(s, reply.msg, OperationContext(), DEFAULT_FLAGS)
+          s.key_interest.mgetOrPut(msg.object_id, initHashSet[string]()).incl(
+            key_bin
+          )
+        var missing: seq[string]
+        if msg.object_id in self:
+          let obj = self.objects[msg.object_id]
+          # Handle-first: the requester (or a hub between us) may not hold the
+          # container yet — a chained request can outrun the closure push that
+          # carries it. An ADD for an unknown object is dropped on arrival and
+          # the want dangles (only the first want per key forwards), so the
+          # entry would never load. The empty-body CREATE is idempotent and
+          # makes the ADDs below always applicable.
+          if not obj.placeholder:
+            obj.publish_create(s, contents = false)
+          for key_bin in msg.obj.from_flatty(seq[string]):
+            let reply = obj.publish_key(obj, key_bin)
+            if reply.found:
+              # Per-key deep: nested containers (a chunk's delta seq) go
+              # first so the receiver's parse links them — and they're
+              # followed, so their future ops (delta appends) stream.
+              for nested_id in reply.nested:
+                if nested_id in self and not self.objects[nested_id].placeholder:
+                  s.interest.incl nested_id
+                  self.objects[nested_id].publish_create(s)
+              self.send(s, reply.msg, OperationContext(), DEFAULT_FLAGS)
+            else:
+              missing.add key_bin
+        else:
+          missing = msg.obj.from_flatty(seq[string])
+        if missing.len > 0:
+          if self.is_authority:
+            self.send(
+              s,
+              Message(
+                kind: NOT_FOUND,
+                object_id: msg.object_id,
+                obj: missing.to_flatty,
+              ),
+              OperationContext(),
+              DEFAULT_FLAGS,
+            )
+          else:
+            var to_forward: seq[string]
+            for key_bin in missing:
+              if msg.object_id notin self.pending_key_wants:
+                self.pending_key_wants[msg.object_id] =
+                  init_table[string, seq[Subscription]]()
+              if key_bin notin self.pending_key_wants[msg.object_id]:
+                to_forward.add key_bin
+                self.pending_key_wants[msg.object_id][key_bin] = @[s]
+              elif s notin self.pending_key_wants[msg.object_id][key_bin]:
+                self.pending_key_wants[msg.object_id][key_bin].add s
+            if to_forward.len > 0:
+              var fwd = msg
+              fwd.obj = to_forward.to_flatty
+              self.forward_request(s, fwd)
       elif msg.deep:
-        # Deep fetch: the id plus its ownership closure. BFS over `owned_by` —
-        # the requested id may be an *owner* (a unit/EdRef id with no container
-        # of its own), so it expands even when it isn't in `objects`. Each owned
-        # container is published and added to interest; if any of those are
-        # themselves owners someday, the walk follows them too.
-        var ids = @[msg.object_id]
-        var i = 0
-        while i < ids.len:
-          let id = ids[i]
-          inc i
-          if id in self:
-            s.interest.incl id
-            self.objects[id].publish_create(s)
-          if id in self.owned_by:
-            for owned_id in self.owned_by[id]:
-              if owned_id notin ids:
-                ids.add owned_id
+        # Deep fetch: the id plus its ownership closure (see publish_closure —
+        # the requested id may be an *owner*, a unit id with no container of its
+        # own, and the walk recurses through owned members into their subtrees).
+        let found = self.publish_closure(s, msg.object_id, follow = msg.follow)
+        if msg.follow:
+          # Follow the root id itself even if nothing exists yet: a later
+          # CREATE under this id is then delivered without re-fetching.
+          s.interest.incl msg.object_id
+        if not found:
+          if self.is_authority:
+            self.send(
+              s,
+              Message(kind: NOT_FOUND, object_id: msg.object_id),
+              OperationContext(),
+              DEFAULT_FLAGS,
+            )
+          else:
+            self.add_obj_want(s, msg)
       else:
-        if msg.object_id notin self:
-          continue
-        s.interest.incl msg.object_id
-        self.objects[msg.object_id].publish_create(s)
+        if msg.object_id in self and not self.objects[msg.object_id].placeholder:
+          if msg.follow:
+            s.interest.incl msg.object_id
+          self.objects[msg.object_id].publish_create(s)
+        else:
+          # Missing — or held only as an unloaded placeholder, which would
+          # serve empty state; chain instead so the real data comes back.
+          if msg.follow:
+            # Keep the interest so a later CREATE under this id is delivered
+            # without re-fetching.
+            s.interest.incl msg.object_id
+          if self.is_authority:
+            self.send(
+              s,
+              Message(kind: NOT_FOUND, object_id: msg.object_id),
+              OperationContext(),
+              DEFAULT_FLAGS,
+            )
+          else:
+            self.add_obj_want(s, msg)
   elif msg.kind != BLANK:
     if msg.object_id notin self:
-      # :( this should throw an error
-      debug "missing object", object_id = msg.object_id
+      # An op for an object we don't hold is dropped. Usually benign
+      # (partial replica, version skew), but a drop on a paging path means a
+      # requested entry silently never loads — surface the first one per
+      # object so a stalled chain is visible in the logs.
+      if msg.object_id notin self.warned_missing:
+        self.warned_missing.incl msg.object_id
+        notice "dropping op for missing object",
+          object_id = msg.object_id, kind = msg.kind
       return
     let obj = self.objects[msg.object_id]
     obj.change_receiver(
@@ -858,6 +1332,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     )
     if msg.lsn > self.applied_lsn:
       self.applied_lsn = msg.lsn
+    # Ops (table ADDs) may have brought entries chained key-waiters want.
+    self.serve_key_wants(msg.object_id)
   else:
     fail "Can't recv a blank message"
 
@@ -1012,6 +1488,7 @@ proc tick*(
 
   self.flush_buffers
   self.flush_key_requests # send this frame's batched per-key fetches
+  self.flush_key_releases # ...and its batched per-key releases (paging out)
 
   # Replay whatever a silent (blocking) materialize deferred — at this tick
   # boundary, before new traffic: first the messages it buffered (apply + fire
@@ -1125,17 +1602,19 @@ proc tick*(
               old_ctx_id = sub.ctx_id, new_ctx_id = source_str
             self.unsubscribe(sub)
 
-          # Handshake (capabilities, partial, roots) rides in the SUBSCRIBE `obj`.
+          # Handshake (capabilities, partial, fetch ids) rides in the SUBSCRIBE `obj`.
           # Empty (older peer) = unfiltered, full replica.
           var caps: HashSet[int]
           var is_partial = false
           var interest: HashSet[string]
+          var is_deep = false
           if msg.obj.len > 0:
-            let (cap_ids, p, roots) =
-              msg.obj.from_flatty((seq[int], bool, seq[string]))
+            let (cap_ids, p, fetch_ids, d) =
+              msg.obj.from_flatty((seq[int], bool, seq[string], bool))
             caps = cap_ids.to_hash_set
             is_partial = p
-            interest = roots.to_hash_set
+            is_deep = d
+            interest = fetch_ids.to_hash_set
 
           var new_sub = Subscription(
             kind: REMOTE,
@@ -1144,6 +1623,7 @@ proc tick*(
             last_sent_time: epoch_time(),
             capabilities: caps,
             partial: is_partial,
+            deep: is_deep,
             interest: interest,
           )
           # Register all mappings from the subscribe message
@@ -1185,25 +1665,25 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   ## placeholder, same as the non-blocking path. Drains both the local
   ## (cross-thread) and remote (network) transports.
   privileged
-  if id notin self or not self.objects[id].placeholder:
+  if id in self and ?self.objects[id] and not self.objects[id].placeholder:
     return
-  self.fetch(id)
+  let pending_fetch = self.fetch(id)
   if not self.blocking:
     return
 
   template triage(candidate: Message) =
-    # Apply only the target object's CREATE (silently — its callback is
-    # deferred); buffer everything else for the next tick. SUBSCRIBE can't be
-    # replayed sub-less, but a blocking *client* shouldn't receive one.
-    if candidate.object_id == id and candidate.kind == CREATE:
+    # Apply only the target object's CREATE — or its NOT_FOUND NACK, which
+    # resolves the fetch so we stop waiting — silently (callbacks deferred);
+    # buffer everything else for the next tick. SUBSCRIBE can't be replayed
+    # sub-less, but a blocking *client* shouldn't receive one.
+    if candidate.object_id == id and candidate.kind in {CREATE, NOT_FOUND}:
       self.process_message(candidate)
     elif candidate.kind != SUBSCRIBE:
       self.pending_msgs.add candidate
 
   let deadline = get_mono_time() + init_duration(seconds = 5)
   self.silent = true
-  while id in self and self.objects[id].placeholder and
-      get_mono_time() < deadline:
+  while pending_fetch.state == Pending and get_mono_time() < deadline:
     # Local transport.
     var m: Message
     while self.chan.try_recv(m):

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -429,14 +429,18 @@ proc serve_key_wants(self: EdContext, object_id: string) =
 proc request_targets(self: EdContext): seq[Subscription] =
   ## Who to send a REQUEST to: our upstreams (the contexts we page from).
   ## Never downstream — a clone's copy of us is stale-by-definition, and
-  ## letting it answer can overwrite fresher local state with its echo.
-  ## No known upstream (e.g. a one-way local subscribe) falls back to all
-  ## subscribers.
+  ## letting it answer can overwrite fresher local state with its echo. Only a
+  ## non-authority forwards, and a non-authority pages from a recorded upstream,
+  ## so this is non-empty in practice. An empty result means a degenerate
+  ## topology (a non-authority with no upstream); rather than fall back to all
+  ## subscribers — which could route the request downstream — treat it as a bug
+  ## (assert in debug, log in release) and forward nowhere.
   for sub in self.subscribers:
     if sub.ctx_id in self.upstream_ctx_ids:
       result.add sub
   if result.len == 0:
-    result = self.subscribers
+    error "request_with_no_upstream", ctx = self.id
+    assert false, "request_targets: forwarding with no recorded upstream"
 
 proc forward_request(self: EdContext, requester: Subscription, msg: Message) =
   ## Chain a request we can't serve: send it to our upstream(s).

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -430,8 +430,8 @@ proc request_targets(self: EdContext): seq[Subscription] =
   ## Who to send a REQUEST to: our upstreams (the contexts we page from).
   ## Never downstream — a clone's copy of us is stale-by-definition, and
   ## letting it answer can overwrite fresher local state with its echo.
-  ## No known upstream (a one-way local subscribe never told us) falls back
-  ## to everyone, preserving the old behavior for legacy topologies.
+  ## No known upstream (e.g. a one-way local subscribe) falls back to all
+  ## subscribers.
   for sub in self.subscribers:
     if sub.ctx_id in self.upstream_ctx_ids:
       result.add sub
@@ -1201,8 +1201,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     #
     # Never serve a REQUEST from our own upstream: our copy is a stale subset
     # of theirs, and answering would echo old state back over fresher data.
-    # (Requests are routed upstream-only, so this shouldn't arrive; guard
-    # against legacy senders.)
+    # (Requests route upstream-only, so this shouldn't normally arrive.)
     for src in source:
       if src in self.upstream_ctx_ids:
         return

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -643,17 +643,21 @@ proc add_subscriber*(
         from_ctx = self.id, to_ctx = sub.ctx_id, ed_id = id
 
 proc unsubscribe*(self: EdContext, sub: Subscription) =
+  # Snapshot the id before the delete below: `sub` is a borrowed param (ORC
+  # doesn't refcount parameters), and the seq slot is the only owner, so the
+  # delete frees it -- every later read must use this local, not `sub`.
+  let ctx_id = sub.ctx_id
   if sub.kind == REMOTE:
     self.reactor.disconnect(sub.connection)
   else:
     # ???
     discard
   self.subscribers.delete self.subscribers.find(sub)
-  self.unsubscribed.add sub.ctx_id
+  self.unsubscribed.add ctx_id
   # Purge the subscriber's chained wants so nothing is served to a dead sub.
   var empty_ids: seq[string]
   for id, wants in self.pending_obj_wants.mpairs:
-    wants = wants.filter_it(it.sub.ctx_id != sub.ctx_id)
+    wants = wants.filter_it(it.sub.ctx_id != ctx_id)
     if wants.len == 0:
       empty_ids.add id
   for id in empty_ids:
@@ -662,7 +666,7 @@ proc unsubscribe*(self: EdContext, sub: Subscription) =
   for id, keys in self.pending_key_wants.mpairs:
     var empty_keys: seq[string]
     for key_bin, waiters in keys.mpairs:
-      waiters = waiters.filter_it(it.ctx_id != sub.ctx_id)
+      waiters = waiters.filter_it(it.ctx_id != ctx_id)
       if waiters.len == 0:
         empty_keys.add key_bin
     for key_bin in empty_keys:
@@ -1199,11 +1203,17 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     # forward, and only the first want for an id/key does; the authority never
     # forwards (its miss is the real NOT_FOUND).
     #
-    # Never serve a REQUEST from our own upstream: our copy is a stale subset
-    # of theirs, and answering would echo old state back over fresher data.
-    # (Requests route upstream-only, so this shouldn't normally arrive.)
+    # A REQUEST only ever arrives from a downstream subscriber that pages from
+    # us; it can't come from one of our own upstreams, since upstreams are
+    # authorities (or page further up) and never send requests back down. If one
+    # does, our copy is a stale subset of theirs and serving it would echo old
+    # state over fresher data -- treat it as a bug (assert in debug, log in
+    # release) but stay safe by not serving.
     for src in source:
       if src in self.upstream_ctx_ids:
+        error "request_from_upstream",
+          ctx = self.id, src = src, source = source.to_seq.join(",")
+        assert src notin self.upstream_ctx_ids
         return
     for s in self.subscribers:
       if s.ctx_id notin source:

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -73,7 +73,10 @@ proc register_type(typ: type) =
       for field in self[].fields:
         when field is Ed:
           if ?field and field.id in ctx:
-            field = type(field)(ctx[field.id])
+            # Direct registry read — `ctx[...]` would blocking-materialize in a
+            # `blocking` scope, which deserialization must never do (and a func
+            # can't have side effects).
+            field = type(field)(ctx.objects[field.id])
       result = self
 
   with_lock:
@@ -232,6 +235,27 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
     # the instance when its last real reference drops (RefHandle then cleans the
     # pool), giving move-identity for free: a removed-then-readded replica
     # re-links the same instance across any gap.
+
+    # Member ownership: an OWNS_MEMBERS collection's EdRef members belong to the
+    # collection's *owner* — membership drives the `owned_by` index, and removal
+    # un-registers, so an independently-removed member just drops out of the
+    # cascade. Entries are ref_pool keys (tid:id); `destroy_owned` resolves them
+    # there and cascades through the EdRef `destroy` method. Runs identically on
+    # every context that applies the ADD/REMOVE, so the index needs no extra sync.
+    let container = self.objects.getOrDefault(ed_id)
+    if not container.is_nil and OWNS_MEMBERS in container.flags:
+      # An ownerless flagged collection (the root units list) indexes members
+      # under its own id instead: nothing cascades into them, but the closure
+      # push / deep fetch can still find them.
+      let owner =
+        if container.owner_id.len > 0:
+          container.owner_id
+        else:
+          ed_id
+      if ADDED in change.changes:
+        self.owned_by.mgetOrPut(owner, initHashSet[string]()).incl(id)
+      if REMOVED in change.changes and owner in self.owned_by:
+        self.owned_by[owner].excl(id)
 
 proc find_ref*[T](self: EdContext, value: var T): bool =
   privileged

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -38,6 +38,10 @@ type
     ## registry can clean up `ref_pool` when ORC reclaims the instance, keeping the
     ## pool's non-owning (cursor) hold from dangling — the subtype's own default
     ## destructor stays intact (only the trivial `RefHandle` gets a custom one).
+    id*: string
+      ## The ref's identity (sync identity rides on it via `ref_id` = tid:id).
+      ## Lives on the base so runtime code (the `destroy` method, `own` scopes,
+      ## ownership) can use it without knowing the concrete type.
     ref_handle*: RefHandle
     destroyed* {.ed_ignore.}: bool
       ## Idempotency latch for `destroy`, set at its top. `ed_ignore`: local
@@ -52,6 +56,16 @@ type
     SYNC_LOCAL        ## Sync changes to other local contexts (threads)
     SYNC_REMOTE       ## Sync changes to remote contexts (network)
     SYNC_ALL_NO_OVERWRITE  ## Sync without overwriting existing data
+    LAZY              ## Pull-only: closure pushes / deep-fetch serving skip
+                      ## this container — it syncs via explicit fetch or per-key
+                      ## requests (big voxel tables). Arrives as a placeholder
+                      ## otherwise.
+    OWNS_MEMBERS      ## This collection's EdRef members are *owned* by the
+                      ## collection's owner: membership registers them in
+                      ## `owned_by` (removal un-registers), so the owner's
+                      ## `destroy_owned` cascades into them. For true child
+                      ## collections (a unit's `units`) — NOT reference
+                      ## collections (a sign's owner, a selection list).
 
   ChangeKind* = enum
     ## Types of changes that can occur on an `Ed` container.
@@ -78,7 +92,14 @@ type
     TOUCH
     SUBSCRIBE
     PACKED
-    REQUEST  # partial replica asking the authority for an object by id
+    REQUEST    # partial replica asking the authority for an object by id
+    NOT_FOUND  # authority's NACK: the REQUESTed id isn't there (right now)
+    RELEASE    # per-key paging: a replica dropped table keys (obj = key batch).
+               # Receivers decide by role: a registered partial subscriber's
+               # RELEASE retracts its key interest; one arriving from *upstream*
+               # is an eviction notice — drop the keys locally and relay
+               # downstream. Full clones forward without evicting; the
+               # authority terminates it.
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]
@@ -121,6 +142,12 @@ type
     delta*: bool    # true for collection (non-idempotent) ops, false for registers
     deep*: bool     # REQUEST only: also send the ownership closure (everything
                     # the requested id owns via owned_by, recursively)
+    follow*: bool   # REQUEST only: register interest so future ops follow — and,
+                    # for a missing id, so it's delivered when it's created later
+    key_bin*: string # Table ops only: the serialized key, stamped by
+                     # build_message so fanout can filter per-key (LAZY tables /
+                     # key interest) without deserializing `obj`. Sender-side
+                     # only — blanked from the remote body.
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -169,7 +196,20 @@ type
     # `interest` (its roots + ids it has fetched). Default (not partial) gets
     # everything — the existing full-replica behavior.
     partial*: bool
+    # Partial + deep: push the ownership closure of OWNS_MEMBERS collection
+    # members (ahead of the collection / the member ADD). A game client wants
+    # this — units arrive render-ready; a narrow utility (enu_mcp) doesn't, and
+    # deep-fetches the few things it touches. Explicit per subscription for now;
+    # the default may later defer to a per-object preference (an EdFlags bit),
+    # making it tri-state.
+    deep*: bool
     interest*: HashSet[string]
+    # Per-key interest (LAZY tables): object_id -> serialized keys this
+    # subscriber has requested. A requested key streams its future ops — even
+    # one that was missing at request time (an empty-space voxel chunk someone
+    # later builds in). RELEASE retracts. Orthogonal to `interest`: a table in
+    # `interest` streams *all* its keys.
+    key_interest*: Table[string, HashSet[string]]
     # Capability filter: the set of container type-ids this subscriber can
     # materialize (its registered `type_initializers`). The authority skips any
     # object whose `type_id` isn't here, so a peer never receives an object it
@@ -193,6 +233,23 @@ type
       last_sent_time*: float64
     else:
       discard
+
+  FetchState* = enum
+    ## Where a `fetch` stands. Resolves on a later tick (the request round-trip).
+    Pending   ## request sent; no answer yet
+    Found     ## the object (or, for a deep owner fetch, its closure) arrived
+    NotFound  ## the authority answered NOT_FOUND — it didn't exist *at fetch
+              ## time*. With `follow` (the default) it still arrives later if
+              ## something creates it; the handle stays NotFound either way.
+
+  Fetch* = ref object
+    ## Handle returned by `fetch`. Watch `state`; once `Found`, `obj` links the
+    ## container — except for a deep fetch of an *owner* id (a unit), which has
+    ## no container of its own: state resolves via its arriving closure and
+    ## `obj` stays nil.
+    id*: string
+    state*: FetchState
+    obj*: ref EdBase
 
   EdContext* = ref object
     ## Central coordination object managing `Ed` container lifecycle, subscriptions,
@@ -225,6 +282,23 @@ type
     # keys). A frame's worth of request() calls collapse into one REQUEST per
     # table, flushed on the next tick.
     pending_key_requests*: Table[string, seq[string]]
+    # Per-key releases buffered between ticks, mirroring pending_key_requests:
+    # one RELEASE per table per tick. Broadcast to all peers — upstream reads it
+    # as an interest retract, downstream as an eviction notice.
+    pending_key_releases*: Table[string, seq[string]]
+    # Contexts we subscribed *to* (our data sources). An eviction notice
+    # (RELEASE) is honored only when it arrives from upstream — we are a clone
+    # of that context, so a key it dropped is gone for us too. This is how
+    # partiality inherits down a clone chain (a full clone of a full source
+    # never receives one); the authority has no upstream and terminates.
+    upstream_ctx_ids*: HashSet[string]
+    # This context subscribed partial somewhere: it holds data on demand, not
+    # by contract. Gates hub shedding — a partial hub that retracts the last
+    # downstream interest in a key drops its own copy and chains the release
+    # upstream; a *full* clone never sheds (it wants everything).
+    partial_replica*: bool
+    # Objects we've already logged a dropped-op notice for (once per id).
+    warned_missing*: HashSet[string]
     changed_callback_eid: EID
     last_id: int
     close_procs: Table[EID, proc() {.gcsafe.}]
@@ -236,6 +310,17 @@ type
     # (`destroy_owned`) in *any* context — including one that didn't construct it
     # (e.g. the server cleaning up an MCP-created bot after the client drops).
     owned_by*: Table[string, HashSet[string]]
+    # In-flight fetches by id; resolved (Found/NotFound) as answers arrive, then
+    # removed. Re-fetching after a NotFound mints a fresh handle.
+    fetches*: Table[string, Fetch]
+    # Request chaining (hubs): wants we couldn't serve locally, forwarded
+    # upstream and remembered here. Served when the data arrives; NACK-relayed
+    # when the upstream answers NOT_FOUND. The authority never forwards — a
+    # miss there is a real NOT_FOUND.
+    pending_obj_wants*:
+      Table[string, seq[tuple[sub: Subscription, deep: bool, follow: bool]]]
+    # object_id -> key_bin -> waiting subscribers (per-key table requests).
+    pending_key_wants*: Table[string, Table[string, seq[Subscription]]]
     ref_pool: Table[string, CountedRef]
     subscribers*: seq[Subscription]
     chan: Chan[Message]
@@ -295,7 +380,10 @@ type
     ): Message {.gcsafe.}
 
     publish_create: proc(
-      sub = Subscription(), broadcast = false, op_ctx = OperationContext()
+      sub = Subscription(),
+      broadcast = false,
+      op_ctx = OperationContext(),
+      contents = true, # false = handle only (empty-body CREATE; LAZY push)
     ) {.gcsafe.}
 
     change_receiver:
@@ -304,11 +392,23 @@ type
     # Per-key fetch (partial EdTable). Given a serialized key, build the ADD op
     # carrying that key's current value, so a partial subscriber can pull one
     # entry without the whole table. `found = false` if the key isn't present.
-    # nil for non-table containers.
+    # `nested` lists Ed containers inside the value (a chunk's delta seq) — the
+    # server publishes those *before* the entry so the receiver links them
+    # (per-key deep, one round trip). nil for non-table containers.
     publish_key:
-      proc(self: ref EdBase, key_bin: string): tuple[found: bool, msg: Message] {.
-        gcsafe
-      .}
+      proc(
+        self: ref EdBase, key_bin: string
+      ): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.}
+
+    # Per-key eviction (paging). Given a serialized key, drop the entry locally
+    # — fires REMOVED callbacks, no publish — and report whether it was present
+    # plus the ids of Ed containers nested in its value (so the caller can shed
+    # interest / relay them). The local half of `release` and the receiving half
+    # of a RELEASE eviction notice. nil for non-table containers.
+    evict_key:
+      proc(
+        self: ref EdBase, key_bin: string
+      ): tuple[found: bool, nested: seq[string]] {.gcsafe.}
 
     # Back-reference to the owning context. `{.cursor.}` (non-owning): the
     # context owns its objects via `objects*` (a strong OrderedTable), so this
@@ -488,6 +588,7 @@ proc to_flatty*(s: var string, msg: Message) =
   s.to_flatty msg.origin
   s.to_flatty msg.delta
   s.to_flatty msg.deep
+  s.to_flatty msg.follow
   when defined(ed_trace):
     s.to_flatty msg.trace
     s.to_flatty msg.id
@@ -511,6 +612,7 @@ proc from_flatty*(s: string, i: var int, msg: var Message) =
   s.from_flatty(i, msg.origin)
   s.from_flatty(i, msg.delta)
   s.from_flatty(i, msg.deep)
+  s.from_flatty(i, msg.follow)
   when defined(ed_trace):
     s.from_flatty(i, msg.trace)
     s.from_flatty(i, msg.id)

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -149,6 +149,13 @@ proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =
   result = Ed[T, O](self.objects[src.id])
 
 proc `[]`*(self: EdContext, id: string): ref EdBase =
+  ## Container lookup by id. Raises `KeyError` when absent — except inside a
+  ## `blocking` scope, where an unknown id is fetched from the authority and
+  ## waited for (bounded, silent pump); a NOT_FOUND NACK fails fast. Still
+  ## absent afterwards → `KeyError` as usual. A destroyed-but-unswept id keeps
+  ## its old behavior (returns nil) and doesn't trigger a fetch.
+  if self.blocking and self.materialize != nil and id notin self.objects:
+    self.materialize(self, id)
   result = self.objects[id]
 
 proc len*(self: Chan): int =

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -12,6 +12,27 @@ var initialized = false
 proc ctx(): EdContext =
   Ed.thread_ctx
 
+proc relay_fill*[T, O](item: Ed[T, O], op_ctx: OperationContext) =
+  ## Re-broadcast a just-filled placeholder to our own subscribers: they hold
+  ## the same id as a placeholder (minted from the same inline ref), and the
+  ## relayed CREATE fills theirs and clears their flag — `loaded` then means
+  ## the same thing on every hop. Exported because the generated type
+  ## initializer expands at the `Ed.bootstrap` call site, where the private
+  ## `publish_create` field isn't reachable.
+  privileged
+  # The immediate fill runs inside the receive path's owner scope
+  # (`msg.owner_id.own:`), but the placeholder was minted ownerless and the
+  # post-materialize stamp hasn't run yet — stamp before relaying, or second
+  # hops receive the fill unowned (same window as the create-relay fix). The
+  # deferred (subscribe-time) fill runs after the stamp, so `owner_id` is
+  # already set there and `current_owner_id` is empty — both paths covered.
+  if current_owner_id.len > 0 and item.owner_id != current_owner_id:
+    item.owner_id = current_owner_id
+    item.ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(
+      item.id
+    )
+  item.publish_create(broadcast = true, op_ctx = op_ctx)
+
 proc create_initializer[T, O](self: Ed[T, O]) =
   const ed_type_id = self.type.tid
 
@@ -34,10 +55,13 @@ proc create_initializer[T, O](self: Ed[T, O]) =
             debug "restoring received object", id
             var value = bin.from_flatty(T, ctx)
             let item = Ed[T, O](ctx[id])
-            ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+            let was_placeholder = item.placeholder
+            ctx.filling = was_placeholder # fill of a placeholder → tag Fill
             item.placeholder = false # fill: real state arrived
             `value=`(item, value, op_ctx = op_ctx)
             ctx.filling = false
+            if was_placeholder:
+              relay_fill(item, op_ctx)
           else:
             if id notin ctx:
               discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
@@ -47,17 +71,28 @@ proc create_initializer[T, O](self: Ed[T, O]) =
               {.gcsafe.}:
                 let value = bin.from_flatty(T, ctx)
               let item = Ed[T, O](ctx[id])
-              ctx.filling = item.placeholder # fill of a placeholder → tag Fill
+              let was_placeholder = item.placeholder
+              ctx.filling = was_placeholder # fill of a placeholder → tag Fill
               item.placeholder = false # fill: real state arrived
               `value=`(item, value, op_ctx = op_ctx)
               ctx.filling = false
+              if was_placeholder:
+                relay_fill(item, op_ctx)
             ctx.value_initializers.add(initializer)
         elif id notin ctx:
           discard Ed[T, O].init(ctx = ctx, id = id, flags = flags, op_ctx)
+          if LAZY in flags:
+            # A LAZY container's empty-body CREATE is a *handle*, not a fill:
+            # contents arrive per-key (request/release). Placeholder keeps
+            # `loaded` false; touch skips LAZY, so reads never materialize the
+            # whole table by accident.
+            Ed[T, O](ctx[id]).placeholder = true
         else:
           # Empty-body CREATE for an object we were holding as a placeholder:
-          # it exists for real now, just with no value yet.
-          Ed[T, O](ctx[id]).placeholder = false
+          # it exists for real now, just with no value yet. LAZY excepted — its
+          # empty-body CREATE is a handle push and says nothing about contents.
+          if LAZY notin flags:
+            Ed[T, O](ctx[id]).placeholder = false
 
 proc defaults[T, O](
     self: Ed[T, O],
@@ -100,13 +135,19 @@ proc defaults[T, O](
       ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(self.id)
 
   self.publish_create = proc(
-      sub: Subscription, broadcast: bool, op_ctx = OperationContext()
+      sub: Subscription,
+      broadcast: bool,
+      op_ctx = OperationContext(),
+      contents = true,
   ) =
     log_defaults "ed publishing"
     trace "publish_create", sub
 
     {.gcsafe.}:
-      let bin = self.tracked.to_flatty
+      # `contents = false` sends a handle: an empty-body CREATE (id + flags,
+      # no data). Used to push LAZY containers to partial subscribers — the
+      # receiver registers a placeholder and pulls entries per-key.
+      let bin = if contents: self.tracked.to_flatty else: ""
     let id = self.id
     let owner_id = self.owner_id
     let flags = self.flags
@@ -156,6 +197,11 @@ proc defaults[T, O](
     assert ADDED in change.changes or REMOVED in change.changes or
       TOUCHED in change.changes
     let change = Change[O](change)
+    when change.item is Pair:
+      # Sender-side per-key filter tag (LAZY tables / key interest) — blanked
+      # from the remote body, so it costs nothing on the wire.
+      {.gcsafe.}:
+        msg.key_bin = change.item.key.to_flatty
     when change.item is Ed:
       msg.change_object_id = change.item.id
     elif change.item is Pair[auto, Ed]:
@@ -267,9 +313,12 @@ proc defaults[T, O](
 
   self.publish_key = proc(
       self: ref EdBase, key_bin: string
-  ): tuple[found: bool, msg: Message] {.gcsafe.} =
+  ): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.} =
     # Per-key fetch: build the ADD op for one entry so a partial subscriber can
-    # pull it without the whole table. Only meaningful for table containers.
+    # pull it without the whole table. `nested` carries the ids of Ed
+    # containers inside the value (a chunk's delta seq) so the caller can
+    # publish them ahead of the entry — per-key deep. Only meaningful for
+    # table containers.
     when O is Pair:
       let self = Ed[T, O](self)
       type K = generic_params(O.default.type).get(0)
@@ -277,8 +326,52 @@ proc defaults[T, O](
         let key = key_bin.from_flatty(K, self.ctx)
       if key in self.tracked:
         let pair = O(key: key, value: self.tracked[key])
+        var nested: seq[string]
+        when pair.value is Ed:
+          if ?pair.value:
+            nested.add pair.value.id
+        elif pair.value is ref:
+          if ?pair.value:
+            for _, field in pair.value[].field_pairs:
+              when field is Ed:
+                if ?field:
+                  nested.add field.id
         let change = Change[O](changes: {ADDED}, item: pair)
-        result = (found: true, msg: self.build_message(self, change, self.id, ""))
+        result = (
+          found: true,
+          msg: self.build_message(self, change, self.id, ""),
+          nested: nested,
+        )
+    else:
+      discard
+
+  self.evict_key = proc(
+      self: ref EdBase, key_bin: string
+  ): tuple[found: bool, nested: seq[string]] {.gcsafe.} =
+    # Per-key eviction: drop the entry locally (REMOVED callbacks fire so
+    # watchers un-render; nothing publishes — the authority keeps the data) and
+    # report nested Ed containers so the caller can shed them. The local half
+    # of `release` and the receiving half of an eviction notice.
+    when O is Pair:
+      let self = Ed[T, O](self)
+      type K = generic_params(O.default.type).get(0)
+      {.gcsafe.}:
+        let key = key_bin.from_flatty(K, self.ctx)
+      if key in self.tracked:
+        let pair = O(key: key, value: self.tracked[key])
+        var nested: seq[string]
+        when pair.value is Ed:
+          if ?pair.value:
+            nested.add pair.value.id
+        elif pair.value is ref:
+          if ?pair.value:
+            for _, field in pair.value[].field_pairs:
+              when field is Ed:
+                if ?field:
+                  nested.add field.id
+        self.tracked.del key
+        self.trigger_callbacks(@[Change[O](changes: {REMOVED}, item: pair)])
+        result = (found: true, nested: nested)
     else:
       discard
 

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -69,7 +69,9 @@ template touch_placeholder(self: untyped) =
   ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
   ## context to materialize it (kick a fetch; block until filled when
   ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
-  if self.placeholder and self.ctx.materialize != nil:
+  ## LAZY containers are exempt: they're pull-only by design — entries arrive
+  ## per-key (`request`), so reading one must never materialize the whole table.
+  if self.placeholder and LAZY notin self.flags and self.ctx.materialize != nil:
     self.ctx.materialize(self.ctx, self.id)
 
 proc value*[T, O](self: Ed[T, O]): T =
@@ -107,15 +109,19 @@ proc request*[K, V](self: EdTable[K, V], keys: openArray[K]) =
     self.request(key)
 
 proc release*[K, V](self: EdTable[K, V], key: K) =
-  ## Drop a locally-materialized entry to free memory (eviction). Local only —
-  ## fires a REMOVED change (so watches un-render) but does NOT delete on the
-  ## authority; `request(key)` re-fetches it. No-op if not loaded.
+  ## Drop a locally-materialized entry to free memory (paging out). Never
+  ## deletes on the authority; `request(key)` re-fetches. Three effects:
+  ## evict locally (REMOVED fires, watches un-render), retract our per-key
+  ## interest upstream (ops for this key stop flowing), and notify downstream
+  ## clones so they evict too — all via one batched RELEASE on the next tick.
+  ## Also retracts a pending interest in a key that never loaded (a requested
+  ## empty-space chunk).
   privileged
   assert self.valid
+  let key_bin = key.to_flatty
   if key in self.tracked:
-    let pair = Pair[K, V](key: key, value: self.tracked[key])
-    self.tracked.del key
-    self.trigger_callbacks(@[Change[Pair[K, V]](changes: {REMOVED}, item: pair)])
+    discard self.evict_key(self, key_bin)
+  self.ctx.pending_key_releases.mgetOrPut(self.id, @[]).add key_bin
 
 proc release*[K, V](self: EdTable[K, V], keys: openArray[K]) =
   for key in keys:
@@ -339,32 +345,62 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
   self.ctx.objects[self.id] = nil
   self.ctx.objects_need_packing = true
   self.ctx.latest_op_id.del(self.id)  # drop own-op reconciliation state
-  # Keep the ownership index tidy: drop ourselves from our owner's owned-set.
+  # Keep the ownership index tidy: drop ourselves from our owner's owned-set,
+  # and drop any member index keyed under our own id (an ownerless OWNS_MEMBERS
+  # collection indexes its members that way).
   if self.owner_id.len > 0 and self.owner_id in self.ctx.owned_by:
     self.ctx.owned_by[self.owner_id].excl(self.id)
+  if self.id in self.ctx.owned_by:
+    self.ctx.owned_by.del(self.id)
 
   if publish:
     self.publish_destroy OperationContext(source: [self.ctx.id].toHashSet)
 
+method destroy*(self: EdRef) {.base, gcsafe.}
+  # Forward declaration: destroy_owned cascades into owned members through it.
+
 proc destroy_owned*(ctx: EdContext, owner_id: string) =
-  ## Destroy every container owned by `owner_id` (per the `owned_by` index): each
-  ## fires its CLOSED, drops from `ctx.objects`, and broadcasts DESTROY so
-  ## replicas tear down their mirrors. Works in *any* context — including one that
-  ## didn't construct the object — because ownership is synced (the containers'
-  ## `owner_id`), not derived from the constructing context. The owner's
-  ## `lifetime.finish` handles its callbacks separately. The objects are
-  ## type-erased here (`ref EdBase`), so we destroy via each one's
-  ## `change_receiver` (the same path a received DESTROY takes).
+  ## Destroy everything owned by `owner_id` (per the `owned_by` index). Two
+  ## passes: first owned EdRef *members* (an OWNS_MEMBERS collection's children)
+  ## — cascaded through their `destroy` method while the containers they unlink
+  ## themselves from are still alive — then the owned containers, each firing
+  ## its CLOSED, dropping from `ctx.objects`, and broadcasting DESTROY so
+  ## replicas tear down their mirrors. Works in *any* context — including one
+  ## that didn't construct the object — because ownership is synced, not derived
+  ## from the constructing context. The owner's `lifetime.finish` handles its
+  ## callbacks separately. Containers are type-erased here (`ref EdBase`), so
+  ## they're destroyed via their `change_receiver` (the same path a received
+  ## DESTROY takes); members are ref_pool keys, dispatched via `EdRef.destroy`.
+  privileged
   private_access EdBase
+  ctx.prune_dead_refs() # cursor safety before reading ref_pool entries
   if owner_id in ctx.owned_by:
     # Snapshot: each destroy excls itself from the set we're iterating.
     let owned = ctx.owned_by[owner_id]
+    for id in owned:
+      if id notin ctx.objects and id in ctx.ref_pool:
+        let member = ctx.ref_pool[id].obj
+        if not member.is_nil and member of EdRef and not EdRef(member).destroyed:
+          EdRef(member).destroy()
     for id in owned:
       if id in ctx.objects and ?ctx.objects[id]:
         let obj = ctx.objects[id]
         if not obj.change_receiver.is_nil:
           obj.change_receiver(obj, Message(kind: DESTROY), OperationContext())
     ctx.owned_by.del(owner_id)
+
+method destroy*(self: EdRef) {.base, gcsafe.} =
+  ## Generic teardown for a registered ref: finish its callback lifetime, tear
+  ## down everything it owns — containers, and owned members recursively — then
+  ## latch `destroyed`. Subclasses override with their type-specific cleanup and
+  ## call this last (enu: unlink from the parent, clear globals, then here).
+  ## Deliberately unguarded: an overriding destroy latches `destroyed` at its
+  ## *top* (removal watchers re-enter synchronously) and still needs this body
+  ## to run afterwards.
+  if not self.lifetime.is_nil:
+    self.lifetime.finish()
+  Ed.thread_ctx.destroy_owned(self.id)
+  self.destroyed = true
 
 iterator items*[T](self: EdSet[T] | EdSeq[T]): T =
   privileged

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -509,7 +509,6 @@ proc run*() =
   test "sync":
     type
       Thing = ref object of EdRef
-        id: string
 
       Tree = ref object
         zen: EdValue[string]
@@ -616,12 +615,11 @@ proc run*() =
     type Unit = ref object of EdRef
       units: EdSeq[Unit]
       code: EdValue[string]
-      id: int
 
     Ed.register(Unit, false)
     local_and_remote:
-      var u1 = Unit(id: 1)
-      var u2 = Unit(id: 2)
+      var u1 = Unit(id: "1")
+      var u2 = Unit(id: "2")
       u1.init_ed_fields
       u2.init_ed_fields
       ctx2.tick
@@ -634,7 +632,6 @@ proc run*() =
 
   test "zentable of tables":
     type Shared = ref object of EdRef
-      id: string
       edits: EdTable[int, Table[string, string]]
 
     Ed.register(Shared, false)
@@ -700,7 +697,6 @@ proc run*() =
     # its RefHandle.=destroy clears the ref_pool entry. The registered type must
     # inherit EdRef to carry that handle. See docs/step4-body-protocol-sketch.md.
     type RefType = ref object of EdRef
-      id: string
 
     Ed.register(RefType, false)
 
@@ -803,7 +799,6 @@ proc run*() =
   test "object with registered ref":
     type
       RefType2 = ref object of EdRef
-        id: string
 
       RefType3 = ref object of RefType2
 
@@ -835,7 +830,6 @@ proc run*() =
         Highlighted
 
       SyncUnit = ref object of EdRef
-        id: int
         parent: SyncUnit
         units: EdSeq[SyncUnit]
 
@@ -851,8 +845,8 @@ proc run*() =
 
       ctx2.tick
       var dest = State.init_from(src, ctx = ctx2)
-      var src_change_id = 0
-      var dest_change_id = 0
+      var src_change_id = ""
+      var dest_change_id = ""
 
       src.units.changes:
         var change = change
@@ -866,29 +860,29 @@ proc run*() =
           change = Change[SyncUnit](change.triggered_by[0])
         dest_change_id = change.item.id
 
-      let base = SyncUnit(id: 1).init_ed_fields(flags = flags)
+      let base = SyncUnit(id: "1").init_ed_fields(flags = flags)
       src.units.add base
       ctx2.tick
 
-      let child = SyncUnit(id: 3).init_ed_fields(flags = flags)
+      let child = SyncUnit(id: "3").init_ed_fields(flags = flags)
       ctx2.tick
-      src_change_id = 0
-      dest_change_id = 0
+      src_change_id = ""
+      dest_change_id = ""
       base.units.add child
 
       ctx2.tick
-      check src_change_id == 3
-      check dest_change_id == 3
+      check src_change_id == "3"
+      check dest_change_id == "3"
 
       Ed.thread_ctx = ctx2
       let grandchild =
-        SyncUnit(id: 4).init_ed_fields(ctx = ctx2, flags = flags)
+        SyncUnit(id: "4").init_ed_fields(ctx = ctx2, flags = flags)
 
       dest.units[0].units.add grandchild
 
       ctx1.tick
-      check src_change_id == 4
-      check dest_change_id == 4
+      check src_change_id == "4"
+      check dest_change_id == "4"
 
 when is_main_module:
   Ed.bootstrap

--- a/tests/error_handling_tests.nim
+++ b/tests/error_handling_tests.nim
@@ -24,7 +24,6 @@ proc run*() =
     var ctx = EdContext.init(id = "ref_ctx")
 
     type RefObject = ref object of EdRef
-      id: string
       data: int
 
     Ed.register(RefObject, false)
@@ -50,11 +49,9 @@ proc run*() =
 
     type
       NodeA = ref object of EdRef
-        id: string
         b_ref: EdValue[NodeB]
 
       NodeB = ref object of EdRef
-        id: string
         a_ref: EdValue[NodeA]
 
     Ed.register(NodeA, false)

--- a/tests/lifetime_tests.nim
+++ b/tests/lifetime_tests.nim
@@ -3,9 +3,9 @@ import ed
 import ed/zens/contexts
 
 type OwnerTest = ref object of EdRef
-  id: string
   items: EdSeq[int]
   val: EdValue[int]
+  kids: EdSeq[OwnerTest]
 
 proc run*() =
   suite "lifetime":
@@ -184,3 +184,57 @@ proc run*() =
 
       ctx3.destroy_owned("relay_bot")
       check "relay_items" notin ctx3
+
+    test "EdRef destroy: lifetime, owned containers, destroyed latch":
+      var ctx = EdContext.init(id = "rd_ctx")
+      Ed.thread_ctx = ctx
+      var external = EdValue[int].init(ctx = ctx, id = "rd_ext")
+      var owner = OwnerTest(id: "rd_owner")
+      var fired = 0
+      owner.own:
+        owner.items = EdSeq[int].init(ctx = ctx, id = "rd_items")
+        external.track proc(changes: seq[Change[int]]) {.gcsafe.} =
+          fired.inc
+
+      external.value = 1
+      check fired > 0
+
+      owner.destroy() # the ed-generic teardown
+      check owner.destroyed
+      check "rd_items" notin ctx # owned containers gone
+      let after = fired
+      external.value = 2
+      check fired == after # lifetime finished → callback untracked
+
+    test "OWNS_MEMBERS: destroying the owner cascades into members":
+      var ctx = EdContext.init(id = "om_ctx")
+      Ed.thread_ctx = ctx
+      var child = OwnerTest(id: "om_child")
+      child.own:
+        child.items = EdSeq[int].init(ctx = ctx, id = "om_child_items")
+      var parent = OwnerTest(id: "om_parent")
+      parent.own:
+        parent.kids = EdSeq[OwnerTest].init(
+          ctx = ctx, id = "om_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+        )
+      parent.kids.add child # membership → owned by parent
+
+      parent.destroy()
+      check child.destroyed # member cascaded via the destroy method
+      check "om_child_items" notin ctx # ...including the child's own containers
+      check "om_kids" notin ctx # parent's container destroyed too
+
+    test "OWNS_MEMBERS: a removed member is not cascaded":
+      var ctx = EdContext.init(id = "om_ctx2")
+      Ed.thread_ctx = ctx
+      var child = OwnerTest(id: "om2_child")
+      var parent = OwnerTest(id: "om2_parent")
+      parent.own:
+        parent.kids = EdSeq[OwnerTest].init(
+          ctx = ctx, id = "om2_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+        )
+      parent.kids.add child
+      parent.kids -= child # removal un-registers from the owned index
+
+      parent.destroy()
+      check not child.destroyed # independently-removed member untouched

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -34,7 +34,7 @@ proc run*() =
       var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
 
       # Client is interested only in the parent, not its children.
-      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.subscribe(authority, partial = true, fetch = ["parent"])
       client.tick()
       check "parent" in client
 
@@ -62,7 +62,7 @@ proc run*() =
       var authority = EdContext.init(id = "ma_auth", is_authority = true)
       var client = EdContext.init(id = "ma_client")
       var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
-      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.subscribe(authority, partial = true, fetch = ["parent"])
       client.tick()
 
       var child = EdValue[string].init(ctx = authority, id = "child")
@@ -83,7 +83,7 @@ proc run*() =
       var authority = EdContext.init(id = "mf_auth", is_authority = true)
       var client = EdContext.init(id = "mf_client")
       var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
-      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.subscribe(authority, partial = true, fetch = ["parent"])
       client.tick()
       var child = EdValue[string].init(ctx = authority, id = "child")
       child.value = "hi"
@@ -108,7 +108,7 @@ proc run*() =
       var client = EdContext.init(id = "ms_client")
       var parent = EdSeq[EdValue[string]].init(ctx = authority, id = "parent")
       var other = EdValue[int].init(ctx = authority, id = "other")
-      client.subscribe(authority, partial = true, roots = @["parent", "other"])
+      client.subscribe(authority, partial = true, fetch = ["parent", "other"])
       client.tick()
 
       var child = EdValue[string].init(ctx = authority, id = "child")
@@ -162,7 +162,7 @@ proc run*() =
 
       var client = EdContext.init(id = "rmat-client")
       # Partial subscribe over the network: interested only in the parent.
-      client.subscribe(address, partial = true, roots = @["parent"])
+      client.subscribe(address, partial = true, fetch = ["parent"])
 
       # The pre-populated parent arrives; its out-of-interest child is a
       # placeholder (created in from_flatty). Wait briefly for it (UDP).
@@ -196,7 +196,7 @@ proc run*() =
       child[3] = "three"
       parent += child
 
-      client.subscribe(authority, partial = true, roots = @["parent"])
+      client.subscribe(authority, partial = true, fetch = ["parent"])
       client.tick()
       let table = EdTable[int, string](client["child"])
       check "child" in client

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -24,7 +24,6 @@ proc run*() =
     var ctx = EdContext.init(id = "ref_ctx")
     
     type RefObject = ref object of EdRef
-      id: string
       data: int
       
     Ed.register(RefObject, false)
@@ -50,11 +49,9 @@ proc run*() =
     
     type
       NodeA = ref object of EdRef
-        id: string
         b_ref: EdValue[NodeB]
 
       NodeB = ref object of EdRef
-        id: string
         a_ref: EdValue[NodeA]
     
     Ed.register(NodeA, false)

--- a/tests/object_tests_types.nim
+++ b/tests/object_tests_types.nim
@@ -4,7 +4,6 @@ type
   ZenString* = EdValue[string]
 
   Beep* = ref object of EdRef
-    id*: string
     name_value*: EdValue[string]
 
   Boop* = ref object of Beep

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -1,14 +1,84 @@
-import std/[unittest, sets, tables]
+import std/[unittest, sets, tables, times, monotimes]
 import ed
 import ed/zens/contexts
 
 type DeepOwner = ref object of EdRef
-  id: string
   items: EdSeq[int]
   val: EdValue[int]
 
 proc run*() =
+  Ed.register(DeepOwner, false)
+
   suite "partial replicas":
+    test "OWNS_MEMBERS member closures push to partial subscribers, in order":
+      var authority = EdContext.init(id = "omp_auth", is_authority = true)
+      var client = EdContext.init(id = "omp_client")
+      Ed.thread_ctx = authority
+
+      var u1 = DeepOwner(id: "omp_u1")
+      u1.own:
+        u1.items = EdSeq[int].init(ctx = authority, id = "omp_u1_items")
+      u1.items.add 5
+      var units = EdSeq[DeepOwner].init(
+        ctx = authority, id = "omp_units", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+      )
+      units.add u1
+
+      # The subscribe pushes u1's closure ahead of the collection: the client's
+      # parse links the member's fields to real containers - no husks.
+      client.subscribe(
+        authority, partial = true, fetch = ["omp_units"], deep = true
+      )
+      client.tick()
+      check "omp_u1_items" in client
+      let m1 = EdSeq[DeepOwner](client["omp_units"])[0]
+      check m1.items.len == 1
+      check m1.items[0] == 5
+
+      # A member added later: its closure precedes the ADD too.
+      var u2 = DeepOwner(id: "omp_u2")
+      u2.own:
+        u2.items = EdSeq[int].init(ctx = authority, id = "omp_u2_items")
+      u2.items.add 6
+      units.add u2
+      client.tick()
+      check "omp_u2_items" in client
+      let m2 = EdSeq[DeepOwner](client["omp_units"])[1]
+      check m2.items.len == 1
+      check m2.items[0] == 6
+
+      # The closure joined the interest set: members keep syncing.
+      u2.items.add 7
+      client.tick()
+      check m2.items.len == 2
+
+    test "deep = false (default): no member closures, fetch what you touch":
+      var authority = EdContext.init(id = "omd_auth", is_authority = true)
+      var client = EdContext.init(id = "omd_client")
+      Ed.thread_ctx = authority
+
+      var u1 = DeepOwner(id: "omd_u1")
+      u1.own:
+        u1.items = EdSeq[int].init(ctx = authority, id = "omd_u1_items")
+      var units = EdSeq[DeepOwner].init(
+        ctx = authority, id = "omd_units", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+      )
+      units.add u1
+
+      # Narrow subscriber (an enu_mcp-style utility): the directory arrives,
+      # the members' closures don't.
+      client.subscribe(authority, partial = true, fetch = ["omd_units"])
+      client.tick()
+      check "omd_units" in client
+      # The member's container arrives only as a placeholder stand-in (the
+      # inline reference mints one) — its value was not pushed.
+      check not client["omd_u1_items"].loaded
+
+      # It pulls what it touches, explicitly.
+      client.fetch("omd_u1", deep = true)
+      authority.tick()
+      client.tick()
+      check client["omd_u1_items"].loaded
     test "partial subscriber only receives its interest set":
       var authority = EdContext.init(id = "p_authority", is_authority = true)
       var client = EdContext.init(id = "p_client")
@@ -19,7 +89,7 @@ proc run*() =
       y.value = 2
 
       # Interested only in obj_x.
-      client.subscribe(authority, partial = true, roots = @["obj_x"])
+      client.subscribe(authority, partial = true, fetch = ["obj_x"])
       client.tick()
 
       check "obj_x" in client # pushed (in interest)
@@ -42,7 +112,7 @@ proc run*() =
       x.value = 1
       y.value = 2
 
-      client.subscribe(authority, partial = true, roots = @["f_x"])
+      client.subscribe(authority, partial = true, fetch = ["f_x"])
       client.tick()
       check "f_y" notin client
 
@@ -58,6 +128,443 @@ proc run*() =
       client.tick()
       check EdValue[int](client["f_y"]).value == 20
 
+    test "fetch returns a handle that resolves Found with the object":
+      var authority = EdContext.init(id = "fh_auth", is_authority = true)
+      var client = EdContext.init(id = "fh_client")
+      var x = EdValue[int].init(ctx = authority, id = "fh_x")
+      x.value = 4
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+
+      let handle = client.fetch("fh_x")
+      check handle.state == Pending
+      authority.tick()
+      client.tick()
+      check handle.state == Found
+      check handle.obj == client["fh_x"]
+
+    test "fetching a missing id resolves NotFound (authority NACK)":
+      var authority = EdContext.init(id = "nf_auth", is_authority = true)
+      var client = EdContext.init(id = "nf_client")
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+
+      let handle = client.fetch("does_not_exist", follow = false)
+      check handle.state == Pending
+      authority.tick()
+      client.tick()
+      check handle.state == NotFound
+      check "does_not_exist" notin client
+
+    test "follow (default): a missing fetch is delivered when created later":
+      var authority = EdContext.init(id = "fl_auth", is_authority = true)
+      var client = EdContext.init(id = "fl_client")
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+
+      let handle = client.fetch("late_obj")
+      authority.tick()
+      client.tick()
+      check handle.state == NotFound # didn't exist at fetch time...
+
+      var late = EdValue[int].init(ctx = authority, id = "late_obj")
+      late.value = 9
+      client.tick()
+      check "late_obj" in client # ...but the kept interest delivered it
+      check EdValue[int](client["late_obj"]).value == 9
+
+    test "follow = false: snapshot only — no future ops, no late delivery":
+      var authority = EdContext.init(id = "sn_auth", is_authority = true)
+      var client = EdContext.init(id = "sn_client")
+      var snap = EdValue[int].init(ctx = authority, id = "snap_x")
+      snap.value = 1
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+
+      let handle = client.fetch("snap_x", follow = false)
+      authority.tick()
+      client.tick()
+      check handle.state == Found
+      check EdValue[int](client["snap_x"]).value == 1
+
+      snap.value = 2
+      client.tick()
+      check EdValue[int](client["snap_x"]).value == 1 # frozen: no interest
+
+      let missing = client.fetch("snap_later", follow = false)
+      authority.tick()
+      client.tick()
+      check missing.state == NotFound
+      var later = EdValue[int].init(ctx = authority, id = "snap_later")
+      later.value = 3
+      client.tick()
+      check "snap_later" notin client # never arrives without follow
+
+    test "blocking ctx[] pulls an unknown id; a NACK fails fast":
+      var authority = EdContext.init(id = "bk_auth", is_authority = true)
+      var client = EdContext.init(id = "bk_client")
+      var x = EdValue[int].init(ctx = authority, id = "bk_x")
+      x.value = 7
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      check "bk_x" notin client
+
+      # Single-threaded choreography: queue the answer into the client's channel
+      # first; the blocking read's pump then drains it (the fetch dedups onto
+      # the in-flight handle rather than re-sending).
+      discard client.fetch("bk_x")
+      authority.tick()
+      var got: ref EdBase
+      client.blocking:
+        got = client["bk_x"]
+      check EdValue[int](got).value == 7
+
+      # Unknown id: the NACK resolves the blocking wait promptly (KeyError),
+      # well inside the pump's safety deadline.
+      discard client.fetch("bk_missing", follow = false)
+      authority.tick()
+      let started = get_mono_time()
+      expect KeyError:
+        client.blocking:
+          discard client["bk_missing"]
+      check get_mono_time() - started < init_duration(seconds = 2)
+
+    test "request chaining: a hub forwards a miss and relays the answer":
+      var a = EdContext.init(id = "ch_auth", is_authority = true)
+      var b = EdContext.init(id = "ch_hub")
+      var c = EdContext.init(id = "ch_leaf")
+      var x = EdValue[int].init(ctx = a, id = "ch_x")
+      x.value = 11
+      b.subscribe(a, partial = true, fetch = [])
+      b.tick()
+      c.subscribe(b, partial = true, fetch = [])
+      c.tick()
+      check "ch_x" notin b # the hub doesn't have it either
+
+      let handle = c.fetch("ch_x")
+      b.tick() # hub: miss -> remembers the want, forwards upstream
+      a.tick() # authority serves the hub
+      b.tick() # hub materializes, serves the waiting leaf
+      c.tick() # leaf receives
+      check handle.state == Found
+      check EdValue[int](c["ch_x"]).value == 11
+      check "ch_x" in b # the hub holds it now too
+
+    test "request chaining: an authority miss NACKs back down the chain":
+      var a = EdContext.init(id = "chn_auth", is_authority = true)
+      var b = EdContext.init(id = "chn_hub")
+      var c = EdContext.init(id = "chn_leaf")
+      b.subscribe(a, partial = true, fetch = [])
+      b.tick()
+      c.subscribe(b, partial = true, fetch = [])
+      c.tick()
+
+      let handle = c.fetch("chn_missing", follow = false)
+      b.tick() # forward
+      a.tick() # authority: real miss -> NOT_FOUND
+      b.tick() # relay to the waiter
+      c.tick()
+      check handle.state == NotFound
+
+    test "request chaining: per-key through a placeholder hub":
+      var a = EdContext.init(id = "chk_auth", is_authority = true)
+      var b = EdContext.init(id = "chk_hub")
+      var c = EdContext.init(id = "chk_leaf")
+      var tbl = EdTable[int, string].init(ctx = a, id = "chk_tbl")
+      tbl[1] = "one"
+      var parent = EdSeq[EdValue[string]].init(ctx = a, id = "chk_parent")
+      # Reference the table indirectly so partial subscribers mint placeholders
+      # for it (the voxel topology: worker holds the table unloaded).
+      var pointer_value = EdValue[string].init(ctx = a, id = "chk_ptr")
+      parent += pointer_value
+      b.subscribe(a, partial = true, fetch = ["chk_parent", "chk_tbl_ph"])
+      b.tick()
+      c.subscribe(b, partial = true, fetch = ["chk_parent"])
+      c.tick()
+
+      # Mint the placeholder relationship directly: leaf + hub hold the table
+      # id but not its data.
+      discard c.fetch("chk_tbl") # chains: b -> a; both materialize
+      b.tick()
+      a.tick()
+      b.tick()
+      c.tick()
+      check "chk_tbl" in c
+      let leaf_tbl = EdTable[int, string](c["chk_tbl"])
+      check leaf_tbl.loaded(1) == false or leaf_tbl[1] == "one"
+        # whole-object fetch may carry the value; the per-key path below is
+        # exercised against key 2, added after the fetch
+      tbl[2] = "two"
+      b.tick() # hub may or may not see it (interest-dependent); leaf requests:
+      leaf_tbl.request(2)
+      c.tick() # flush the key request
+      b.tick() # hub serves (if loaded) or chains
+      a.tick() # authority serves
+      b.tick() # hub applies + serves the waiter
+      c.tick() # leaf applies
+      check leaf_tbl.loaded(2)
+      check leaf_tbl[2] == "two"
+
+    test "LAZY containers arrive as pull-only handles (no contents)":
+      var authority = EdContext.init(id = "lz_auth", is_authority = true)
+      var client = EdContext.init(id = "lz_client")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "lz_owner")
+      owner.own:
+        owner.items = EdSeq[int].init(ctx = authority, id = "lz_items")
+        discard EdTable[int, string].init(
+          ctx = authority, id = "lz_big", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      EdTable[int, string](authority["lz_big"])[1] = "huge"
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      discard client.fetch("lz_owner", deep = true)
+      authority.tick()
+      client.tick()
+      check "lz_items" in client # normal container came with the closure
+      check "lz_big" in client # LAZY came too — but only as a handle
+      let big = EdTable[int, string](client["lz_big"])
+      check not big.loaded # placeholder: shape unknown, entries page in
+      check not big.loaded(1) # the entry did NOT ride along
+      check big.value.len == 0 # and reading doesn't materialize (LAZY: no touch)
+
+      discard client.fetch("lz_big") # explicit whole-table pull still works
+      authority.tick()
+      client.tick()
+      check big.loaded
+      check big[1] == "huge"
+
+    test "per-key interest: requested keys stream, missing keys pop in":
+      var authority = EdContext.init(id = "ki_auth", is_authority = true)
+      var client = EdContext.init(id = "ki_client")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "ki_owner")
+      var tbl: EdTable[int, string]
+      owner.own:
+        tbl = EdTable[int, string].init(
+          ctx = authority, id = "ki_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      tbl[1] = "one"
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      discard client.fetch("ki_owner", deep = true) # handle rides the closure
+      authority.tick()
+      client.tick()
+      let ctbl = EdTable[int, string](client["ki_tbl"])
+      check not ctbl.loaded(1) # handle only — entries page in on request
+
+      # Requesting a present key loads it — and subscribes to it: a later
+      # write to that key streams without re-requesting.
+      ctbl.request(1)
+      client.tick()
+      authority.tick()
+      client.tick()
+      check ctbl.loaded(1)
+      check ctbl[1] == "one"
+      tbl[1] = "one, live"
+      authority.tick()
+      client.tick()
+      check ctbl[1] == "one, live"
+
+      # Requesting a missing key is a normal answer (empty space) — but the
+      # interest sticks, so the key pops in when someone builds there.
+      ctbl.request(2)
+      client.tick()
+      authority.tick()
+      client.tick()
+      check not ctbl.loaded(2)
+      tbl[2] = "two"
+      authority.tick()
+      client.tick()
+      check ctbl.loaded(2)
+      check ctbl[2] == "two"
+
+      # A key never requested doesn't stream.
+      tbl[3] = "three"
+      authority.tick()
+      client.tick()
+      check not ctbl.loaded(3)
+
+    test "release: evicts locally, retracts upstream, downstream clones shed":
+      var authority = EdContext.init(id = "rl_auth", is_authority = true)
+      var pager = EdContext.init(id = "rl_pager")
+      var clone = EdContext.init(id = "rl_clone")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "rl_owner")
+      var tbl: EdTable[int, string]
+      owner.own:
+        tbl = EdTable[int, string].init(
+          ctx = authority, id = "rl_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      tbl[1] = "one"
+
+      pager.subscribe(authority, partial = true, fetch = [])
+      pager.tick()
+      clone.subscribe(pager) # full clone of the partial pager (a node ctx)
+      clone.tick()
+      discard pager.fetch("rl_owner", deep = true) # handle rides the closure
+      authority.tick()
+      pager.tick()
+      clone.tick()
+      let ptbl = EdTable[int, string](pager["rl_tbl"])
+      let ntbl = EdTable[int, string](clone["rl_tbl"])
+      check not ptbl.loaded(1) # handle only
+
+      ptbl.request(1) # page in
+      pager.tick()
+      authority.tick()
+      pager.tick()
+      clone.tick()
+      check ptbl.loaded(1)
+      check ntbl.loaded(1) # the fill relayed to the clone
+
+      ptbl.release(1) # page out
+      check not ptbl.loaded(1) # evicted locally, immediately
+      pager.tick() # flush the RELEASE broadcast
+      authority.tick()
+      clone.tick()
+      check not ntbl.loaded(1) # eviction notice reached the clone
+
+      tbl[1] = "one, unseen" # interest was retracted: this must NOT stream
+      authority.tick()
+      pager.tick()
+      clone.tick()
+      check not ptbl.loaded(1)
+      check not ntbl.loaded(1)
+
+      ptbl.request(1) # paging back in re-fetches and re-subscribes
+      pager.tick()
+      authority.tick()
+      pager.tick()
+      clone.tick()
+      check ptbl[1] == "one, unseen"
+      check ntbl[1] == "one, unseen"
+
+    test "hub shedding: last retract releases the hub's copy upstream":
+      # The enu client topology: authority (server) <- partial hub (worker)
+      # <- full leaf (node ctx). The leaf drives paging; releases must shed
+      # the hub's copy and chain the retract up, or the hub re-accumulates
+      # a full replica and keeps paying for ops it no longer needs.
+      var authority = EdContext.init(id = "hs_auth", is_authority = true)
+      var hub = EdContext.init(id = "hs_hub")
+      var leaf = EdContext.init(id = "hs_leaf")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "hs_owner")
+      var tbl: EdTable[int, string]
+      owner.own:
+        tbl = EdTable[int, string].init(
+          ctx = authority, id = "hs_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      tbl[1] = "one"
+
+      hub.subscribe(authority, partial = true, fetch = [])
+      hub.tick()
+      leaf.subscribe(hub) # full clone of the partial hub
+      leaf.tick()
+      discard hub.fetch("hs_owner", deep = true)
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      let htbl = EdTable[int, string](hub["hs_tbl"])
+      let ltbl = EdTable[int, string](leaf["hs_tbl"])
+
+      ltbl.request(1) # leaf pages in: chains leaf -> hub -> authority
+      leaf.tick() # flush the key request
+      hub.tick() # miss: forward upstream
+      authority.tick() # serve
+      hub.tick() # apply + serve the waiting leaf
+      leaf.tick() # apply
+      check htbl.loaded(1) # the hub caches what it relayed
+      check ltbl[1] == "one"
+
+      ltbl.release(1) # leaf pages out
+      check not ltbl.loaded(1)
+      leaf.tick() # flush the RELEASE to the hub
+      hub.tick() # retract leaf + shed own copy + queue the chained release
+      hub.tick() # flush it upstream
+      authority.tick() # retract the hub's interest
+      leaf.tick()
+      check not htbl.loaded(1) # hub shed its copy
+
+      tbl[1] = "one, unseen" # nobody is interested: must not stream
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      check not htbl.loaded(1)
+      check not ltbl.loaded(1)
+
+      ltbl.request(1) # paging back in re-chains end to end
+      leaf.tick()
+      hub.tick()
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      check htbl[1] == "one, unseen"
+      check ltbl[1] == "one, unseen"
+
+    test "per-key chain outruns the closure push (handle-first replies)":
+      # A leaf can request keys before the hub holds the table (the closure
+      # push carrying the LAZY handle hasn't landed). Without handle-first
+      # replies the per-key ADD drops at the hub as an op for a missing
+      # object, the want dangles (only the first want per key forwards), and
+      # the entry never loads — the invisible-tower bug.
+      var authority = EdContext.init(id = "hf_auth", is_authority = true)
+      var hub = EdContext.init(id = "hf_hub")
+      var leaf = EdContext.init(id = "hf_leaf")
+      Ed.thread_ctx = authority
+      var tbl = EdTable[int, string].init(
+        ctx = authority, id = "hf_tbl", flags = DEFAULT_FLAGS + {LAZY}
+      )
+      tbl[1] = "one"
+
+      hub.subscribe(authority, partial = true, fetch = [])
+      hub.tick()
+      leaf.subscribe(hub)
+      leaf.tick()
+      # The leaf knows the table only by its derived id — neither it nor the
+      # hub holds the container.
+      let ltbl = EdTable[int, string].init_placeholder(leaf, "hf_tbl")
+      check "hf_tbl" notin hub
+
+      ltbl.request(1)
+      leaf.tick() # flush: chains through the hub, which lacks the table
+      hub.tick() # miss: forward upstream
+      authority.tick() # serve: handle first, then the entry
+      hub.tick() # apply handle + entry; serve the waiting leaf
+      leaf.tick() # apply
+      check "hf_tbl" in hub
+      check EdTable[int, string](hub["hf_tbl"]).loaded(1)
+      check ltbl[1] == "one"
+
+    test "per-key replies carry nested containers (chunk-deep)":
+      var authority = EdContext.init(id = "kd_auth", is_authority = true)
+      var client = EdContext.init(id = "kd_client")
+      var tbl = EdTable[int, EdSeq[int]].init(ctx = authority, id = "kd_tbl")
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      discard client.fetch("kd_tbl", follow = false) # snapshot: empty, no interest
+      authority.tick()
+      client.tick()
+      check "kd_tbl" in client
+
+      var entry = EdSeq[int].init(ctx = authority, id = "kd_entry")
+      entry.add 7
+      tbl[1] = entry # not streamed: the client holds no interest
+      client.tick()
+      let ctbl = EdTable[int, EdSeq[int]](client["kd_tbl"])
+      check not ctbl.loaded(1)
+
+      ctbl.request(1)
+      client.tick() # flush the key request
+      authority.tick() # serve: nested seq first, then the entry
+      client.tick() # apply
+      check ctbl.loaded(1)
+      check "kd_entry" in client
+      check EdSeq[int](client["kd_entry"]).len == 1 # nested arrived loaded
+      check ctbl[1][0] == 7 # and the entry links to it
+
     test "deep fetch pulls an owner's full ownership closure":
       var authority = EdContext.init(id = "d_auth", is_authority = true)
       var client = EdContext.init(id = "d_client")
@@ -68,7 +575,7 @@ proc run*() =
         bot.val = EdValue[int].init(ctx = authority, id = "d_val")
       bot.items.add 3
 
-      client.subscribe(authority, partial = true, roots = @[])
+      client.subscribe(authority, partial = true, fetch = [])
       client.tick()
       check "d_items" notin client # out of interest
       check "d_val" notin client
@@ -92,7 +599,7 @@ proc run*() =
     test "objects created after subscribe respect partial interest":
       var authority = EdContext.init(id = "pc_auth", is_authority = true)
       var client = EdContext.init(id = "pc_client")
-      client.subscribe(authority, partial = true, roots = @["pc_root"])
+      client.subscribe(authority, partial = true, fetch = ["pc_root"])
       client.tick()
 
       # Created after the subscribe — the broadcast CREATE must still be filtered.
@@ -105,7 +612,7 @@ proc run*() =
     test "a partial client's own object syncs back from the authority":
       var authority = EdContext.init(id = "po_auth", is_authority = true)
       var client = EdContext.init(id = "po_client")
-      client.subscribe(authority, partial = true, roots = @[])
+      client.subscribe(authority, partial = true, fetch = [])
       client.tick()
 
       # Client creates its own object; the authority should pick it up and

--- a/tests/publish_tests.nim
+++ b/tests/publish_tests.nim
@@ -7,7 +7,6 @@ from std/times import init_duration
 proc run*() =
   type
     Unit = ref object of EdRef
-      id: string
 
     Build = ref object of Unit
       build_stuff: string


### PR DESCRIPTION
**Stacked on #15.** PR 3 — partial replicas matured into a paging substrate.

- **Fetch handles** — `fetch` returns a `Fetch` (Pending/Found/NotFound, with `follow`); blocking `ctx[]` waits on it.
- **Deep / owner fetch** — pulls an id's synced-ownership closure recursively; `OWNS_MEMBERS` member closures are pushed ahead of the collection so parse links members (no husks). `EdRef.destroy` + member cascade.
- **Per-key paging (LAZY tables)** — `request`/`release`/`loaded`, batched one REQUEST/RELEASE per table per tick; requested keys stream future ops even if missing at request time; per-key deep for Ed-valued entries.
- **Request chaining** — hubs forward misses upstream and relay answers/NACKs back; only first want per id/key forwards; authority terminates; no-cache hub sheds on last retract.

Full suite green (incl. expanded `partial_tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)