### PR TITLE
refactor(proxy): proxy/body split — registry-owned bodies, sentinel proxies

### DIFF
--- a/docs/proxy-body.md
+++ b/docs/proxy-body.md
@@ -1,0 +1,79 @@
+# Proxy/Body Split
+
+The v2 container object model, building on `object-lifecycle.md`. Each container is
+two objects: a registry-owned **body** (the data + everything the wire needs) and a
+GC-owned **proxy** (the thin `ref` the app holds). `ctx[id]` returns the proxy;
+field access on the proxy forwards to the body through templates, so call sites
+(and all of enu) compile unchanged.
+
+## Why
+
+A mostly-unloaded world shouldn't pay for per-id object shells — a husk costs
+~300+ bytes (six per-instance closure envs), and every referenced-but-unloaded id
+paid it. Bodies make cold objects cheap and persistable; the proxy is the cheap,
+reconstructible handle whose liveness drives local-resource and interest decisions.
+
+## Settled decisions
+
+- **True ref proxy.** The proxy is a `ref`; `==` is reference identity, never an id
+  override. No value proxies, no tombstones. `ctx[id]` must return *the* live proxy
+  while one exists, or `state.open_unit == self` breaks — so identity is
+  load-bearing (`resolve_proxy`).
+- **Registry-owned bodies.** `EdContext.objects` maps `id → ref EdBodyBase`
+  (strong). The body carries `tracked`, sync state, and the sync closures
+  (`build_message`/`change_receiver`/`publish_*`/per-key). Storage is a tier seam:
+  `id → live body | serialized bin | absent`; evicting on a replica drops to absent
+  (upstream re-serves), persisting later demotes to bin — the CREATE bin already
+  *is* the serialization format.
+- **Identity map via deferred prune (not `GC_ref`).** The body holds a *non-owning*
+  (`{.cursor.}`) backref to the live proxy. The proxy's `ProxyHandle.=destroy`
+  dereferences nothing — it records `(ctx_uid, object_id, gen)` on a lock-guarded
+  global pending list; `prune_dead_proxies` clears dead backrefs *before any
+  identity read* and on tick. `resolve_proxy` returns the live proxy via the
+  backref or mints one over the body. `gen` guards an out-of-order prune from
+  clearing a newer proxy. This is exactly the `RefHandle`/`ref_pool` discipline,
+  applied to containers — the old "weak-backref + GC_ref dance" risk is solved.
+
+  *Cross-thread (load-bearing):* the pending tables are lock-guarded **globals**,
+  not threadvars — a context can be minted on one thread and live on another — and
+  once global, `EdContext.uid` must be a **process-global atomic** (two threadvar
+  counters both minting uid 1 drained each other's deaths: a silent UAF only
+  client_smoke caught).
+
+## Callbacks live on the body (sentinel model)
+
+Empirically, **Nim ORC does not collect closure-environment cycles** (reproduced
+with no ed involved). So a proxy-side self-capturing watcher could never reclaim.
+The fix:
+
+- **The body owns the callbacks** (`changed_callbacks`/`paused_eids`/`link_eid` on
+  `EdBody[T, O]`). The proxy is a *sentinel* — body ref + `ProxyHandle`, nothing
+  else — so it dies promptly at refcount zero, and the next prune sweeps the
+  callbacks registered through its generation (`callback_gens`/`sweep_gen`). This is
+  the scripting workflow: fetch → watch → drop → reclaimed, no GC heroics.
+- **The live proxy reaches a callback as a parameter (`it`), never a capture** —
+  stored shape `proc(changes, it: ref EdBase)`; 1-arg `track` callbacks wrap. So a
+  watcher written against `it` pins nothing and dies with its proxy.
+- **Capture rule:** a closure stored on a body must capture nothing that reaches a
+  body or context. The body's own self-capturing closures
+  (`mint`/`untrack_zid`/`sweep_gen`, and `publish_create`, which also reaches the
+  context) are released explicitly at unregistration (`release_closures`) — leaving
+  them set re-introduces the object↔context cycle the cursor backref broke, and ORC
+  won't collect it.
+- A **narrow static warning** fires only when a `changes`/`watch` body references
+  the watched container as a bare identifier — the genuine self-capture footgun
+  (a root-ident version was 67/91 noise on enu; the bare-ident version: 0).
+
+Lifetime/untrack remains the contract for side-effecting watchers; sentinel
+collection is the safety net and the scripting default.
+
+## Notes
+
+- Proxy→body indirection is on every access; hot read paths (voxel render) were
+  benchmarked across the mechanical split.
+- Paging out (per-key evict) also unregisters an evicted entry's nested container
+  bodies (the orphaned `chunk_deltas` seqs) — identity is intentionally *not*
+  preserved across page-out (re-page-in resolves a fresh body+proxy; watchers died
+  with the proxy, the Lifetime story working as designed).
+- The touch/LRU evictor that uses proxy-liveness as its safety gate is in
+  `partial-replicas.md` (the eviction layer).

--- a/src/ed/components/private/tracking.nim
+++ b/src/ed/components/private/tracking.nim
@@ -13,16 +13,33 @@ proc `-`*[T](a, b: seq[T]): seq[T] =
 template `&`*[T](a, b: set[T]): set[T] =
   a + b
 
-proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) {.gcsafe.} =
-  private_access EdObject[T, O]
-  private_access EdBase
+proc trigger_callbacks*[T, O](body: EdBody[T, O], changes: seq[Change[O]]) {.gcsafe.}
 
-  if changes.len == 0:
+proc trigger_callbacks_deferred[T, O](body: EdBody[T, O], changes: seq[Change[O]]) =
+  # Silent-materialize deferral: re-fires at the next tick. Captures the body
+  # (registry-owned) in a ctx-held seq — a plain chain, dropped when replayed.
+  privileged
+  body.ctx.pending_fills.add proc() {.gcsafe.} =
+    body.trigger_callbacks(changes)
+
+proc trigger_callbacks*[T, O](body: EdBody[T, O], changes: seq[Change[O]]) {.gcsafe.} =
+  ## Body-side: callbacks are registry-owned (see EdBody). The live proxy is
+  ## resolved lazily — only when there are callbacks to fire — and passed as
+  ## the `it` parameter, never captured.
+  privileged
+
+  if changes.len == 0 or body.changed_callbacks.len == 0:
     return
+  let ctx = body.ctx
+  let it: ref EdBase =
+    if ctx != nil:
+      ctx.resolve_proxy(body)
+    else:
+      nil
 
   # Tag changes produced while filling a placeholder so callbacks can tell a
   # materialize-on-access fill from an ordinary mutation.
-  if self.ctx != nil and self.ctx.filling:
+  if ctx != nil and ctx.filling:
     for c in changes:
       c.reason = Fill
 
@@ -30,31 +47,35 @@ proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) {.gcsafe.
   # defer the callbacks to the next explicit tick (preserves tick-boundary
   # semantics and clean reentrancy). The value is already applied, so the
   # blocking read still returns real data.
-  if self.ctx != nil and self.ctx.silent:
+  if ctx != nil and ctx.silent:
     let deferred = changes
-    self.ctx.pending_fills.add proc() {.gcsafe.} =
-      self.trigger_callbacks(deferred)
+    body.trigger_callbacks_deferred(deferred)
     return
 
-  let callbacks = self.changed_callbacks.dup
+  let callbacks = body.changed_callbacks.dup
   for zid, callback in callbacks.pairs:
-    if zid in self.changed_callbacks and zid notin self.paused_eids:
-      callback(changes)
+    if zid in body.changed_callbacks and zid notin body.paused_eids:
+      callback(changes, it)
+
+proc trigger_callbacks*[T, O](self: Ed[T, O], changes: seq[Change[O]]) {.gcsafe.} =
+  privileged
+  EdBody[T, O](self.body).trigger_callbacks(changes)
 
 proc link_child*[K, V](
     self: EdTable[K, V], child, obj: Pair[K, V], field_name = ""
 ) =
   proc link[S, K, V, T, O](self: S, pair: Pair[K, V], child: Ed[T, O]) =
-    private_access EdBase
+    privileged
     log_defaults
-    child.link_eid = child.track proc(changes: seq[Change[O]]) =
+    let parent_body = self.typed_body # capture the body, never the proxy
+    child.typed_body.link_eid = child.track proc(changes: seq[Change[O]]) =
       if changes.len == 1 and changes[0].changes == {CLOSED}:
         # Don't propagate CLOSED changes
         return
       let change = Change.init(pair, {MODIFIED})
       change.triggered_by = cast[seq[BaseChange]](changes)
       change.triggered_by_type = $O
-      self.trigger_callbacks(@[change])
+      parent_body.trigger_callbacks(@[change])
     debug "linking zen",
       child = ($child.type, $child.id), self = ($self.type, $self.id)
 
@@ -67,9 +88,10 @@ proc link_child*[T, O, L](self: EdSeq[T], child: O, obj: L, field_name = "") =
     self = self
     obj = obj
   proc link[T, O](child: Ed[T, O]) =
-    private_access EdBase
+    privileged
     log_defaults
-    child.link_eid = child.track proc(changes: seq[Change[O]]) =
+    let parent_body = self.typed_body # capture the body, never the proxy
+    child.typed_body.link_eid = child.track proc(changes: seq[Change[O]]) =
       if changes.len == 1 and changes[0].changes == {CLOSED}:
         # Don't propagate CLOSED changes
         return
@@ -77,28 +99,29 @@ proc link_child*[T, O, L](self: EdSeq[T], child: O, obj: L, field_name = "") =
       let change = Change.init(obj, {MODIFIED}, field_name = field_name)
       change.triggered_by = cast[seq[BaseChange]](changes)
       change.triggered_by_type = $O
-      self.trigger_callbacks(@[change])
+      parent_body.trigger_callbacks(@[change])
     debug "linking zen",
       child = ($child.type, $child.id),
       self = ($self.type, $self.id),
-      zid = child.link_eid,
+      zid = child.typed_body.link_eid,
       child_addr = cast[int](unsafe_addr child[]).to_hex
 
   if ?child:
     link(child)
 
 proc unlink*(self: Ed) =
-  private_access EdBase
+  privileged
   log_defaults
-  debug "unlinking", id = self.id, zid = self.link_eid
-  self.untrack(self.link_eid)
-  self.link_eid = 0
+  debug "unlinking", id = self.id, zid = self.typed_body.link_eid
+  self.untrack(self.typed_body.link_eid)
+  self.typed_body.link_eid = 0
 
 proc unlink*[T: Pair](pair: T) =
+  privileged
   log_defaults
-  debug "unlinking", id = pair.value.id, zid = pair.value.link_eid
-  pair.value.untrack(pair.value.link_eid)
-  pair.value.link_eid = 0
+  debug "unlinking", id = pair.value.id, zid = pair.value.typed_body.link_eid
+  pair.value.untrack(pair.value.typed_body.link_eid)
+  pair.value.typed_body.link_eid = 0
 
 proc link_or_unlink*[T, O](self: Ed[T, O], change: Change[O], link: bool) =
   log_defaults

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -108,7 +108,7 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
       s.from_flatty(i, info)
       # :(
       if info.object_id in flatty_ctx:
-        value = value.type()(flatty_ctx.objects[info.object_id])
+        value = value.type()(flatty_ctx.resolve_proxy(flatty_ctx.objects[info.object_id]))
       else:
         # A nested Ed reference we don't hold (a partial replica receiving a
         # pre-populated parent, or a parent that arrived before its child).
@@ -757,7 +757,11 @@ proc fetch*(
   ## its whole owned state in one request. The already-loaded short-circuit is
   ## skipped for deep fetches: holding the root says nothing about the closure.
   if not deep and object_id in self and not self.objects[object_id].placeholder:
-    return Fetch(id: object_id, state: Found, obj: self.objects[object_id])
+    return Fetch(
+      id: object_id,
+      state: Found,
+      obj: self.resolve_proxy(self.objects[object_id]),
+    )
   if object_id in self.fetches and self.fetches[object_id].state == Pending:
     return self.fetches[object_id]
   result = Fetch(id: object_id, state: Pending)
@@ -1047,7 +1051,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       let pending_fetch = self.fetches[msg.object_id]
       pending_fetch.state = Found
       if msg.object_id in self.objects and ?self.objects[msg.object_id]:
-        pending_fetch.obj = self.objects[msg.object_id]
+        pending_fetch.obj = self.resolve_proxy(self.objects[msg.object_id])
       self.fetches.del(msg.object_id)
     if msg.owner_id.len > 0 and msg.owner_id in self.fetches:
       self.fetches[msg.owner_id].state = Found
@@ -1169,7 +1173,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           if msg.object_id in self:
             let obj = self.objects[msg.object_id]
             if obj.evict_key != nil:
-              discard obj.evict_key(obj, key_bin)
+              let evicted = obj.evict_key(obj, key_bin)
+              self.drop_nested_bodies(evicted.nested)
           self.pending_key_releases.mgetOrPut(msg.object_id, @[]).add key_bin
     if not retracted:
       var from_upstream = false
@@ -1182,7 +1187,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           let obj = self.objects[msg.object_id]
           if obj.evict_key != nil:
             for key_bin in keys:
-              discard obj.evict_key(obj, key_bin)
+              let evicted = obj.evict_key(obj, key_bin)
+              self.drop_nested_bodies(evicted.nested)
         if not self.is_authority:
           # Relay to our own subscribers (downstream clones); the accumulated
           # source stops it echoing back the way it came.
@@ -1356,13 +1362,14 @@ proc untrack*[T, O](self: Ed[T, O], zid: EID) =
   assert self.valid
 
   # :(
-  if zid in self.changed_callbacks:
-    let callback = self.changed_callbacks[zid]
-    if zid notin self.paused_eids:
-      callback(@[Change.init(O, {CLOSED})])
-    self.ctx.close_procs.del(zid)
-    debug "removing close proc", zid
-    self.changed_callbacks.del(zid)
+  let body = self.typed_body
+  if zid in body.changed_callbacks:
+    let callback = body.changed_callbacks[zid]
+    if zid notin body.paused_eids:
+      callback(@[Change.init(O, {CLOSED})], self)
+    self.ctx.close_index.del(zid)
+    body.changed_callbacks.del(zid)
+    body.callback_gens.del(zid)
   else:
     error "no change callback for zid", zid = zid
 
@@ -1374,7 +1381,7 @@ proc bind_lifetime*[T, O](self: Ed[T, O], lifetime: Lifetime, zid: EID) =
   ## owner dying first — is safe and idempotent.
   privileged
   lifetime.add proc() {.gcsafe.} =
-    if not self.destroyed and zid in self.changed_callbacks:
+    if not self.destroyed and zid in self.typed_body.changed_callbacks:
       self.untrack(zid)
 
 proc track*[T, O](
@@ -1388,10 +1395,15 @@ proc track*[T, O](
   assert self.valid
   inc self.ctx.changed_callback_eid
   let zid = self.ctx.changed_callback_eid
-  self.changed_callbacks[zid] = callback
-  debug "adding close proc", zid
-  self.ctx.close_procs[zid] = proc() =
-    self.untrack(zid)
+  let body = self.typed_body
+  # Wrap the 1-arg callback in the stored 2-arg shape; the wrapper captures
+  # only the user's closure (their captures are their pins).
+  body.changed_callbacks[zid] = proc(
+      changes: seq[Change[O]], it: ref EdBase
+  ) {.gcsafe.} =
+    callback(changes)
+  body.callback_gens[zid] = body.proxy_gen
+  self.ctx.close_index[zid] = self.id
   result = zid
 
   # Inside an `own` scope, route this callback's untrack through the owner's
@@ -1411,6 +1423,31 @@ proc track*[T, O](
     callback(changes, zid)
 
   result = zid
+
+proc track*[T, O](
+    self: Ed[T, O],
+    callback:
+      proc(changes: seq[Change[O]], zid: EID, it: Ed[T, O]) {.gcsafe.},
+): EID {.discardable.} =
+  ## The non-capturing form: the live proxy arrives as `it` each fire, so the
+  ## callback needs no reference to the watched object at all — a proxy
+  ## tracked this way still dies promptly when the app drops it. The sugar
+  ## (`changes`/`watch`) builds on this.
+  privileged
+  assert self.valid
+  inc self.ctx.changed_callback_eid
+  let zid = self.ctx.changed_callback_eid
+  let body = self.typed_body
+  body.changed_callbacks[zid] = proc(
+      changes: seq[Change[O]], it: ref EdBase
+  ) {.gcsafe.} =
+    callback(changes, zid, Ed[T, O](it))
+  body.callback_gens[zid] = body.proxy_gen
+  self.ctx.close_index[zid] = self.id
+  result = zid
+  {.gcsafe.}:
+    if not current_lifetime.is_nil:
+      self.bind_lifetime(current_lifetime, zid)
 
 proc track*[T, O](
     self: Ed[T, O],
@@ -1488,6 +1525,7 @@ proc tick*(
   self.unsubscribed = @[]
   var count = 0
   self.free_refs
+  self.prune_dead_proxies # clear backrefs of proxies ORC reclaimed
   let timeout =
     if not ?max_duration:
       MonoTime.high
@@ -1743,13 +1781,42 @@ macro check_no_return*(body: untyped): untyped =
     )
   result = body
 
+macro warn_self_capture(watched: untyped, body: untyped): untyped =
+  ## Bare-identifier self-capture detection for the `changes`/`watch` sugar:
+  ## a callback body that references the watched *variable* captures it,
+  ## pinning the object until untracked (closure cycles are not collected).
+  ## Deliberately narrow — only a bare identifier, only outside dot-RHS
+  ## positions — so it stays near-zero false positives (enu fires none).
+  result = new_empty_node()
+  if watched.kind in {nnk_ident, nnk_sym}:
+    let name = watched.str_val
+    proc references(n: NimNode): bool =
+      if n.kind in {nnk_ident, nnk_sym} and eq_ident(n, name):
+        return true
+      for i in 0 ..< n.len:
+        if n.kind == nnk_dot_expr and i == 1:
+          continue # `x.foo` — foo is a field, not a capture
+        if references(n[i]):
+          return true
+    if references(body):
+      warning(
+        "callback closes over '" & name &
+          "', pinning it until untracked — use `it` (the injected live " &
+          "proxy) or bind a Lifetime",
+        watched,
+      )
+
 template changes*[T, O](self: Ed[T, O], pause_me, body) =
-  let zen = self
+  warn_self_capture(self, body)
   make_discardable block:
     {.line.}:
-      zen.track proc(changes: seq[Change[O]], zid {.inject.}: EID) {.gcsafe.} =
+      track self, proc(
+          changes: seq[Change[O]], zid {.inject.}: EID, it {.inject.}: Ed[T, O]
+      ) {.gcsafe.} =
+        # `it` is the live proxy, delivered as a parameter — referencing it
+        # captures nothing, so sugar watchers never pin their object.
         let pause_zid = if pause_me: zid else: 0
-        zen.pause(pause_zid):
+        it.pause(pause_zid):
           for change {.inject.} in changes:
             template added(): bool =
               ADDED in change.changes

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -51,9 +51,9 @@ proc register_type(typ: type) =
       for src, dest in fields(self[], clone[]):
         when src is Ed:
           if ?src:
-            var field = type(src)()
-            field.id = src.id
-            dest = field
+            # Proxy/body split: a bare `type(src)()` has no body, and `.id`
+            # forwards there — mint a husk that carries one.
+            dest = type(src).init_husk(src.id)
         elif src is ref:
           dest = nil
         elif src is ptr:
@@ -75,8 +75,10 @@ proc register_type(typ: type) =
           if ?field and field.id in ctx:
             # Direct registry read — `ctx[...]` would blocking-materialize in a
             # `blocking` scope, which deserialization must never do (and a func
-            # can't have side effects).
-            field = type(field)(ctx.objects[field.id])
+            # can't have side effects; resolve_proxy's registry upkeep is cast
+            # away as the one tolerated effect).
+            {.no_side_effect.}:
+              field = type(field)(ctx.resolve_proxy(ctx.objects[field.id]))
       result = self
 
   with_lock:

--- a/src/ed/deps.nim
+++ b/src/ed/deps.nim
@@ -1,9 +1,9 @@
-import std/[tables, monotimes, times, importutils, strutils, sequtils, sets]
+import std/[tables, monotimes, times, importutils, strutils, sequtils, sets, locks, atomics]
 import pkg/threading/channels
 import pkg/[flatty, netty, pretty]
 export times except seconds
 export
   tables, monotimes, importutils, strutils, sequtils, channels, flatty, pretty,
-  sets
+  sets, locks, atomics
 
 export netty except Message

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -301,16 +301,13 @@ type
     warned_missing*: HashSet[string]
     changed_callback_eid: EID
     last_id: int
-    # zid -> object id, for context-level `untrack(zid)`. Plain data on
-    # purpose: the old shape stored a closure capturing the proxy, which made
-    # the context strong-hold every tracked proxy until explicit untrack —
-    # never-collected callbacks (caught by the memory tests). Stale entries
-    # for proxies that died untracked linger as tiny strings, pinning nothing.
+    # zid -> object id, for context-level `untrack(zid)`. Plain data (not a
+    # closure) so it pins nothing: a stale entry for a proxy that died untracked
+    # lingers as a tiny string, holding nothing alive.
     close_index: Table[EID, string]
-    # The body registry: canonical, registry-owned state per id (phase 2 of the
-    # proxy/body split). Proxies are minted on demand over these — see
-    # `resolve_proxy`; `ctx[id]` still returns the proxy, so the public API is
-    # unchanged.
+    # The body registry: canonical, registry-owned state per id. Proxies are
+    # minted on demand over these — see `resolve_proxy`; `ctx[id]` still returns
+    # the proxy, so the public API is unchanged.
     objects*: OrderedTable[string, ref EdBodyBase]
     objects_need_packing*: bool
     # Ownership index: owner EdRef id -> ids of the containers it owns (whose
@@ -367,12 +364,10 @@ type
 
   EdBodyBase* = object of RootObj
     ## Registry-side state of a container — the *body* of the proxy/body split
-    ## (docs/proxy-body-design.md). Carries the data and everything the wire
-    ## needs; the app-facing proxy (`Ed`) forwards here via templates, so call
-    ## sites read unchanged. Phase 1 is purely structural: each proxy
-    ## strong-holds its body 1:1 and the registry still holds proxies — bodies
-    ## become registry-owned (and proxies weak-backref'd) with the identity
-    ## map in phase 2.
+    ## (docs/proxy-body.md). Carries the data and everything the wire needs; the
+    ## app-facing proxy (`Ed`) forwards here via templates, so call sites read
+    ## unchanged. The registry owns the body; the proxy is reached through the
+    ## `proxy` backref + `mint` (resolve_proxy).
     id*: string
     # The EdRef (by id) that owns this container, or "" if unowned. Set when the
     # container is created inside an `own` scope, and on materialize from the
@@ -515,11 +510,10 @@ type
 const DEFAULT_FLAGS* = {SYNC_LOCAL, SYNC_REMOTE}
   ## Default flags for `Ed` containers: sync both locally and remotely.
 
-# Proxy → body forwarding (proxy/body split, phase 1). Templates expand at the
-# call site, so existing field accesses — reads *and* writes — compile
-# unchanged; private body fields still require `privileged` there, preserving
-# today's visibility discipline. The typed `tracked` forward casts through
-# `EdBody[T]`; everything else lives on the untyped base.
+# Proxy → body forwarding. Templates expand at the call site, so field accesses
+# (reads *and* writes) compile unchanged; private body fields still require
+# `privileged` there. The typed `tracked` forward casts through `EdBody[T]`;
+# everything else lives on the untyped base.
 template tracked*[T, O](self: Ed[T, O]): untyped =
   EdBody[T, O](self.body).tracked
 
@@ -587,11 +581,9 @@ proc evict_key*(
 
 var next_ctx_uid*: Atomic[int]
   ## Global source of `EdContext.uid`. Must be process-wide: the dead-handle
-  ## pending tables are global (a context can be created on one thread and
-  ## live on another), so colliding uids across threads would misattribute
-  ## deaths — a thread-local counter did exactly that (two threads' first
-  ## contexts both got uid 1, one drained the other's records, and the
-  ## undrained backref cursor dangled).
+  ## pending tables are global (a context can be created on one thread and live
+  ## on another), so a uid colliding across threads would misattribute deaths —
+  ## one context draining another's records and dangling its backref cursor.
 
 var dead_handles_lock: Lock
 dead_handles_lock.init_lock
@@ -663,7 +655,7 @@ proc prune_dead_proxies*(self: EdContext) =
 proc resolve_proxy*(self: EdContext, body: ref EdBodyBase): ref EdBase =
   ## The identity map: the one live proxy for `body`, minting if none. Two
   ## resolutions of the same id are reference-equal while anything holds the
-  ## proxy — honest `ref` identity (docs/proxy-body-design.md).
+  ## proxy — honest `ref` identity (docs/proxy-body.md).
   if body == nil:
     return nil
   self.prune_dead_proxies

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -301,8 +301,17 @@ type
     warned_missing*: HashSet[string]
     changed_callback_eid: EID
     last_id: int
-    close_procs: Table[EID, proc() {.gcsafe.}]
-    objects*: OrderedTable[string, ref EdBase]
+    # zid -> object id, for context-level `untrack(zid)`. Plain data on
+    # purpose: the old shape stored a closure capturing the proxy, which made
+    # the context strong-hold every tracked proxy until explicit untrack —
+    # never-collected callbacks (caught by the memory tests). Stale entries
+    # for proxies that died untracked linger as tiny strings, pinning nothing.
+    close_index: Table[EID, string]
+    # The body registry: canonical, registry-owned state per id (phase 2 of the
+    # proxy/body split). Proxies are minted on demand over these — see
+    # `resolve_proxy`; `ctx[id]` still returns the proxy, so the public API is
+    # unchanged.
+    objects*: OrderedTable[string, ref EdBodyBase]
     objects_need_packing*: bool
     # Ownership index: owner EdRef id -> ids of the containers it owns (whose
     # `owner_id` points back here). Built as containers are created/materialized,
@@ -356,8 +365,14 @@ type
       dump_at*: MonoTime
       counts*: array[MessageKind, int]
 
-  EdBase* = object of RootObj
-    ## Base type for all `Ed` containers. Not used directly.
+  EdBodyBase* = object of RootObj
+    ## Registry-side state of a container — the *body* of the proxy/body split
+    ## (docs/proxy-body-design.md). Carries the data and everything the wire
+    ## needs; the app-facing proxy (`Ed`) forwards here via templates, so call
+    ## sites read unchanged. Phase 1 is purely structural: each proxy
+    ## strong-holds its body 1:1 and the registry still holds proxies — bodies
+    ## become registry-owned (and proxies weak-backref'd) with the identity
+    ## map in phase 2.
     id*: string
     # The EdRef (by id) that owns this container, or "" if unowned. Set when the
     # container is created inside an `own` scope, and on materialize from the
@@ -371,12 +386,9 @@ type
     # it triggers a fetch; when the real state arrives the bit clears and a Fill
     # change fires. Default false = a normal, fully-loaded object.
     placeholder*: bool
-    link_eid: EID
-    paused_eids: set[EID]
-    bound_eids: seq[EID]
     flags*: set[EdFlags]
     build_message: proc(
-      self: ref EdBase, change: BaseChange, id: string, trace: string
+      body: ref EdBodyBase, change: BaseChange, id: string, trace: string
     ): Message {.gcsafe.}
 
     publish_create: proc(
@@ -387,7 +399,7 @@ type
     ) {.gcsafe.}
 
     change_receiver:
-      proc(self: ref EdBase, msg: Message, op_ctx: OperationContext) {.gcsafe.}
+      proc(body: ref EdBodyBase, msg: Message, op_ctx: OperationContext) {.gcsafe.}
 
     # Per-key fetch (partial EdTable). Given a serialized key, build the ADD op
     # carrying that key's current value, so a partial subscriber can pull one
@@ -397,7 +409,7 @@ type
     # (per-key deep, one round trip). nil for non-table containers.
     publish_key:
       proc(
-        self: ref EdBase, key_bin: string
+        body: ref EdBodyBase, key_bin: string
       ): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.}
 
     # Per-key eviction (paging). Given a serialized key, drop the entry locally
@@ -407,7 +419,7 @@ type
     # of a RELEASE eviction notice. nil for non-table containers.
     evict_key:
       proc(
-        self: ref EdBase, key_bin: string
+        body: ref EdBodyBase, key_bin: string
       ): tuple[found: bool, nested: seq[string]] {.gcsafe.}
 
     # Back-reference to the owning context. `{.cursor.}` (non-owning): the
@@ -420,12 +432,70 @@ type
     # while the context is alive, and no Ed object has an ORC `=destroy` that
     # dereferences `ctx`). Validated under AddressSanitizer (tests/asan.sh).
     ctx* {.cursor.}: EdContext
+    # The live proxy for this body, or nil. Non-owning ({.cursor.}): the app
+    # and containers own proxies; when the last reference drops, the proxy's
+    # ProxyHandle records the death and `prune_dead_proxies` clears this —
+    # always *before* an identity read, so the cursor is never read dangling
+    # (the RefHandle discipline, applied to containers).
+    proxy {.cursor.}: ref EdBase
+    proxy_gen: int
+    # Typed proxy factory, wired in `defaults` (the only place the concrete
+    # Ed[T, O] is known). Mints over this body, sets the backref + handle.
+    mint: proc(): ref EdBase {.gcsafe.}
+    # Typed context-level untrack (see EdContext.close_index): untracks `zid`
+    # on the live proxy, or no-ops — a dead proxy already took its callbacks
+    # with it. Captures only the body (the mint pattern).
+    untrack_zid: proc(zid: EID) {.gcsafe.}
+    # Sweep callbacks registered through a now-dead proxy generation; returns
+    # the swept zids so the context can clear its close_index. Typed work
+    # behind an untyped hook (the publish_key pattern).
+    sweep_gen: proc(gen: int): seq[EID] {.gcsafe.}
 
-  ChangeCallback[O] = proc(changes: seq[Change[O]]) {.gcsafe.}
+  ChangeCallback[O] = proc(
+    changes: seq[Change[O]], it: ref EdBase
+  ) {.gcsafe.}
+    ## Stored callback shape: the live proxy arrives as a *parameter* (`it`),
+    ## never a capture — parameters pin nothing, so a watcher written against
+    ## `it` lets its proxy die promptly at refcount zero. `it` is nil only for
+    ## CLOSED notifications fired after the proxy is already gone.
+
+  EdBody*[T, O] = ref object of EdBodyBase
+    ## Typed body: the canonical data AND the callbacks live here — registry-
+    ## owned, no reliance on cycle collection (which Nim's ORC empirically
+    ## does not perform for closure environments). A closure stored here must
+    ## capture nothing that reaches a body or a context, or it leaks for the
+    ## registry's lifetime; the `it` parameter exists so it never needs to.
+    tracked: T
+    changed_callbacks: OrderedTable[EID, ChangeCallback[O]]
+    # zid -> proxy generation that registered it. When a dead proxy's gen is
+    # pruned, its callbacks sweep with it — deterministic next-tick cleanup.
+    callback_gens: Table[EID, int]
+    link_eid: EID
+    paused_eids: set[EID]
+
+  ProxyHandle* = ref object
+    ## Per-proxy registry-cleanup handle (the container twin of `RefHandle`).
+    ## When a proxy's last reference drops, ORC destroys its fields and this
+    ## handle's `=destroy` records the death for the context to prune — the
+    ## destructor dereferences *nothing* (the context, even the body, may be
+    ## reclaimed in the same ORC batch). `gen` guards out-of-order prunes: a
+    ## body only clears its backref if the dead proxy was its *current* one.
+    ctx_uid*: int
+    object_id*: string
+    gen*: int
+
+  EdBase* = object of RootObj
+    ## Base type for all `Ed` containers — the *proxy* side of the split: what
+    ## the app holds. Local, handle-scoped state only (change callbacks and
+    ## their EID bookkeeping die with the proxy); everything synced forwards
+    ## to `body`. Minted by `ctx[id]`/`resolve_proxy` when none is live —
+    ## reference identity holds because the body's backref always points at
+    ## *the* live proxy (prune-before-read keeps it honest).
+    body*: ref EdBodyBase
+    proxy_handle: ProxyHandle
+    bound_eids: seq[EID]
 
   EdObject[T, O] = object of EdBase
-    changed_callbacks: OrderedTable[EID, ChangeCallback[O]]
-    tracked: T
 
   Ed*[T, O] = ref object of EdObject[T, O]
     ## Generic reactive container. T is the contained type, O is the change object type.
@@ -445,13 +515,88 @@ type
 const DEFAULT_FLAGS* = {SYNC_LOCAL, SYNC_REMOTE}
   ## Default flags for `Ed` containers: sync both locally and remotely.
 
-var next_ctx_uid* {.threadvar.}: int
-  ## Thread-local source of `EdContext.uid`. Per-thread is enough: a context is
-  ## created on, ticks on, and frees its refs on, one home thread, and
-  ## `pending_dead_refs` is thread-local too — so uids only ever collide across
-  ## threads, where the separate pending tables keep them apart.
+# Proxy → body forwarding (proxy/body split, phase 1). Templates expand at the
+# call site, so existing field accesses — reads *and* writes — compile
+# unchanged; private body fields still require `privileged` there, preserving
+# today's visibility discipline. The typed `tracked` forward casts through
+# `EdBody[T]`; everything else lives on the untyped base.
+template tracked*[T, O](self: Ed[T, O]): untyped =
+  EdBody[T, O](self.body).tracked
 
-var pending_dead_refs* {.threadvar.}: Table[int, seq[string]]
+template typed_body*[T, O](self: Ed[T, O]): EdBody[T, O] =
+  EdBody[T, O](self.body)
+
+template id*(self: ref EdBase): untyped =
+  self.body.id
+
+template owner_id*(self: ref EdBase): untyped =
+  self.body.owner_id
+
+template destroyed*(self: ref EdBase): untyped =
+  self.body.destroyed
+
+template placeholder*(self: ref EdBase): untyped =
+  self.body.placeholder
+
+template flags*(self: ref EdBase): untyped =
+  self.body.flags
+
+template ctx*(self: ref EdBase): untyped =
+  self.body.ctx
+
+proc init_husk*[T, O](_: typedesc[Ed[T, O]], id: string): Ed[T, O] =
+  ## A bare serialization stand-in: proxy + body carrying only the id. Used by
+  ## registered-type `stringify`, which clones a ref and reduces its Ed fields
+  ## to their ids — the receiver re-links them from its own registry. Not
+  ## registered anywhere; never escapes serialization.
+  result = Ed[T, O]()
+  result.body = EdBody[T, O](id: id)
+
+# The sync closures: the call-arity procs forward invocations (a dotted call
+# through a proc field parses as a call of the *symbol*, so a field-resolving
+# template alone can't take the arguments). Assignment and nil checks go
+# through `self.body.X` directly under `privileged`.
+proc build_message*(
+    self: ref EdBase, slf: ref EdBase, change: BaseChange, id, trace: string
+): Message {.gcsafe.} =
+  self.body.build_message(slf.body, change, id, trace)
+
+proc publish_create*(
+    self: ref EdBase,
+    sub = Subscription(),
+    broadcast = false,
+    op_ctx = OperationContext(),
+    contents = true,
+) {.gcsafe.} =
+  self.body.publish_create(sub, broadcast, op_ctx, contents)
+
+proc change_receiver*(
+    self: ref EdBase, slf: ref EdBase, msg: Message, op_ctx: OperationContext
+) {.gcsafe.} =
+  self.body.change_receiver(slf.body, msg, op_ctx)
+
+proc publish_key*(
+    self: ref EdBase, slf: ref EdBase, key_bin: string
+): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.} =
+  self.body.publish_key(slf.body, key_bin)
+
+proc evict_key*(
+    self: ref EdBase, slf: ref EdBase, key_bin: string
+): tuple[found: bool, nested: seq[string]] {.gcsafe.} =
+  self.body.evict_key(slf.body, key_bin)
+
+var next_ctx_uid*: Atomic[int]
+  ## Global source of `EdContext.uid`. Must be process-wide: the dead-handle
+  ## pending tables are global (a context can be created on one thread and
+  ## live on another), so colliding uids across threads would misattribute
+  ## deaths — a thread-local counter did exactly that (two threads' first
+  ## contexts both got uid 1, one drained the other's records, and the
+  ## undrained backref cursor dangled).
+
+var dead_handles_lock: Lock
+dead_handles_lock.init_lock
+
+var pending_dead_refs*: Table[int, seq[string]]
   ## ctx uid -> ref_ids whose registered instance ORC has reclaimed. Populated by
   ## `RefHandle.=destroy`, which must NOT touch its `EdContext` (it may already be
   ## freed — even within the same cycle-collection batch). Each context drains its
@@ -468,19 +613,102 @@ proc `=destroy`(h: var typeof(RefHandle()[])) =
   ## until the registry sets `ctx_uid`/`ref_id` on the instance's first ADD.
   if h.ctx_uid != 0 and h.ref_id.len > 0:
     {.cast(gcsafe).}:
+      dead_handles_lock.acquire()
       pending_dead_refs.mget_or_put(h.ctx_uid, @[]).add(h.ref_id)
+      dead_handles_lock.release()
   `=destroy`(h.ref_id)
+
+var pending_dead_proxies*: Table[int, seq[(string, int)]]
+  ## ctx uid -> (object_id, gen) of container proxies ORC has reclaimed.
+  ## Populated by `ProxyHandle.=destroy` (which must touch nothing); drained by
+  ## `prune_dead_proxies` before any proxy-identity read and on tick. Global +
+  ## lock-guarded (NOT a threadvar): a context can be created on one thread —
+  ## minting proxies there — and then live on another (the threading tests'
+  ## worker handoff), so deaths must be visible to the pruning thread.
+
+proc `=destroy`(h: var typeof(ProxyHandle()[])) =
+  ## Records a dead proxy for its context to prune. Dereferences nothing — the
+  ## body and even the context may be reclaimed in the same ORC batch. A custom
+  ## `=destroy` replaces field destruction, so `object_id` is freed by hand.
+  if h.ctx_uid != 0 and h.object_id.len > 0:
+    {.cast(gcsafe).}:
+      dead_handles_lock.acquire()
+      pending_dead_proxies.mget_or_put(h.ctx_uid, @[]).add((h.object_id, h.gen))
+      dead_handles_lock.release()
+  `=destroy`(h.object_id)
+
+proc prune_dead_proxies*(self: EdContext) =
+  ## Clear body→proxy backrefs whose proxies ORC has reclaimed. Must run before
+  ## any backref read so a dangling cursor is never returned; `gen` ensures a
+  ## late prune can't clear a *newer* proxy minted after the death was recorded.
+  {.cast(gcsafe).}:
+    var dead: seq[(string, int)]
+    dead_handles_lock.acquire()
+    if self.uid in pending_dead_proxies:
+      dead = pending_dead_proxies[self.uid]
+      pending_dead_proxies.del(self.uid)
+    dead_handles_lock.release()
+    for (object_id, gen) in dead:
+      if object_id in self.objects and self.objects[object_id] != nil and
+          self.objects[object_id].proxy_gen == gen:
+        let body = self.objects[object_id]
+        body.proxy = nil
+        # The dead proxy's callbacks die with it — registered through it,
+        # cleaned when it goes (the sentinel model). Deterministic: next
+        # prune, not cycle-collector cadence.
+        if body.sweep_gen != nil:
+          for zid in body.sweep_gen(gen):
+            self.close_index.del(zid)
+
+proc resolve_proxy*(self: EdContext, body: ref EdBodyBase): ref EdBase =
+  ## The identity map: the one live proxy for `body`, minting if none. Two
+  ## resolutions of the same id are reference-equal while anything holds the
+  ## proxy — honest `ref` identity (docs/proxy-body-design.md).
+  if body == nil:
+    return nil
+  self.prune_dead_proxies
+  if body.proxy != nil:
+    return body.proxy
+  if body.mint != nil:
+    return body.mint()
+
+proc release_closures*(body: ref EdBodyBase) =
+  ## Break the body's self-capturing closures (mint/untrack_zid/sweep_gen all
+  ## capture the body). Required at unregistration: ORC does not collect
+  ## closure cycles, so an unreleased body would leak with its environment.
+  body.mint = nil
+  body.untrack_zid = nil
+  body.sweep_gen = nil
+
+proc drop_nested_bodies*(self: EdContext, nested: seq[string]) =
+  ## Unregister the nested container bodies an evicted entry carried (a paged-
+  ## out chunk's delta seq): the registry releases its strong hold, so the
+  ## memory frees once any remaining holder drops, and the id resolves fresh
+  ## on re-page-in. Local only — eviction never destroys upstream data.
+  for id in nested:
+    if id in self.objects:
+      let body = self.objects[id]
+      if body != nil:
+        if body.owner_id.len > 0 and body.owner_id in self.owned_by:
+          self.owned_by[body.owner_id].excl id
+        body.release_closures
+      self.objects.del id
+
 
 proc prune_dead_refs*(self: EdContext) =
   ## Remove from `ref_pool` the entries whose instances ORC has reclaimed (see
   ## `pending_dead_refs`). Must run before any `ref_pool` identity lookup so a
   ## dangling cursor is never read, and on tick to keep the pool tidy. Idempotent;
   ## cheap when nothing is pending.
-  if self.uid in pending_dead_refs:
-    {.cast(gcsafe).}:
-      for ref_id in pending_dead_refs[self.uid]:
-        self.ref_pool.del(ref_id)
+  {.cast(gcsafe).}:
+    var dead: seq[string]
+    dead_handles_lock.acquire()
+    if self.uid in pending_dead_refs:
+      dead = pending_dead_refs[self.uid]
       pending_dead_refs.del(self.uid)
+    dead_handles_lock.release()
+    for ref_id in dead:
+      self.ref_pool.del(ref_id)
 
 proc to_flatty*(s: var string, x: RefHandle) =
   ## Per-context-local state (uid + id), never synced — its uid is meaningless in

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -29,7 +29,7 @@ proc init_metrics*(_: type EdContext, labels: varargs[string]) =
 
 proc pack_objects*(self: EdContext) =
   if self.objects_need_packing:
-    var table: OrderedTable[string, ref EdBase]
+    var table: OrderedTable[string, ref EdBodyBase]
     for key, value in self.objects:
       if ?value:
         table[key] = value
@@ -79,10 +79,10 @@ proc init*(
 
   debug "EdContext initialized", id
 
-  inc next_ctx_uid
+  let uid = next_ctx_uid.fetch_add(1) + 1
   result = EdContext(
     id: id,
-    uid: next_ctx_uid,
+    uid: uid,
     blocking_recv: blocking_recv,
     max_recv_duration: max_recv_duration,
     min_recv_duration: min_recv_duration,
@@ -146,7 +146,7 @@ proc stamp_lsn*(self: EdContext, msg: var Message) =
     msg.lsn = self.next_lsn
 
 proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =
-  result = Ed[T, O](self.objects[src.id])
+  result = Ed[T, O](self.resolve_proxy(self.objects[src.id]))
 
 proc `[]`*(self: EdContext, id: string): ref EdBase =
   ## Container lookup by id. Raises `KeyError` when absent — except inside a
@@ -156,7 +156,7 @@ proc `[]`*(self: EdContext, id: string): ref EdBase =
   ## its old behavior (returns nil) and doesn't trigger a fetch.
   if self.blocking and self.materialize != nil and id notin self.objects:
     self.materialize(self, id)
-  result = self.objects[id]
+  result = self.resolve_proxy(self.objects[id])
 
 proc len*(self: Chan): int =
   private_access Chan

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -100,9 +100,18 @@ proc defaults[T, O](
     id: string,
     op_ctx: OperationContext,
     broadcast = true,
+    flags = DEFAULT_FLAGS,
+    placeholder = false,
 ): Ed[T, O] =
   privileged
   log_defaults
+
+  # The proxy/body split: the body carries the data + sync state; field access
+  # on the proxy forwards to it (types.nim templates). Minted here — before
+  # anything reads a forwarded field — since object construction can no longer
+  # set what are now body fields.
+  let body = EdBody[T, O](flags: flags, placeholder: placeholder)
+  self.body = body
 
   create_initializer(self)
 
@@ -123,7 +132,44 @@ proc defaults[T, O](
 
   if self.id in ctx.objects and not ?ctx.objects[self.id]:
     ctx.pack_objects
-  ctx.objects[self.id] = self
+  # The registry owns the body; the proxy is reachable through the backref +
+  # mint (resolve_proxy). `ctx_uid` by value so the handle's destructor never
+  # dereferences the context.
+  ctx.objects[self.id] = body
+  let ctx_uid = ctx.uid
+  body.mint = proc(): ref EdBase {.gcsafe.} =
+    let proxy = Ed[T, O](body: body)
+    inc body.proxy_gen
+    proxy.proxy_handle = ProxyHandle(
+      ctx_uid: ctx_uid, object_id: body.id, gen: body.proxy_gen
+    )
+    body.proxy = proxy
+    proxy
+  body.untrack_zid = proc(zid: EID) {.gcsafe.} =
+    # Context-level untrack: only meaningful while a proxy is live — a dead
+    # proxy's callbacks died with it. Prune first so the backref read is safe.
+    if body.ctx != nil:
+      body.ctx.prune_dead_proxies
+    if zid in body.changed_callbacks:
+      # Mirrors proxy-level `untrack` (defined downstream in subscriptions —
+      # not importable here): CLOSED notification, then drop the callback.
+      # `it` is the live proxy or nil — callbacks are body-side now.
+      let callback = body.changed_callbacks[zid]
+      if zid notin body.paused_eids:
+        callback(@[Change.init(O, {CLOSED})], body.proxy)
+      body.changed_callbacks.del(zid)
+      body.callback_gens.del(zid)
+  body.sweep_gen = proc(gen: int): seq[EID] {.gcsafe.} =
+    for zid, g in tables.pairs(body.callback_gens):
+      if g == gen:
+        result.add zid
+    for zid in result:
+      body.changed_callbacks.del(zid)
+      body.callback_gens.del(zid)
+  body.proxy_gen = 1
+  body.proxy = self
+  self.proxy_handle =
+    ProxyHandle(ctx_uid: ctx_uid, object_id: self.id, gen: 1)
 
   # If created inside an `own` scope, record the owner: bake its id into the
   # container and index it, so the owner's `destroy_owned` can tear this down in
@@ -134,7 +180,7 @@ proc defaults[T, O](
       self.owner_id = current_owner_id
       ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(self.id)
 
-  self.publish_create = proc(
+  self.body.publish_create = proc(
       sub: Subscription,
       broadcast: bool,
       op_ctx = OperationContext(),
@@ -147,13 +193,13 @@ proc defaults[T, O](
       # `contents = false` sends a handle: an empty-body CREATE (id + flags,
       # no data). Used to push LAZY containers to partial subscribers — the
       # receiver registers a placeholder and pulls entries per-key.
-      let bin = if contents: self.tracked.to_flatty else: ""
-    let id = self.id
-    let owner_id = self.owner_id
-    let flags = self.flags
+      let bin = if contents: body.tracked.to_flatty else: ""
+    let id = body.id
+    let owner_id = body.owner_id
+    let flags = body.flags
 
     template send_msg(src_ctx, sub) =
-      const ed_type_id = self.type.tid
+      const ed_type_id = Ed[T, O].tid
 
       # Capability filter: don't send an object to a peer that can't materialize
       # its type. Empty `capabilities` = unfiltered (same-build / no handshake).
@@ -172,7 +218,7 @@ proc defaults[T, O](
           msg.trace = get_stack_trace()
 
         src_ctx.send(
-          sub, msg, op_ctx, flags = self.flags & {SYNC_ALL_NO_OVERWRITE}
+          sub, msg, op_ctx, flags = body.flags & {SYNC_ALL_NO_OVERWRITE}
         )
 
     if sub.kind != BLANK:
@@ -184,8 +230,8 @@ proc defaults[T, O](
           ctx.send_msg(sub)
     ctx.tick_reactor
 
-  self.build_message = proc(
-      self: ref EdBase, change: BaseChange, id, trace: string
+  self.body.build_message = proc(
+      body: ref EdBodyBase, change: BaseChange, id, trace: string
   ): Message =
     var msg = Message(object_id: id, type_id: Ed[T, O].tid)
     # Collections (change object O differs from tracked T) are delta /
@@ -237,11 +283,13 @@ proc defaults[T, O](
         fail "Can't build message for changes " & $change.changes
     result = msg
 
-  self.change_receiver = proc(
-      self: ref EdBase, msg: Message, op_ctx: OperationContext
+  self.body.change_receiver = proc(
+      body: ref EdBodyBase, msg: Message, op_ctx: OperationContext
   ) =
-    assert self of Ed[T, O]
-    let self = Ed[T, O](self)
+    # Resolve (minting if none is live) the typed proxy: assign/unassign and
+    # callback triggering run through it. A fresh mint simply has no app
+    # callbacks to fire.
+    let self = Ed[T, O](body.ctx.resolve_proxy(body))
 
     if msg.kind == DESTROY:
       self.destroy
@@ -254,7 +302,7 @@ proc defaults[T, O](
         # placeholder so the container op applies and cardinality is correct.
         # Reading the placeholder later triggers a fetch (materialize-on-access).
         discard O.init_placeholder(self.ctx, object_id)
-      let item = O(self.ctx.objects[object_id])
+      let item = O(self.ctx.resolve_proxy(self.ctx.objects[object_id]))
     elif O is Pair[auto, Ed]:
       # Workaround for compile issue. This should be `O`, not `O.default.type`.
       type K = generic_params(O.default.type).get(0)
@@ -273,7 +321,7 @@ proc defaults[T, O](
           return
         # Value object not materialized yet — placeholder it (see above).
         discard V.init_placeholder(self.ctx, msg.change_object_id)
-      let value = V(self.ctx.objects[msg.change_object_id])
+      let value = V(self.ctx.resolve_proxy(self.ctx.objects[msg.change_object_id]))
       {.gcsafe.}:
         let item = O(key: msg.obj.from_flatty(K, self.ctx), value: value)
     else:
@@ -311,8 +359,8 @@ proc defaults[T, O](
     else:
       fail "Can't handle message " & $msg.kind
 
-  self.publish_key = proc(
-      self: ref EdBase, key_bin: string
+  self.body.publish_key = proc(
+      body: ref EdBodyBase, key_bin: string
   ): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.} =
     # Per-key fetch: build the ADD op for one entry so a partial subscriber can
     # pull it without the whole table. `nested` carries the ids of Ed
@@ -320,7 +368,7 @@ proc defaults[T, O](
     # publish them ahead of the entry — per-key deep. Only meaningful for
     # table containers.
     when O is Pair:
-      let self = Ed[T, O](self)
+      let self = Ed[T, O](body.ctx.resolve_proxy(body))
       type K = generic_params(O.default.type).get(0)
       {.gcsafe.}:
         let key = key_bin.from_flatty(K, self.ctx)
@@ -345,15 +393,15 @@ proc defaults[T, O](
     else:
       discard
 
-  self.evict_key = proc(
-      self: ref EdBase, key_bin: string
+  self.body.evict_key = proc(
+      body: ref EdBodyBase, key_bin: string
   ): tuple[found: bool, nested: seq[string]] {.gcsafe.} =
     # Per-key eviction: drop the entry locally (REMOVED callbacks fire so
     # watchers un-render; nothing publishes — the authority keeps the data) and
     # report nested Ed containers so the caller can shed them. The local half
     # of `release` and the receiving half of an eviction notice.
     when O is Pair:
-      let self = Ed[T, O](self)
+      let self = Ed[T, O](body.ctx.resolve_proxy(body))
       type K = generic_params(O.default.type).get(0)
       {.gcsafe.}:
         let key = key_bin.from_flatty(K, self.ctx)
@@ -389,8 +437,8 @@ proc init_placeholder*[T, O](
   ## `ctx.objects` under `id` and marked `placeholder`; no CREATE goes out.
   ## Reading it triggers a fetch; the real state fills it in later.
   # `op_ctx` is only consulted by defaults' broadcast, which we skip.
-  result = Ed[T, O](flags: DEFAULT_FLAGS, placeholder: true).defaults(
-    ctx, id, OperationContext(), broadcast = false
+  result = Ed[T, O]().defaults(
+    ctx, id, OperationContext(), broadcast = false, placeholder = true
   )
 
 proc init*(
@@ -402,7 +450,7 @@ proc init*(
 ): T =
   ## Initialize an empty `Ed` container of the given type.
   ctx.setup_op_ctx
-  T(flags: flags).defaults(ctx, id, op_ctx)
+  T().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*(
     _: type,
@@ -413,7 +461,7 @@ proc init*(
     op_ctx = OperationContext(),
 ): Ed[string, string] =
   ctx.setup_op_ctx
-  result = Ed[string, string](flags: flags).defaults(ctx, id, op_ctx)
+  result = Ed[string, string]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*(
     _: type Ed,
@@ -424,7 +472,7 @@ proc init*(
     op_ctx = OperationContext(),
 ): Ed[T, T] =
   ctx.setup_op_ctx
-  result = Ed[T, T](flags: flags).defaults(ctx, id, op_ctx)
+  result = Ed[T, T]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*[T: ref | object | tuple | array | SomeOrdinal | SomeNumber | string | ptr](
     _: type Ed,
@@ -435,7 +483,7 @@ proc init*[T: ref | object | tuple | array | SomeOrdinal | SomeNumber | string |
     op_ctx = OperationContext(),
 ): Ed[T, T] =
   ctx.setup_op_ctx
-  var self = Ed[T, T](flags: flags).defaults(ctx, id, op_ctx)
+  var self = Ed[T, T]().defaults(ctx, id, op_ctx, flags = flags)
 
   mutate(op_ctx):
     self.tracked = tracked
@@ -450,7 +498,7 @@ proc init*[O](
     op_ctx = OperationContext(),
 ): Ed[set[O], O] =
   ctx.setup_op_ctx
-  var self = Ed[set[O], O](flags: flags).defaults(ctx, id, op_ctx)
+  var self = Ed[set[O], O]().defaults(ctx, id, op_ctx, flags = flags)
 
   mutate(op_ctx):
     self.tracked = tracked
@@ -465,7 +513,7 @@ proc init*[K, V](
     op_ctx = OperationContext(),
 ): EdTable[K, V] =
   ctx.setup_op_ctx
-  var self = EdTable[K, V](flags: flags).defaults(ctx, id, op_ctx)
+  var self = EdTable[K, V]().defaults(ctx, id, op_ctx, flags = flags)
 
   mutate(op_ctx):
     self.tracked = tracked
@@ -480,7 +528,7 @@ proc init*[O](
     op_ctx = OperationContext(),
 ): Ed[seq[O], O] =
   ctx.setup_op_ctx
-  var self = Ed[seq[O], O](flags: flags).defaults(ctx, id, op_ctx)
+  var self = Ed[seq[O], O]().defaults(ctx, id, op_ctx, flags = flags)
 
   mutate(op_ctx):
     self.tracked = tracked
@@ -495,7 +543,7 @@ proc init*[O](
     op_ctx = OperationContext(),
 ): Ed[seq[O], O] =
   ctx.setup_op_ctx
-  result = Ed[seq[O], O](flags: flags).defaults(ctx, id, op_ctx)
+  result = Ed[seq[O], O]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*[O](
     _: type Ed,
@@ -506,7 +554,7 @@ proc init*[O](
     op_ctx = OperationContext(),
 ): Ed[set[O], O] =
   ctx.setup_op_ctx
-  result = Ed[set[O], O](flags: flags).defaults(ctx, id, op_ctx)
+  result = Ed[set[O], O]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*[K, V](
     _: type Ed,
@@ -517,7 +565,7 @@ proc init*[K, V](
     op_ctx = OperationContext(),
 ): Ed[Table[K, V], Pair[K, V]] =
   ctx.setup_op_ctx
-  result = Ed[Table[K, V], Pair[K, V]](flags: flags).defaults(ctx, id, op_ctx)
+  result = Ed[Table[K, V], Pair[K, V]]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*(
     _: type Ed,
@@ -528,7 +576,7 @@ proc init*(
     op_ctx = OperationContext(),
 ): EdTable[K, V] =
   ctx.setup_op_ctx
-  result = EdTable[K, V](flags: flags).defaults(ctx, id, op_ctx)
+  result = EdTable[K, V]().defaults(ctx, id, op_ctx, flags = flags)
 
 proc init*[T, O](
     self: var Ed[T, O],

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -4,29 +4,32 @@ import ed/[core, components/private/tracking, types {.all.}]
 import ./[contexts, validations, private]
 
 proc untrack_all*[T, O](self: Ed[T, O]) =
-  private_access EdObject[T, O]
-  private_access EdBase
-  private_access EdContext
+  privileged
   assert self.valid
   self.trigger_callbacks(@[Change.init(O, {CLOSED})])
-  for zid, _ in self.changed_callbacks.pairs:
-    self.ctx.close_procs.del(zid)
+  let body = self.typed_body
+  for zid, _ in body.changed_callbacks.pairs:
+    self.ctx.close_index.del(zid)
 
   for zid in self.bound_eids:
     self.ctx.untrack(zid)
 
-  self.changed_callbacks.clear
+  body.changed_callbacks.clear
+  body.callback_gens.clear
 
 proc untrack*(ctx: EdContext, zid: EID) =
   private_access EdContext
+  private_access EdBodyBase
 
-  # :(
-  if zid in ctx.close_procs:
-    ctx.close_procs[zid]()
-    debug "deleting close proc", zid
-    ctx.close_procs.del(zid)
+  if zid in ctx.close_index:
+    let object_id = ctx.close_index[zid]
+    ctx.close_index.del(zid)
+    if object_id in ctx.objects and ctx.objects[object_id] != nil:
+      let body = ctx.objects[object_id]
+      if body.untrack_zid != nil:
+        body.untrack_zid(zid)
   else:
-    debug "No close proc for zid", zid = zid
+    debug "No close index entry for zid", zid = zid
 
 proc contains*[T, O](self: Ed[T, O], child: O): bool =
   privileged
@@ -120,7 +123,10 @@ proc release*[K, V](self: EdTable[K, V], key: K) =
   assert self.valid
   let key_bin = key.to_flatty
   if key in self.tracked:
-    discard self.evict_key(self, key_bin)
+    let evicted = self.evict_key(self, key_bin)
+    # The entry's nested containers (a chunk's delta seq) leave the registry
+    # too — paging out actually frees their memory (proxy/body phase 3).
+    self.ctx.drop_nested_bodies(evicted.nested)
   self.ctx.pending_key_releases.mgetOrPut(self.id, @[]).add key_bin
 
 proc release*[K, V](self: EdTable[K, V], keys: openArray[K]) =
@@ -311,18 +317,18 @@ proc resume_changes*(self: Ed, eids: varargs[EID]) =
     self.paused_eids = {}
   else:
     for eid in eids:
-      self.paused_eids.excl(eid)
+      self.typed_body.paused_eids.excl(eid)
 
 template pause_impl(self: Ed, eids: untyped, body: untyped) =
-  private_access EdBase
+  privileged
 
-  let previous = self.paused_eids
+  let previous = self.typed_body.paused_eids
   for eid in eids:
-    self.paused_eids.incl(eid)
+    self.typed_body.paused_eids.incl(eid)
   try:
     body
   finally:
-    self.paused_eids = previous
+    self.typed_body.paused_eids = previous
 
 template pause*(self: Ed, eids: varargs[EID], body: untyped) =
   mixin valid
@@ -330,10 +336,10 @@ template pause*(self: Ed, eids: varargs[EID], body: untyped) =
   pause_impl(self, eids, body)
 
 template pause*(self: Ed, body: untyped) =
-  private_access EdObject
+  privileged
   mixin valid
   assert self.valid
-  pause_impl(self, self.changed_callbacks.keys, body)
+  pause_impl(self, self.typed_body.changed_callbacks.keys, body)
 
 proc destroy*[T, O](self: Ed[T, O], publish = true) =
   ## Destroy the container and remove it from its context.
@@ -342,6 +348,7 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
   assert self.valid
   self.untrack_all
   self.destroyed = true
+  self.body.release_closures # break body self-captures (no cycle GC)
   self.ctx.objects[self.id] = nil
   self.ctx.objects_need_packing = true
   self.ctx.latest_op_id.del(self.id)  # drop own-op reconciliation state

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -125,7 +125,7 @@ proc release*[K, V](self: EdTable[K, V], key: K) =
   if key in self.tracked:
     let evicted = self.evict_key(self, key_bin)
     # The entry's nested containers (a chunk's delta seq) leave the registry
-    # too — paging out actually frees their memory (proxy/body phase 3).
+    # too, so paging out actually frees their memory.
     self.ctx.drop_nested_bodies(evicted.nested)
   self.ctx.pending_key_releases.mgetOrPut(self.id, @[]).add key_bin
 

--- a/src/ed/zens/private.nim
+++ b/src/ed/zens/private.nim
@@ -39,3 +39,5 @@ template privileged*() =
   private_access EdContext
   private_access EdBase
   private_access EdObject
+  private_access EdBodyBase
+  private_access EdBody

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -470,7 +470,7 @@ proc run*() =
     var calls = 0
     s.changes:
       calls += 1
-      s.value = "cal"
+      it.value = "cal"
 
     s.value = "vin"
     check calls == 2

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -167,6 +167,28 @@ proc run*() =
     obj.value = "no_trigger"
     check callback_count == 0
 
+  test "dropped proxy frees promptly; its callbacks sweep on the next prune":
+    # The sentinel model (callbacks live on the registry-owned body): a proxy
+    # holds nothing, so it dies at refcount zero — no cycle collector — and
+    # the next prune sweeps the callbacks registered through it. No GC_full_
+    # collect anywhere in this test.
+    var ctx = EdContext.init(id = "pc_ctx")
+    Ed.thread_ctx = ctx
+    var fired = 0
+    block:
+      var obj = EdValue[string].init(ctx = ctx, id = "pc_obj")
+      discard obj.track proc(changes: seq[Change[string]]) {.gcsafe.} =
+        inc fired # no reference to obj: nothing pins the proxy
+      obj.value = "one"
+      check fired >= 1
+      fired = 0
+    # Proxy died promptly at block exit; resolving the id prunes the dead
+    # generation, sweeping its callbacks, and mints a fresh proxy.
+    var again = EdValue[string](ctx["pc_obj"])
+    again.value = "two"
+    check fired == 0 # the dead generation's callback did not survive
+    check again.value == "two" # canonical data lives on the body throughout
+
 when is_main_module:
   Ed.bootstrap
   run()

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -504,6 +504,54 @@ proc run*() =
       check htbl[1] == "one, unseen"
       check ltbl[1] == "one, unseen"
 
+    test "paging out drops an entry's nested container bodies":
+      # The chunk_deltas case: each entry's value is its own container. Before
+      # phase 3 the seq stayed pinned in ctx.objects after eviction; now the
+      # registry releases it (the stats screen's object count follows paging),
+      # and re-paging-in resolves a fresh body.
+      var authority = EdContext.init(id = "nb_auth", is_authority = true)
+      var client = EdContext.init(id = "nb_client")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "nb_owner")
+      var tbl: EdTable[int, EdSeq[int]]
+      owner.own:
+        tbl = EdTable[int, EdSeq[int]].init(
+          ctx = authority, id = "nb_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      var entry = EdSeq[int].init(ctx = authority, id = "nb_entry")
+      entry.add 7
+      tbl[1] = entry
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      discard client.fetch("nb_owner", deep = true)
+      authority.tick()
+      client.tick()
+      let ctbl = EdTable[int, EdSeq[int]](client["nb_tbl"])
+
+      ctbl.request(1)
+      client.tick()
+      authority.tick()
+      client.tick()
+      check ctbl.loaded(1)
+      check "nb_entry" in client # the nested seq came with the entry
+
+      ctbl.release(1)
+      check not ctbl.loaded(1)
+      check "nb_entry" notin client # ...and leaves the registry with it
+
+      client.tick() # flush the release upstream
+      authority.tick()
+      check "nb_entry" in authority # eviction is local; the authority keeps it
+
+      ctbl.request(1) # paging back in restores entry + nested seq
+      client.tick()
+      authority.tick()
+      client.tick()
+      check ctbl.loaded(1)
+      check "nb_entry" in client
+      check ctbl[1][0] == 7
+
     test "per-key chain outruns the closure push (handle-first replies)":
       # A leaf can request keys before the hub holds the table (the closure
       # push carrying the LAZY handle hasn't landed). Without handle-first

--- a/tests/threading_tests.nim
+++ b/tests/threading_tests.nim
@@ -16,13 +16,13 @@ proc start_worker(ctx: EdContext) {.thread.} =
   var working = true
   b.changes:
     if "scott".added:
-      b.value = "marie"
+      it.value = "marie"
     if "claire".added:
-      b.value = "cal"
+      it.value = "cal"
     if "vin".added:
-      b.value = "banana"
+      it.value = "banana"
     if "bacon".added:
-      b.value = "ghetti"
+      it.value = "ghetti"
     if "done".added:
       working = false
 
@@ -51,18 +51,18 @@ proc run*() =
     var working = true
     a.changes:
       if "marie".added:
-        a.value = "claire"
+        it.value = "claire"
       if "cal".added:
-        a.value = "vin"
+        it.value = "vin"
       if "banana".added:
-        a.value = "bacon"
+        it.value = "bacon"
       if "ghetti".added:
         remaining -= 1
         if remaining == 0:
-          a.value = "done"
+          it.value = "done"
           working = false
         else:
-          a.value = "scott"
+          it.value = "scott"
 
     while working:
       Ed.thread_ctx.tick


### PR DESCRIPTION
**Stacked on #16.** PR 4 — the v2 container object model. The biggest structural change in the stack, but API-frozen: forwarding templates keep every call site (and all of enu) compiling unchanged.

- **Registry-owned bodies** — `objects: id → ref EdBodyBase` holds `tracked` + sync state/closures; the proxy is a thin `ref` the app holds. Cold objects get cheap/persistable (no per-id husks).
- **True ref proxy + identity map** — `resolve_proxy` returns *the* live proxy via a non-owning body→proxy backref, minting if none. Deferred prune (not `GC_ref`): `ProxyHandle.=destroy` records `(ctx_uid, object_id, gen)` on a lock-guarded global pending list; `prune_dead_proxies` clears dead backrefs before every identity read. `EdContext.uid` is now a process-global atomic (fixes a cross-thread uid-collision UAF).
- **Sentinel callbacks** — callbacks live on the body (ORC doesn't collect closure cycles); the proxy is a sentinel that dies promptly and sweeps its generation's callbacks. The live proxy arrives as the `it` parameter, never a capture; body self-captures released via `release_closures`. Narrow self-capture warning.

Full suite + `tests/asan.sh` green (0 ASan errors — this is the UAF-class step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)