### PR TITLE
feat(evict): partial-replica evictor + live/cache interest tiers

### DIFF
--- a/docs/partial-replicas.md
+++ b/docs/partial-replicas.md
@@ -105,10 +105,38 @@ downstream interest in a key sheds its own copy and chains the release upstream.
 
 ## Notes
 
-- Whole-object interest is **grows-only** (roots + fetched ids accumulate); per-key
-  interest is sheddable via `release`. Whole-object eviction is a later layer (it
-  needs the per-key/eviction machinery, not a
-  durable log; the authority serves subsets from memory).
 - Builds on the relaxed validation (a replica already tolerates ops for objects it
   doesn't hold) and the per-object reconciliation frontier (delivery is already
   per-object). See `consistency.md`.
+
+## Eviction & interest tiers
+
+Only a **partial replica** evicts. A full clone mirrors everything its upstream
+has — there's no safe residue to drop, and evicting one breaks live round-trips
+(an enu node ctx, a full clone, given `mem_limit = 0` intermittently hung the bot
+test and godot shutdown), so a full clone ignores `mem_limit` entirely. Client
+memory is managed at the **worker** (the partial replica), on its own thread with
+orderly teardown.
+
+`mem_limit` is an honest byte budget: `0` = no cache (evict the moment something
+isn't live; negatives clamp here), `0 < n < Unbounded` = cache to `n` bytes then
+shed LRU, `Unbounded` (= `int.high`) = never evict (authority, full clones). Two
+predicates centralize the decode: `evicts` (partial + finite limit) and
+`has_budget` (evicts + positive → tracks per-body bytes). The sweep
+(`evict_sweep`) is the safety/policy split from `proxy-body.md`: a body is a
+candidate only with **no live proxy** (safety) and outside live interest (policy);
+cold/over-budget candidates drop, retracting interest upstream so the stream stops.
+
+**Interest tiers (live vs cache).** `interest` conflated "hold because I'm using
+it" with "hold because I cached it"; since interest propagates upward, a downstream
+caching freely pinned its upstream forever. So interest splits: live
+(`interest − interest_cache`, mandatory — the upstream must hold and stream it, and
+it protects against eviction) vs cache (`interest_cache`, still streamed so the
+cache stays current, but *not* eviction-protecting — the upstream may reclaim it
+under its own pressure and invalidate the holder). Each sweep `reconcile_tier`
+sends a lightweight `INTEREST` op (`demote`/`promote`) upstream when an object's
+local liveness (`is_live_here`) flips. So an upstream is bounded by
+`live(subtree) + its own budget`, never by a downstream's `mem_limit`; propagation
+cascades through hubs with no special-casing. A caching hub keeps released per-key
+entries as cache-tier and sheds them by per-key LRU under its own budget (a player
+stepping back into an area is served locally, no refetch).

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -848,7 +848,7 @@ const churn_limit = 8
   ## much traffic, and refill is a single fetch. A see-it-work default.
 
 proc evict_sweep*(self: EdContext) =
-  ## Partial-replica eviction (docs/proxy-body-design.md phase 4), by mode (see
+  ## Partial-replica eviction (docs/partial-replicas.md), by mode (see
   ## EdContext.mem_limit): 0 evict every unclaimed body now; finite n churn +
   ## LRU-to-budget; Unbounded never evict. All eviction is gated on
   ## `evict_candidate`.
@@ -856,9 +856,8 @@ proc evict_sweep*(self: EdContext) =
   ## ONLY partial replicas evict (`evicts`). A full clone (partial_replica =
   ## false) mirrors everything its upstream has — there's no safe "residue" to
   ## drop, because anything it holds is synced state something may read back.
-  ## Evicting on a full clone breaks live round-trips (observed: an enu node ctx
-  ## given a finite limit intermittently hung the bot test mid-sync, and hung
-  ## godot's shutdown). So `mem_limit` is ignored on a full clone.
+  ## Evicting on a full clone breaks live round-trips, so `mem_limit` is ignored
+  ## there.
   if not self.evicts:
     return
   self.prune_dead_proxies

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -1,7 +1,7 @@
 import
   std/[
     importutils, isolation, tables, sets, sequtils, algorithm, intsets, locks,
-    math, times, strutils, macros, os,
+    math, times, strutils, macros, os, heapqueue,
   ]
 
 import pkg/threading/channels {.all.}
@@ -212,7 +212,6 @@ proc remote_body(msg: Message, no_overwrite: bool): string =
   var body_msg = msg
   body_msg.source = @[]
   body_msg.id_mappings = @[]
-  body_msg.key_bin = "" # sender-side per-key filter tag; not wire data
   if no_overwrite:
     body_msg.obj = ""
   result = body_msg.to_flatty.ed_compress
@@ -348,7 +347,7 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   self.ctx.tick_reactor
 
 proc publish_closure(
-    self: EdContext, s: Subscription, root_id: string, follow = true
+    self: EdContext, s: Subscription, root_id: string
 ): bool {.discardable.} =
   ## Serve an ownership closure to `s`: BFS from `root_id` over `owned_by`,
   ## publishing every container and following member keys (tid:id) into the
@@ -356,7 +355,8 @@ proc publish_closure(
   ## OWNS_MEMBERS collection's member closures *before* the collection itself —
   ## so a partial subscriber's parse links member fields to real containers
   ## instead of minting unregistered husks. Returns whether anything was found.
-  ## With `follow`, everything published joins `s.interest` so future ops flow.
+  ## Everything published (except LAZY handles) joins `s.interest` so future ops
+  ## flow.
   privileged
   var ids = @[root_id]
   var to_publish: seq[string]
@@ -392,8 +392,7 @@ proc publish_closure(
       # entries with request/release; a whole-table push would defeat LAZY.
       zen.publish_create(s, contents = false)
     else:
-      if follow:
-        s.interest.incl id
+      s.interest.incl id
       zen.publish_create(s)
 
 proc serve_key_wants(self: EdContext, object_id: string) =
@@ -463,9 +462,9 @@ proc add_obj_want(self: EdContext, requester: Subscription, msg: Message) =
     for want in self.pending_obj_wants[msg.object_id]:
       if want.sub.ctx_id == requester.ctx_id:
         return
-    self.pending_obj_wants[msg.object_id].add (requester, msg.deep, msg.follow)
+    self.pending_obj_wants[msg.object_id].add (requester, msg.deep)
   else:
-    self.pending_obj_wants[msg.object_id] = @[(requester, msg.deep, msg.follow)]
+    self.pending_obj_wants[msg.object_id] = @[(requester, msg.deep)]
     self.forward_request(requester, msg)
 
 proc pack_messages(msgs: seq[Message]): seq[Message] =
@@ -488,7 +487,10 @@ proc pack_messages(msgs: seq[Message]): seq[Message] =
         assert packed_msg.type_id == 0 or packed_msg.type_id == msg.type_id
 
         packed_msg.type_id = msg.type_id
-      ops.add (msg.kind, msg.ref_id, msg.change_object_id, msg.obj)
+      ops.add (
+        msg.kind, msg.ref_id, msg.change_object_id, msg.obj, msg.delta,
+        msg.key_bin,
+      )
 
     packed_msg.obj = ops.to_flatty
     result = @[packed_msg]
@@ -739,18 +741,217 @@ proc subscribe*(
     # Reverse direction (us → authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false, upstream = false)
 
+proc any_interest*(self: EdContext, object_id: string): bool =
+  ## Does any subscriber below us still hold *live* interest in this object —
+  ## directly or via a key? Cache-tier interest (`interest_cache`) does NOT
+  ## count: the subscriber only has it cached, so we may evict it and
+  ## invalidate them (Option 2). Interest auto-propagates downward, so "no live
+  ## interest" means nothing live in the whole subtree beneath us.
+  for s in self.subscribers:
+    if s.ctx_id in self.upstream_ctx_ids:
+      continue # the reverse link to our upstream is not downstream interest
+    if object_id in s.interest and object_id notin s.interest_cache:
+      return true
+    if object_id in s.key_interest:
+      return true
+  result = false
+
+proc cache_holders(self: EdContext, object_id: string): seq[Subscription] =
+  ## Subscribers holding `object_id` at cache tier — they need an invalidation
+  ## when we evict it, so they drop their now-orphaned cache.
+  for s in self.subscribers:
+    if s.ctx_id in self.upstream_ctx_ids:
+      continue
+    if object_id in s.interest_cache:
+      result.add s
+
+proc evict_body*(self: EdContext, object_id: string) =
+  ## Reclaim a dormant, unclaimed body: drop it locally and retract our
+  ## interest upstream so its ops stop flowing (otherwise the next op would
+  ## just re-materialize it). No downstream relay — by the candidate gate
+  ## nobody below us wants it. The data is safe on the authority; a later
+  ## access re-fetches. Partial replicas only.
+  if object_id notin self.objects or self.objects[object_id] == nil:
+    return
+  let body = self.objects[object_id]
+  # Retract upstream: a whole-object RELEASE (empty key batch) tells our
+  # source to stop following it for us.
+  let msg = Message(kind: RELEASE, object_id: object_id)
+  for sub in self.subscribers:
+    if sub.ctx_id in self.upstream_ctx_ids:
+      self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  # Invalidate any downstream cache holders: the body's gone, so the cache they
+  # hold of it is orphaned (a whole-object RELEASE from us = eviction notice).
+  for holder in self.cache_holders(object_id):
+    holder.interest.excl object_id
+    holder.interest_cache.excl object_id
+    self.send(holder, msg, OperationContext(), DEFAULT_FLAGS)
+  # Stop following it ourselves, drop ownership-index + bytes, unregister.
+  if body.owner_id.len > 0 and body.owner_id in self.owned_by:
+    self.owned_by[body.owner_id].excl object_id
+  self.forget_body_bytes(body)
+  body.release_closures
+  self.objects.del object_id
+  self.objects_need_packing = true
+  self.tick_reactor
+
+proc is_live_here(self: EdContext, body: ref EdBodyBase): bool =
+  ## Is this object live at our node — actively used, not merely cached?
+  ## True when we hold a live proxy, it's a piece of a live owner, or some
+  ## downstream holds *live* interest. Drives the interest tier we report
+  ## upstream (live vs cache) and the eviction gate.
+  if body == nil:
+    return false
+  if body.proxy != nil:
+    return true
+  if body.owner_id.len > 0 and body.owner_id in self.objects and
+      self.objects[body.owner_id] != nil and self.objects[body.owner_id].proxy != nil:
+    return true
+  if self.any_interest(body.id): # any_interest is live-only (Option 2)
+    return true
+  result = false
+
+proc evict_candidate(self: EdContext, body: ref EdBodyBase): bool =
+  ## Eligible for eviction: not live here (no live use, nobody below wants it
+  ## live), and it actually holds data worth reclaiming. Placeholders and LAZY
+  ## handles are never candidates (no resident data; LAZY is paged per-key).
+  if body == nil or body.placeholder or LAZY in body.flags:
+    return false
+  result = not self.is_live_here(body)
+
+const up_live = 1
+const up_cache = 2
+
+proc reconcile_tier(self: EdContext, body: ref EdBodyBase) =
+  ## Tell our upstream whether we hold this object live or merely cached, when
+  ## that flips (Option 2). Only for objects we follow from upstream (up_tier
+  ## set on materialize); our own creations are left alone. A demote lets the
+  ## upstream reclaim it under *its* pressure; a promote re-protects it.
+  if body == nil or body.up_tier == 0:
+    return
+  let live = self.is_live_here(body)
+  if not live and body.up_tier != up_cache:
+    body.up_tier = up_cache
+    let msg = Message(kind: INTEREST, object_id: body.id, demote: true)
+    for sub in self.subscribers:
+      if sub.ctx_id in self.upstream_ctx_ids:
+        self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+  elif live and body.up_tier == up_cache:
+    body.up_tier = up_live
+    let msg = Message(kind: INTEREST, object_id: body.id, demote: false)
+    for sub in self.subscribers:
+      if sub.ctx_id in self.upstream_ctx_ids:
+        self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
+
+const churn_limit = 8
+  ## Arriving ops on a dormant body before we evict it: holding it costs that
+  ## much traffic, and refill is a single fetch. A see-it-work default.
+
+proc evict_sweep*(self: EdContext) =
+  ## Partial-replica eviction (docs/proxy-body-design.md phase 4), by mode (see
+  ## EdContext.mem_limit): 0 evict every unclaimed body now; finite n churn +
+  ## LRU-to-budget; Unbounded never evict. All eviction is gated on
+  ## `evict_candidate`.
+  ##
+  ## ONLY partial replicas evict (`evicts`). A full clone (partial_replica =
+  ## false) mirrors everything its upstream has — there's no safe "residue" to
+  ## drop, because anything it holds is synced state something may read back.
+  ## Evicting on a full clone breaks live round-trips (observed: an enu node ctx
+  ## given a finite limit intermittently hung the bot test mid-sync, and hung
+  ## godot's shutdown). So `mem_limit` is ignored on a full clone.
+  if not self.evicts:
+    return
+  self.prune_dead_proxies
+  # Idle fast path: nothing an eviction would act on has changed since the last
+  # sweep, and we're within budget — so there's nothing to reconcile, churn, or
+  # shed. Skip the O(objects) scans entirely (a calm context pays ~nothing per
+  # tick). prune_dead_proxies above may have set sweep_dirty (a liveness flip).
+  if not self.sweep_dirty and self.used_bytes <= self.mem_limit:
+    return
+  self.sweep_dirty = false # we're doing the work now
+  if self.mem_limit == 0:
+    # No cache: shed everything that isn't live, this tick. No byte accounting.
+    var gone: seq[string]
+    for id, body in self.objects:
+      if self.evict_candidate(body):
+        gone.add id
+    for id in gone:
+      debug "evicting (no-cache)", object_id = id
+      self.evict_body(id)
+    return
+  # Cache mode (mem_limit > 0). One scan does both: reconcile interest tiers (an
+  # object gone non-live here demotes upstream so it can reclaim it under its own
+  # pressure; one back live re-promotes) and collect churn candidates (a dormant
+  # body that keeps taking ops costs more than a refetch). What we shed is, by
+  # definition, cache tier.
+  var churned: seq[string]
+  for id, body in self.objects:
+    if body == nil:
+      continue
+    self.reconcile_tier(body)
+    if body.updates >= churn_limit and self.evict_candidate(body):
+      churned.add id
+  for id in churned:
+    debug "evicting (churn)", object_id = id, updates = self.objects[id].updates
+    self.evict_body(id)
+  # Pressure pass — only when over budget. LRU: oldest read goes first. A heap
+  # (O(n) build, O(k log n) to pop the k we actually evict) avoids sorting the
+  # whole candidate set just to drop a few off the cold end.
+  if self.used_bytes <= self.mem_limit:
+    return
+  var cands: seq[(MonoTime, string)]
+  for id, body in self.objects:
+    if self.evict_candidate(body):
+      cands.add (body.last_read, id)
+  var cand_heap = cands.to_heap_queue # min by last_read: least-recently-read first
+  while self.used_bytes > self.mem_limit and cand_heap.len > 0:
+    let (_, id) = cand_heap.pop
+    debug "evicting (pressure)",
+      object_id = id, used = self.used_bytes, limit = self.mem_limit
+    self.evict_body(id)
+  # Per-key cache pass — the bulk of a paging client's memory is in LAZY tables
+  # (voxel chunks), which the whole-object passes skip. If still over budget,
+  # shed cache-tier keys (no live downstream interest) least-recently-served
+  # first, retracting each upstream so its stream stops too.
+  if self.used_bytes <= self.mem_limit:
+    return
+  var keyed: seq[(MonoTime, string, string)] # (recency, object_id, key_bin)
+  for id, body in self.objects:
+    if body == nil or LAZY notin body.flags:
+      continue
+    for key_bin in body.key_bytes.keys:
+      var live = false
+      for s in self.subscribers:
+        if s.ctx_id in self.upstream_ctx_ids:
+          continue
+        if id in s.key_interest and key_bin in s.key_interest[id]:
+          live = true
+          break
+      if not live:
+        keyed.add (body.key_last_read.getOrDefault(key_bin), id, key_bin)
+  var key_heap = keyed.to_heap_queue # min by recency: least-recently-served first
+  while self.used_bytes > self.mem_limit and key_heap.len > 0:
+    let (_, id, key_bin) = key_heap.pop
+    debug "evicting key (pressure)", object_id = id
+    let obj = self.objects[id]
+    if obj != nil and obj.evict_key != nil:
+      let evicted = obj.evict_key(obj, key_bin) # evict_key → forget_key_bytes
+      self.drop_nested_bodies(evicted.nested)    # ...clears key_last_read too
+    self.pending_key_releases.mgetOrPut(id, @[]).add key_bin # retract upstream
+
 proc fetch*(
-    self: EdContext, object_id: string, deep = false, follow = true
+    self: EdContext, object_id: string, deep = false
 ): Fetch {.discardable.} =
   ## Ask the authority for `object_id`. Returns a handle that resolves on a
   ## later tick: `Found` (with `obj` linking the container) when it arrives, or
   ## `NotFound` if the authority NACKs. Already holding it loaded resolves
   ## immediately; fetching an id already in flight returns the same handle.
   ##
-  ## `follow` (default) registers interest with the authority, so future ops
-  ## follow — and a *missing* id is delivered whenever something creates it
-  ## (the handle still resolves NotFound for "not there right now").
-  ## `follow = false` is a snapshot: current state only, nothing afterwards.
+  ## Always registers interest, so future ops follow — and a *missing* id is
+  ## delivered whenever something creates it (the handle still resolves NotFound
+  ## for "not there right now"). To stop following, drop your reference: with no
+  ## live proxy the object becomes an eviction candidate and its interest is
+  ## retracted upstream when it's reclaimed (see the evictor / `mem_limit`).
   ##
   ## `deep` also fetches everything the id *owns* (the synced-ownership closure,
   ## recursively) — so an owner id (a unit, which isn't itself a container) pulls
@@ -766,8 +967,7 @@ proc fetch*(
     return self.fetches[object_id]
   result = Fetch(id: object_id, state: Pending)
   self.fetches[object_id] = result
-  var msg =
-    Message(kind: REQUEST, object_id: object_id, deep: deep, follow: follow)
+  var msg = Message(kind: REQUEST, object_id: object_id, deep: deep)
   for sub in self.request_targets:
     self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
@@ -915,6 +1115,11 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   privileged
   log_defaults("ed publishing")
 
+  # Any inbound message can change what an eviction sweep would act on (resident
+  # bytes, interest, liveness), so mark the sweep dirty. Coarse but cheap; the
+  # sweep does its O(objects) work only when this (or a pruned death) is set.
+  self.sweep_dirty = true
+
   # Get source: either from source_set (Local) or decode from source (Remote)
   let source =
     if msg.source_set.len > 0:
@@ -991,6 +1196,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         ref_id: op.ref_id,
         change_object_id: op.change_object_id,
         obj: op.obj,
+        delta: op.delta,
+        key_bin: op.key_bin,
         flags: msg.flags,
         source: msg.source,
         source_set: msg.source_set,
@@ -1044,6 +1251,13 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       self.owned_by.mgetOrPut(msg.owner_id, initHashSet[string]()).incl(
         msg.object_id
       )
+    # Interest tiering (Option 2): a body materialized from an upstream CREATE
+    # is one we follow — mark it live-up so the sweep reconciles its tier as it
+    # goes live/cache here. Only on an evicting partial replica with an upstream.
+    if self.evicts and self.upstream_ctx_ids.len > 0 and
+        msg.object_id in self.objects and self.objects[msg.object_id] != nil:
+      if self.objects[msg.object_id].up_tier == 0:
+        self.objects[msg.object_id].up_tier = up_live
     # Resolve fetch handles: the object itself and — for a deep fetch of an
     # *owner* id — the owner its containers point back to (the owner has no
     # container of its own, so its handle resolves via the arriving closure).
@@ -1064,10 +1278,9 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         let wants = self.pending_obj_wants[id]
         self.pending_obj_wants.del(id)
         for want in wants:
-          if want.follow:
-            want.sub.interest.incl id
+          want.sub.interest.incl id
           if want.deep:
-            discard self.publish_closure(want.sub, id, follow = want.follow)
+            discard self.publish_closure(want.sub, id)
           elif id in self.objects and ?self.objects[id]:
             self.objects[id].publish_create(want.sub)
 
@@ -1118,6 +1331,43 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
             DEFAULT_FLAGS,
           )
         self.pending_obj_wants.del msg.object_id
+  elif msg.kind == RELEASE and msg.obj.len == 0:
+    # Whole-object release (evictor): a peer dropped object_id entirely.
+    #  - From a subscriber: an interest retract — stop streaming it to them.
+    #  - From upstream: an eviction notice — but a received drop is NEVER
+    #    authoritative over a live local hold (Scott's rule). Evict only if we
+    #    aren't using it ourselves and nobody below us wants it; otherwise keep
+    #    using it and let our own evictor reclaim it when it goes dormant.
+    for s in self.subscribers:
+      if s.ctx_id notin source:
+        continue
+      s.interest.excl msg.object_id
+      s.interest_cache.excl msg.object_id
+      s.key_interest.del msg.object_id
+    var from_upstream = false
+    for src in source:
+      if src in self.upstream_ctx_ids:
+        from_upstream = true
+        break
+    if from_upstream and msg.object_id in self and
+        self.objects[msg.object_id].proxy == nil and
+        not self.any_interest(msg.object_id):
+      self.evict_body(msg.object_id)
+  elif msg.kind == INTEREST:
+    # Live/cache tier change from a downstream subscriber (Option 2). Demote
+    # moves the object to that subscriber's cache tier — it still streams, but
+    # no longer protects the object from our eviction; promote moves it back.
+    # Our own up-tier to the authority then reconciles on the next sweep (our
+    # aggregate downstream liveness changed).
+    for s in self.subscribers:
+      if s.ctx_id notin source:
+        continue
+      if msg.object_id notin s.interest:
+        continue
+      if msg.demote:
+        s.interest_cache.incl msg.object_id
+      else:
+        s.interest_cache.excl msg.object_id
   elif msg.kind == RELEASE:
     # Per-key paging notice (see `release`). Role decides the meaning:
     #  - From a subscriber that pages from us: an interest retract — stop
@@ -1156,12 +1406,15 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
                 self.pending_key_wants[msg.object_id][key_bin].filter_it(
                   it.ctx_id != s.ctx_id
                 )
-    if retracted and self.partial_replica and not self.is_authority:
-      # Hub shedding — the symmetric counterpart of request chaining. A
-      # partial hub holds paged keys only to serve its subscribers; when the
-      # last interest in a key retracts, drop our copy and chain the release
-      # upstream (the queued broadcast also notifies any remaining downstream
-      # clones, where eviction is an idempotent no-op).
+    if retracted and self.partial_replica and not self.is_authority and
+        self.mem_limit == 0:
+      # No-cache hub: shed immediately (the symmetric counterpart of request
+      # chaining). When the last interest in a key retracts, drop our copy and
+      # chain the release upstream. A caching hub (mem_limit > 0) instead KEEPS
+      # the key — it becomes cache-tier (no live downstream wants it), stays
+      # current via the stream, and the per-key cache LRU sheds it under our
+      # own pressure (so a downstream's release doesn't force us to refetch on
+      # its return).
       for key_bin in keys:
         var still_wanted = false
         for s in self.subscribers:
@@ -1251,6 +1504,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           for key_bin in msg.obj.from_flatty(seq[string]):
             let reply = obj.publish_key(obj, key_bin)
             if reply.found:
+              if self.has_budget: # recency only feeds the cache LRU
+                obj.key_last_read[key_bin] = get_mono_time() # served → in-view
               # Per-key deep: nested containers (a chunk's delta seq) go
               # first so the receiver's parse links them — and they're
               # followed, so their future ops (delta appends) stream.
@@ -1294,11 +1549,10 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         # Deep fetch: the id plus its ownership closure (see publish_closure —
         # the requested id may be an *owner*, a unit id with no container of its
         # own, and the walk recurses through owned members into their subtrees).
-        let found = self.publish_closure(s, msg.object_id, follow = msg.follow)
-        if msg.follow:
-          # Follow the root id itself even if nothing exists yet: a later
-          # CREATE under this id is then delivered without re-fetching.
-          s.interest.incl msg.object_id
+        let found = self.publish_closure(s, msg.object_id)
+        # Follow the root id itself even if nothing exists yet: a later CREATE
+        # under this id is then delivered without re-fetching.
+        s.interest.incl msg.object_id
         if not found:
           if self.is_authority:
             self.send(
@@ -1311,16 +1565,13 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
             self.add_obj_want(s, msg)
       else:
         if msg.object_id in self and not self.objects[msg.object_id].placeholder:
-          if msg.follow:
-            s.interest.incl msg.object_id
+          s.interest.incl msg.object_id
           self.objects[msg.object_id].publish_create(s)
         else:
           # Missing — or held only as an unloaded placeholder, which would
-          # serve empty state; chain instead so the real data comes back.
-          if msg.follow:
-            # Keep the interest so a later CREATE under this id is delivered
-            # without re-fetching.
-            s.interest.incl msg.object_id
+          # serve empty state; chain instead so the real data comes back. Keep
+          # the interest so a later CREATE under this id is delivered.
+          s.interest.incl msg.object_id
           if self.is_authority:
             self.send(
               s,
@@ -1342,6 +1593,20 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           object_id = msg.object_id, kind = msg.kind
       return
     let obj = self.objects[msg.object_id]
+    # Eviction accounting: an arriving op for a body we're not reading is churn
+    # (the signal that holding it costs traffic); collection deltas also move
+    # its resident size. Cheap, and only when there's a finite budget to track.
+    if self.has_budget:
+      inc obj.updates
+      if msg.delta and msg.key_bin.len > 0:
+        # Table entry: account per-key so per-key evict can subtract exactly.
+        if msg.kind == ASSIGN:
+          self.set_key_bytes(obj, msg.key_bin, msg.obj.len)
+          obj.key_last_read[msg.key_bin] = get_mono_time() # updated → recent
+        elif msg.kind == UNASSIGN:
+          self.forget_key_bytes(obj, msg.key_bin)
+      elif msg.delta and msg.kind == ASSIGN:
+        self.set_body_bytes(obj, obj.bytes + msg.obj.len)
     obj.change_receiver(
       obj,
       msg,
@@ -1540,6 +1805,7 @@ proc tick*(
   self.flush_buffers
   self.flush_key_requests # send this frame's batched per-key fetches
   self.flush_key_releases # ...and its batched per-key releases (paging out)
+  self.evict_sweep        # reclaim dormant/over-budget bodies (partial replicas)
 
   # Replay whatever a silent (blocking) materialize deferred — at this tick
   # boundary, before new traffic: first the messages it buffered (apply + fire

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -233,6 +233,9 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
       let handle_owner = EdRef(item)
       if handle_owner.ref_handle.is_nil:
         handle_owner.ref_handle = RefHandle(ctx_uid: self.uid, ref_id: id)
+      # The instance's own context, for destroy's owner cascade — the one
+      # context it lives in (see EdRef.ctx). Cursor, so no cycle.
+      handle_owner.ctx = self
     # REMOVE only unlinks a container from the ref; it never frees. ORC reclaims
     # the instance when its last real reference drops (RefHandle then cleans the
     # pool), giving move-identity for free: a removed-then-readded replica

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -49,6 +49,13 @@ type
     lifetime*: Lifetime
       ## This ref's teardown actions — external subscriptions and (via `own`) its
       ## owned containers. `destroy` runs `lifetime.finish`. Never synced.
+    ctx* {.cursor.}: EdContext
+      ## The context this instance lives in, stamped on first `ref_pool` add. A
+      ## registered ref belongs to exactly one context (sync mints a separate
+      ## instance per context), so `destroy` uses it — not `Ed.thread_ctx`, which
+      ## is wrong under multiple contexts per thread — to find the right
+      ## `owned_by`/`ref_pool` for the cascade. Non-owning cursor (the context
+      ## outlives its refs); never synced.
 
   EdFlags* = enum
     ## Flags controlling `Ed` container behavior.
@@ -80,7 +87,6 @@ type
     ## Why a change fired, orthogonal to `ChangeKind`. (Unrelated to
     ## `Change.triggered_by`, which is the upstream changes that caused this one.)
     Update    ## An ordinary live change — a mutation or touch
-    Initial   ## Replay of existing contents at `track` time (reserved)
     Fill      ## A placeholder materialized (partial-replica fetch landed)
 
   MessageKind* = enum
@@ -100,6 +106,10 @@ type
                # is an eviction notice — drop the keys locally and relay
                # downstream. Full clones forward without evicting; the
                # authority terminates it.
+    INTEREST   # live/cache tier change (Option 2). Subscriber → upstream:
+               # `demote` (true) downgrades object_id to cache tier (still
+               # streamed, but no longer protects it from eviction); `demote`
+               # false promotes it back to live. Lightweight — no data.
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]
@@ -116,8 +126,14 @@ type
     when defined(ed_trace):
       trace*: string
 
-  PackedMessageOperation* =
-    tuple[kind: MessageKind, ref_id: int, change_object_id: string, obj: string]
+  PackedMessageOperation* = tuple[
+    kind: MessageKind, ref_id: int, change_object_id: string, obj: string,
+    # Carried so a packed table op unpacks to the same Message a standalone one
+    # would: a receiver's per-key byte accounting / fanout filtering keys off
+    # delta + key_bin, and would silently skip packed-delivered table entries
+    # without them (the per-key cache then can't account or evict those keys).
+    delta: bool, key_bin: string,
+  ]
 
   IdMapping* = tuple[short_id: uint8, full_id: string]
 
@@ -142,12 +158,11 @@ type
     delta*: bool    # true for collection (non-idempotent) ops, false for registers
     deep*: bool     # REQUEST only: also send the ownership closure (everything
                     # the requested id owns via owned_by, recursively)
-    follow*: bool   # REQUEST only: register interest so future ops follow — and,
-                    # for a missing id, so it's delivered when it's created later
     key_bin*: string # Table ops only: the serialized key, stamped by
                      # build_message so fanout can filter per-key (LAZY tables /
                      # key interest) without deserializing `obj`. Sender-side
                      # only — blanked from the remote body.
+    demote*: bool    # INTEREST only: true = demote (live→cache), false = promote.
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -204,6 +219,14 @@ type
     # making it tri-state.
     deep*: bool
     interest*: HashSet[string]
+    # Live/cache interest tiers (Option 2; docs/interest-tiers-design.md).
+    # `interest_cache` is a subset of `interest`: those objects still stream
+    # (the subscriber's cache stays current), but they're *cache tier* — this
+    # subscriber holds them cached, not live, so they DON'T protect against
+    # eviction. We may evict a cache-tier object under our own memory pressure
+    # and invalidate the subscriber. Live interest = `interest - interest_cache`
+    # is mandatory: an upstream must hold what's live on a downstream.
+    interest_cache*: HashSet[string]
     # Per-key interest (LAZY tables): object_id -> serialized keys this
     # subscriber has requested. A requested key streams its future ops — even
     # one that was missing at request time (an empty-space voxel chunk someone
@@ -274,6 +297,28 @@ type
     # object fills; otherwise it kicks a fetch and returns the empty placeholder.
     materialize*: proc(self: EdContext, id: string) {.gcsafe.}
     blocking*: bool
+    # Partial-replica evictor (docs/proxy-body-design.md phase 4). `mem_limit`
+    # is a cache budget for unclaimed bodies, in bytes — an honest, monotonic
+    # value from "no cache" up to "unlimited":
+    #     0  no cache — evict everything the moment it isn't live (a utility
+    #        client that holds nothing it isn't actively using). Negatives are
+    #        clamped to this at init.
+    #   0<n  cache up to n bytes; over budget, shed least-recently-read (LRU).
+    #   Unbounded (= int.high)  never evict — unlimited cache.
+    # Only a partial replica evicts (a full clone / authority never does, so the
+    # value is moot there). `used_bytes` is the running sum of resident body
+    # bytes (finite-budget mode only). See `evicts` / `has_budget`.
+    mem_limit*: int
+    used_bytes*: int
+    sweep_dirty*: bool
+      ## Set whenever something an eviction sweep would act on changed since the
+      ## last sweep: a message was processed, or a dead proxy/ref was pruned. The
+      ## sweep skips its (O(objects)) reconcile/churn/pressure work when this is
+      ## false and we're under budget — so a calm context pays ~nothing per tick.
+      ## (A pure read that mints a proxy without any message can delay a promote
+      ## by a tick; harmless and self-correcting.)
+    last_proxy_prune_epoch*: int # last dead_proxy_epoch this ctx pruned at
+    last_ref_prune_epoch*: int   # last dead_ref_epoch this ctx pruned at
     filling*: bool        # set while a placeholder fill applies → tags Fill changes
     silent*: bool         # silent (blocking) materialize: defer callbacks to next tick
     pending_msgs*: seq[Message]            # received-but-deferred during a silent pump
@@ -324,7 +369,7 @@ type
     # when the upstream answers NOT_FOUND. The authority never forwards — a
     # miss there is a real NOT_FOUND.
     pending_obj_wants*:
-      Table[string, seq[tuple[sub: Subscription, deep: bool, follow: bool]]]
+      Table[string, seq[tuple[sub: Subscription, deep: bool]]]
     # object_id -> key_bin -> waiting subscribers (per-key table requests).
     pending_key_wants*: Table[string, Table[string, seq[Subscription]]]
     ref_pool: Table[string, CountedRef]
@@ -382,6 +427,26 @@ type
     # change fires. Default false = a normal, fully-loaded object.
     placeholder*: bool
     flags*: set[EdFlags]
+    # Eviction accounting (partial-replica evictor, docs/proxy-body-design.md
+    # phase 4). All cheap to maintain; only the partial-replica sweep reads them.
+    last_read*: MonoTime  # stamped on a read-touch (value/[]/items/pairs)
+    bytes*: int           # wire-weight, stamped where we serialize (drift-ok)
+    updates*: int         # arriving ops since the last read — the churn signal
+    # Interest tier we last reported to our upstream for this object (Option 2).
+    # Reconciled each sweep against `is_live_here`: when liveness flips we send
+    # a demote (live→cache) or promote (cache→live) so the upstream isn't
+    # obligated to hold what we only have cached. 0 = none, 1 = live, 2 = cache.
+    up_tier*: int
+    # Per-key wire bytes for a table (key_bin -> last ASSIGN obj.len). Lets a
+    # per-key evict/release subtract exactly what the entry added to `bytes`,
+    # so paging out actually shrinks `used_bytes` (whole-body fill leaves this
+    # empty — only delta-grown tables populate it).
+    key_bytes*: Table[string, int]
+    # Per-key recency (key_bin -> last activity), for the per-key cache LRU on
+    # LAZY tables: stamped when a key is served to a downstream (last in-view)
+    # or updated. A hub caches released keys instead of shedding them and sheds
+    # the least-recently-served under memory pressure (interest-tiers stage 2).
+    key_last_read*: Table[string, MonoTime]
     build_message: proc(
       body: ref EdBodyBase, change: BaseChange, id: string, trace: string
     ): Message {.gcsafe.}
@@ -588,6 +653,15 @@ var next_ctx_uid*: Atomic[int]
 var dead_handles_lock: Lock
 dead_handles_lock.init_lock
 
+var dead_proxy_epoch*: Atomic[int]
+var dead_ref_epoch*: Atomic[int]
+  ## Bumped (under the lock) whenever a proxy/ref death is recorded. A context
+  ## remembers the epoch at its last prune (`last_*_prune_epoch`) and skips the
+  ## lock entirely when the epoch hasn't moved — so a tick with no deaths does no
+  ## locking, even though `prune_dead_*` is called from several hot paths
+  ## (tick, resolve_proxy, from_flatty). Process-global, matching the pending
+  ## tables (a context can be created on one thread and pruned on another).
+
 var pending_dead_refs*: Table[int, seq[string]]
   ## ctx uid -> ref_ids whose registered instance ORC has reclaimed. Populated by
   ## `RefHandle.=destroy`, which must NOT touch its `EdContext` (it may already be
@@ -607,6 +681,7 @@ proc `=destroy`(h: var typeof(RefHandle()[])) =
     {.cast(gcsafe).}:
       dead_handles_lock.acquire()
       pending_dead_refs.mget_or_put(h.ctx_uid, @[]).add(h.ref_id)
+      discard dead_ref_epoch.fetch_add(1) # wake the lock-free prune skip
       dead_handles_lock.release()
   `=destroy`(h.ref_id)
 
@@ -626,6 +701,7 @@ proc `=destroy`(h: var typeof(ProxyHandle()[])) =
     {.cast(gcsafe).}:
       dead_handles_lock.acquire()
       pending_dead_proxies.mget_or_put(h.ctx_uid, @[]).add((h.object_id, h.gen))
+      discard dead_proxy_epoch.fetch_add(1) # wake the lock-free prune skip
       dead_handles_lock.release()
   `=destroy`(h.object_id)
 
@@ -634,12 +710,22 @@ proc prune_dead_proxies*(self: EdContext) =
   ## any backref read so a dangling cursor is never returned; `gen` ensures a
   ## late prune can't clear a *newer* proxy minted after the death was recorded.
   {.cast(gcsafe).}:
+    # Lock-free fast path: if no proxy has died anywhere since our last prune,
+    # there's nothing for us to drain — skip the global lock entirely. (A death
+    # in another context can cost us one redundant lock; a tick with no deaths
+    # costs none.)
+    let epoch = dead_proxy_epoch.load
+    if epoch == self.last_proxy_prune_epoch:
+      return
     var dead: seq[(string, int)]
     dead_handles_lock.acquire()
     if self.uid in pending_dead_proxies:
       dead = pending_dead_proxies[self.uid]
       pending_dead_proxies.del(self.uid)
     dead_handles_lock.release()
+    self.last_proxy_prune_epoch = epoch
+    if dead.len > 0:
+      self.sweep_dirty = true # a liveness flip → the next sweep must reconcile
     for (object_id, gen) in dead:
       if object_id in self.objects and self.objects[object_id] != nil and
           self.objects[object_id].proxy_gen == gen:
@@ -672,6 +758,66 @@ proc release_closures*(body: ref EdBodyBase) =
   body.untrack_zid = nil
   body.sweep_gen = nil
 
+const Unbounded* = high(int)
+  ## `mem_limit = Unbounded` means never evict — an unlimited cache. The top of
+  ## the byte-budget range, so the value stays an honest, monotonic size.
+
+const DEFAULT_MEM_LIMIT* = 16 * 1024 * 1024
+  ## A context's default cache budget (16 MB). Moot on a full clone/authority
+  ## (they never evict); a small default cache for partial replicas.
+
+proc evicts*(self: EdContext): bool {.inline.} =
+  ## Reclaims memory under pressure: a partial replica with a finite limit. A
+  ## full clone / authority, and an `Unbounded` limit, never evict.
+  self.partial_replica and self.mem_limit < Unbounded
+
+proc has_budget*(self: EdContext): bool {.inline.} =
+  ## Tracks per-body bytes against a finite cap. No-cache (0) and `Unbounded`
+  ## skip the accounting — there's nothing to compare a running total against.
+  self.evicts and self.mem_limit > 0
+
+proc set_body_bytes*(self: EdContext, body: ref EdBodyBase, n: int) =
+  ## Record a body's resident wire-size and keep `used_bytes` in step. Called
+  ## where we already have the serialized form (publish/fill); drift between
+  ## those points is harmless — the total only gates *when* the limit trips,
+  ## and LRU ordering doesn't use bytes at all. Only the finite-budget mode
+  ## needs accounting; no-cache and Unbounded skip it.
+  if not self.has_budget:
+    return
+  self.used_bytes += n - body.bytes
+  body.bytes = n
+
+proc forget_body_bytes*(self: EdContext, body: ref EdBodyBase) =
+  ## Remove a body's bytes from the running total (on unregister/evict).
+  if not self.has_budget:
+    return
+  self.used_bytes -= body.bytes
+  body.bytes = 0
+
+proc set_key_bytes*(
+    self: EdContext, body: ref EdBodyBase, key_bin: string, n: int
+) =
+  ## Account a table entry's wire size, keyed so it can be subtracted exactly on
+  ## per-key evict. An update replaces the previous figure (no double-count).
+  if not self.has_budget or key_bin.len == 0:
+    return
+  let prev = body.key_bytes.getOrDefault(key_bin, 0)
+  self.set_body_bytes(body, body.bytes + n - prev)
+  body.key_bytes[key_bin] = n
+
+proc forget_key_bytes*(self: EdContext, body: ref EdBodyBase, key_bin: string) =
+  ## Drop a per-key entry's accounting on evict/release: its recency and its
+  ## bytes. Called from `evict_key` (so every eviction site cleans both parallel
+  ## tables — they can't drift) and on UNASSIGN. `del` of a missing key is a
+  ## no-op, so recency is cleared even if bytes were never accounted.
+  if not self.has_budget:
+    return
+  body.key_last_read.del key_bin
+  if key_bin notin body.key_bytes:
+    return
+  self.set_body_bytes(body, max(0, body.bytes - body.key_bytes[key_bin]))
+  body.key_bytes.del key_bin
+
 proc drop_nested_bodies*(self: EdContext, nested: seq[string]) =
   ## Unregister the nested container bodies an evicted entry carried (a paged-
   ## out chunk's delta seq): the registry releases its strong hold, so the
@@ -683,6 +829,7 @@ proc drop_nested_bodies*(self: EdContext, nested: seq[string]) =
       if body != nil:
         if body.owner_id.len > 0 and body.owner_id in self.owned_by:
           self.owned_by[body.owner_id].excl id
+        self.forget_body_bytes(body)
         body.release_closures
       self.objects.del id
 
@@ -693,12 +840,18 @@ proc prune_dead_refs*(self: EdContext) =
   ## dangling cursor is never read, and on tick to keep the pool tidy. Idempotent;
   ## cheap when nothing is pending.
   {.cast(gcsafe).}:
+    let epoch = dead_ref_epoch.load # lock-free skip when nothing died (see proxies)
+    if epoch == self.last_ref_prune_epoch:
+      return
     var dead: seq[string]
     dead_handles_lock.acquire()
     if self.uid in pending_dead_refs:
       dead = pending_dead_refs[self.uid]
       pending_dead_refs.del(self.uid)
     dead_handles_lock.release()
+    self.last_ref_prune_epoch = epoch
+    if dead.len > 0:
+      self.sweep_dirty = true
     for ref_id in dead:
       self.ref_pool.del(ref_id)
 
@@ -709,6 +862,17 @@ proc to_flatty*(s: var string, x: RefHandle) =
   discard
 
 proc from_flatty*(s: string, i: var int, x: var RefHandle) =
+  discard
+
+proc to_flatty*(s: var string, x: EdContext) =
+  ## A context is local runtime state and must never be serialized. The cursor
+  ## backref `EdRef.ctx` would otherwise drag the whole context (and its
+  ## closures) into a ref's wire form when a collection of refs is `to_flatty`d.
+  ## Re-stamped by `ref_count` on the receiver. Mirrors the RefHandle/Lifetime
+  ## skips.
+  discard
+
+proc from_flatty*(s: string, i: var int, x: var EdContext) =
   discard
 
 proc new_lifetime*(): Lifetime =
@@ -808,7 +972,8 @@ proc to_flatty*(s: var string, msg: Message) =
   s.to_flatty msg.origin
   s.to_flatty msg.delta
   s.to_flatty msg.deep
-  s.to_flatty msg.follow
+  s.to_flatty msg.key_bin
+  s.to_flatty msg.demote
   when defined(ed_trace):
     s.to_flatty msg.trace
     s.to_flatty msg.id
@@ -832,7 +997,8 @@ proc from_flatty*(s: string, i: var int, msg: var Message) =
   s.from_flatty(i, msg.origin)
   s.from_flatty(i, msg.delta)
   s.from_flatty(i, msg.deep)
-  s.from_flatty(i, msg.follow)
+  s.from_flatty(i, msg.key_bin)
+  s.from_flatty(i, msg.demote)
   when defined(ed_trace):
     s.from_flatty(i, msg.trace)
     s.from_flatty(i, msg.id)

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -219,7 +219,7 @@ type
     # making it tri-state.
     deep*: bool
     interest*: HashSet[string]
-    # Live/cache interest tiers (Option 2; docs/interest-tiers-design.md).
+    # Live/cache interest tiers (Option 2; docs/partial-replicas.md).
     # `interest_cache` is a subset of `interest`: those objects still stream
     # (the subscriber's cache stays current), but they're *cache tier* — this
     # subscriber holds them cached, not live, so they DON'T protect against
@@ -297,9 +297,9 @@ type
     # object fills; otherwise it kicks a fetch and returns the empty placeholder.
     materialize*: proc(self: EdContext, id: string) {.gcsafe.}
     blocking*: bool
-    # Partial-replica evictor (docs/proxy-body-design.md phase 4). `mem_limit`
-    # is a cache budget for unclaimed bodies, in bytes — an honest, monotonic
-    # value from "no cache" up to "unlimited":
+    # Partial-replica evictor (docs/partial-replicas.md). `mem_limit` is a cache
+    # budget for unclaimed bodies, in bytes — an honest, monotonic value from
+    # "no cache" up to "unlimited":
     #     0  no cache — evict everything the moment it isn't live (a utility
     #        client that holds nothing it isn't actively using). Negatives are
     #        clamped to this at init.
@@ -427,7 +427,7 @@ type
     # change fires. Default false = a normal, fully-loaded object.
     placeholder*: bool
     flags*: set[EdFlags]
-    # Eviction accounting (partial-replica evictor, docs/proxy-body-design.md
+    # Eviction accounting (partial-replica evictor, docs/partial-replicas.md
     # phase 4). All cheap to maintain; only the partial-replica sweep reads them.
     last_read*: MonoTime  # stamped on a read-touch (value/[]/items/pairs)
     bytes*: int           # wire-weight, stamped where we serialize (drift-ok)

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -69,6 +69,7 @@ proc init*(
     min_recv_duration = Duration.default,
     label = "default",
     is_authority = false,
+    mem_limit = DEFAULT_MEM_LIMIT, # 0 = no cache; n = LRU budget; Unbounded = never
 ): EdContext =
   ## Create a new `EdContext`. Set `listen_address` to enable network sync.
   ## Set `is_authority` to make this context the sequencer (leader) that assigns
@@ -90,6 +91,7 @@ proc init*(
     metrics_label: label,
     last_keepalive_tick: epoch_time(),
     is_authority: is_authority,
+    mem_limit: max(0, mem_limit), # clamp: a negative limit means no cache
   )
   if is_authority:
     result.leader_id = id

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -50,16 +50,19 @@ proc create_initializer[T, O](self: Ed[T, O]) =
           debug "creating received object", id
           if not ctx.subscribing and id notin ctx:
             var value = bin.from_flatty(T, ctx)
-            discard Ed.init(value, ctx = ctx, id = id, flags = flags, op_ctx)
+            let item = Ed.init(value, ctx = ctx, id = id, flags = flags, op_ctx)
+            ctx.set_body_bytes(item.body, bin.len) # evictor accounting
           elif not ctx.subscribing:
             debug "restoring received object", id
             var value = bin.from_flatty(T, ctx)
             let item = Ed[T, O](ctx[id])
             let was_placeholder = item.placeholder
+            let prev_filling = ctx.filling # save: `value=` may nest a fill
             ctx.filling = was_placeholder # fill of a placeholder → tag Fill
             item.placeholder = false # fill: real state arrived
             `value=`(item, value, op_ctx = op_ctx)
-            ctx.filling = false
+            ctx.filling = prev_filling # restore (not unconditionally false)
+            ctx.set_body_bytes(item.body, bin.len) # evictor accounting
             if was_placeholder:
               relay_fill(item, op_ctx)
           else:
@@ -72,10 +75,12 @@ proc create_initializer[T, O](self: Ed[T, O]) =
                 let value = bin.from_flatty(T, ctx)
               let item = Ed[T, O](ctx[id])
               let was_placeholder = item.placeholder
+              let prev_filling = ctx.filling # save: `value=` may nest a fill
               ctx.filling = was_placeholder # fill of a placeholder → tag Fill
               item.placeholder = false # fill: real state arrived
               `value=`(item, value, op_ctx = op_ctx)
-              ctx.filling = false
+              ctx.filling = prev_filling # restore (not unconditionally false)
+              ctx.set_body_bytes(item.body, bin.len) # evictor accounting
               if was_placeholder:
                 relay_fill(item, op_ctx)
             ctx.value_initializers.add(initializer)
@@ -418,6 +423,7 @@ proc defaults[T, O](
                 if ?field:
                   nested.add field.id
         self.tracked.del key
+        body.ctx.forget_key_bytes(body, key_bin) # shrink used_bytes on evict
         self.trigger_callbacks(@[Change[O](changes: {REMOVED}, item: pair)])
         result = (found: true, nested: nested)
     else:

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -68,12 +68,23 @@ proc loaded*(self: ref EdBase): bool =
   ## "exists but not loaded" from "exists and is genuinely empty".
   not self.placeholder
 
+template touch_read(self: untyped) =
+  ## Coarse eviction touch: mark the body as recently used and reset its churn
+  ## counter. Every read accessor runs this (it precedes `touch_placeholder`),
+  ## so the evictor's LRU clock and "updates since read" both advance on real
+  ## use — and never on the hot voxel render path, which doesn't read through
+  ## these accessors. Only meaningful on a context with a memory limit.
+  if self.ctx != nil and self.ctx.has_budget:
+    self.body.last_read = get_mono_time()
+    self.body.updates = 0
+
 template touch_placeholder(self: untyped) =
   ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
   ## context to materialize it (kick a fetch; block until filled when
   ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
   ## LAZY containers are exempt: they're pull-only by design — entries arrive
   ## per-key (`request`), so reading one must never materialize the whole table.
+  self.touch_read
   if self.placeholder and LAZY notin self.flags and self.ctx.materialize != nil:
     self.ctx.materialize(self.ctx, self.id)
 
@@ -302,19 +313,21 @@ proc `==`*(a, b: Ed): bool =
 
 proc pause_changes*(self: Ed, eids: varargs[EID]) =
   ## Pause change callbacks. Pass specific EIDs or none to pause all.
+  privileged
   assert self.valid
   if eids.len == 0:
-    for eid in self.changed_callbacks.keys:
-      self.paused_eids.incl(eid)
+    for eid in self.typed_body.changed_callbacks.keys:
+      self.typed_body.paused_eids.incl(eid)
   else:
     for eid in eids:
-      self.paused_eids.incl(eid)
+      self.typed_body.paused_eids.incl(eid)
 
 proc resume_changes*(self: Ed, eids: varargs[EID]) =
   ## Resume change callbacks. Pass specific EIDs or none to resume all.
+  privileged
   assert self.valid
   if eids.len == 0:
-    self.paused_eids = {}
+    self.typed_body.paused_eids = {}
   else:
     for eid in eids:
       self.typed_body.paused_eids.excl(eid)
@@ -348,6 +361,7 @@ proc destroy*[T, O](self: Ed[T, O], publish = true) =
   assert self.valid
   self.untrack_all
   self.destroyed = true
+  self.ctx.forget_body_bytes(self.body) # evictor accounting
   self.body.release_closures # break body self-captures (no cycle GC)
   self.ctx.objects[self.id] = nil
   self.ctx.objects_need_packing = true
@@ -406,7 +420,12 @@ method destroy*(self: EdRef) {.base, gcsafe.} =
   ## to run afterwards.
   if not self.lifetime.is_nil:
     self.lifetime.finish()
-  Ed.thread_ctx.destroy_owned(self.id)
+  # The context this ref lives in (stamped on ref_pool add). Fall back to
+  # thread_ctx only for a ref that never entered a ref_pool — i.e. created and
+  # destroyed without ever being added to a collection, where it was minted on
+  # the current thread anyway.
+  let ctx = if self.ctx != nil: self.ctx else: Ed.thread_ctx
+  ctx.destroy_owned(self.id)
   self.destroyed = true
 
 iterator items*[T](self: EdSet[T] | EdSeq[T]): T =

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -475,6 +475,34 @@ proc run*() =
     s.value = "vin"
     check calls == 2
 
+  test "pause_changes / resume_changes procs (incl. pause-all/resume-all)":
+    # The pause-all / resume-all branches read changed_callbacks/paused_eids,
+    # which the proxy/body split moved onto the body; this exercises them so a
+    # regression is a test failure, not a latent compile error on first use.
+    # Relative checks (a set may emit >1 change) — what matters is that pause
+    # stops the increments and resume restarts them, for both per-eid and all.
+    var s = EdValue[string].init
+    var calls = 0
+    let zid = s.track proc(c: seq[Change[string]]) {.gcsafe.} =
+      calls.inc
+    let c0 = calls
+    s.value = "a"
+    check calls > c0 # fires
+    s.pause_changes zid # per-eid pause
+    let c1 = calls
+    s.value = "b"
+    check calls == c1 # paused → silent
+    s.resume_changes zid
+    s.value = "c"
+    check calls > c1 # resumed
+    let c2 = calls
+    s.pause_changes # pause all
+    s.value = "d"
+    check calls == c2
+    s.resume_changes # resume all
+    s.value = "e"
+    check calls > c2
+
   test "closed":
     var s = ed("")
     var changed = false

--- a/tests/lifetime_tests.nim
+++ b/tests/lifetime_tests.nim
@@ -206,6 +206,30 @@ proc run*() =
       external.value = 2
       check fired == after # lifetime finished → callback untracked
 
+    test "EdRef.destroy uses the ref's own context, not thread_ctx":
+      # A ref stamped with ctxA (it entered ctxA's ref_pool via collection
+      # membership) must tear down ctxA's owned containers even when a *different*
+      # context is the active thread_ctx — destroy follows the ref's ctx backref,
+      # not Ed.thread_ctx (which is wrong under multiple contexts per thread).
+      var ctxA = EdContext.init(id = "xd_a")
+      var ctxB = EdContext.init(id = "xd_b")
+      Ed.thread_ctx = ctxA
+      var child = OwnerTest(id: "xd_child")
+      child.own:
+        child.items = EdSeq[int].init(ctx = ctxA, id = "xd_child_items")
+      var parent = OwnerTest(id: "xd_parent")
+      parent.own:
+        parent.kids = EdSeq[OwnerTest].init(
+          ctx = ctxA, id = "xd_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+        )
+      parent.kids.add child # → ctxA.ref_pool, stamps child.ctx = ctxA
+      check child.ctx == ctxA
+
+      Ed.thread_ctx = ctxB # the wrong context is now active
+      child.destroy()
+      check child.destroyed
+      check "xd_child_items" notin ctxA # torn down via child.ctx, not thread_ctx
+
     test "OWNS_MEMBERS: destroying the owner cascades into members":
       var ctx = EdContext.init(id = "om_ctx")
       Ed.thread_ctx = ctx

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -1,4 +1,4 @@
-import std/[unittest, sets, tables, times, monotimes]
+import std/[unittest, sets, tables, times, monotimes, strutils]
 import ed
 import ed/zens/contexts
 
@@ -149,7 +149,7 @@ proc run*() =
       client.subscribe(authority, partial = true, fetch = [])
       client.tick()
 
-      let handle = client.fetch("does_not_exist", follow = false)
+      let handle = client.fetch("does_not_exist")
       check handle.state == Pending
       authority.tick()
       client.tick()
@@ -173,33 +173,6 @@ proc run*() =
       check "late_obj" in client # ...but the kept interest delivered it
       check EdValue[int](client["late_obj"]).value == 9
 
-    test "follow = false: snapshot only — no future ops, no late delivery":
-      var authority = EdContext.init(id = "sn_auth", is_authority = true)
-      var client = EdContext.init(id = "sn_client")
-      var snap = EdValue[int].init(ctx = authority, id = "snap_x")
-      snap.value = 1
-      client.subscribe(authority, partial = true, fetch = [])
-      client.tick()
-
-      let handle = client.fetch("snap_x", follow = false)
-      authority.tick()
-      client.tick()
-      check handle.state == Found
-      check EdValue[int](client["snap_x"]).value == 1
-
-      snap.value = 2
-      client.tick()
-      check EdValue[int](client["snap_x"]).value == 1 # frozen: no interest
-
-      let missing = client.fetch("snap_later", follow = false)
-      authority.tick()
-      client.tick()
-      check missing.state == NotFound
-      var later = EdValue[int].init(ctx = authority, id = "snap_later")
-      later.value = 3
-      client.tick()
-      check "snap_later" notin client # never arrives without follow
-
     test "blocking ctx[] pulls an unknown id; a NACK fails fast":
       var authority = EdContext.init(id = "bk_auth", is_authority = true)
       var client = EdContext.init(id = "bk_client")
@@ -221,7 +194,7 @@ proc run*() =
 
       # Unknown id: the NACK resolves the blocking wait promptly (KeyError),
       # well inside the pump's safety deadline.
-      discard client.fetch("bk_missing", follow = false)
+      discard client.fetch("bk_missing")
       authority.tick()
       let started = get_mono_time()
       expect KeyError:
@@ -259,7 +232,7 @@ proc run*() =
       c.subscribe(b, partial = true, fetch = [])
       c.tick()
 
-      let handle = c.fetch("chn_missing", follow = false)
+      let handle = c.fetch("chn_missing")
       b.tick() # forward
       a.tick() # authority: real miss -> NOT_FOUND
       b.tick() # relay to the waiter
@@ -442,13 +415,255 @@ proc run*() =
       check ptbl[1] == "one, unseen"
       check ntbl[1] == "one, unseen"
 
+    test "evictor: per-key release shrinks used_bytes (paging out frees mem)":
+      # The voxel case: a LAZY table grows per-key as chunks page in, and
+      # releasing a chunk must subtract exactly what it added — otherwise the
+      # memory figure only ever climbs (the bug Scott saw: ed mem up on
+      # move-in, never down on move-out).
+      var authority = EdContext.init(id = "pk_auth", is_authority = true)
+      var client = EdContext.init(id = "pk_client", mem_limit = 1024 * 1024)
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "pk_owner")
+      var tbl: EdTable[int, string]
+      owner.own:
+        tbl = EdTable[int, string].init(
+          ctx = authority, id = "pk_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      tbl[1] = 'x'.repeat(200)
+      tbl[2] = 'y'.repeat(200)
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      discard client.fetch("pk_owner", deep = true) # the LAZY handle rides in
+      authority.tick()
+      client.tick()
+      let ctbl = EdTable[int, string](client["pk_tbl"])
+      check client.used_bytes == 0 # handle only, no entries yet
+
+      ctbl.request(1)
+      ctbl.request(2)
+      client.tick()
+      authority.tick()
+      client.tick()
+      check ctbl.loaded(1) and ctbl.loaded(2)
+      let loaded = client.used_bytes
+      check loaded >= 400 # both entries accounted
+
+      ctbl.release(1) # page one chunk out
+      client.tick()
+      check not ctbl.loaded(1)
+      check client.used_bytes < loaded # ...and the memory actually dropped
+      check client.used_bytes >= 200 # the still-loaded entry remains accounted
+
+    test "interest tiers: a downstream cache doesn't pin its hub (Option 2)":
+      # A ← H ← L. L caches X with a big limit; that must NOT force H to hold X.
+      # When L demotes X (it goes non-live), H may reclaim X under its own
+      # pressure and invalidate L.
+      var authority = EdContext.init(id = "it_auth", is_authority = true)
+      var hub = EdContext.init(id = "it_hub", mem_limit = 200)
+      var leaf = EdContext.init(id = "it_leaf", mem_limit = 10_000_000)
+      Ed.thread_ctx = authority
+      discard EdValue[string].init(ctx = authority, id = "it_x")
+      EdValue[string](authority["it_x"]).value = 'z'.repeat(400)
+
+      hub.subscribe(authority, partial = true, fetch = [])
+      hub.tick()
+      leaf.subscribe(hub, partial = true, fetch = [])
+      leaf.tick()
+
+      # L fetches X live (chains L→H→A); H holds it because L is live on it.
+      var f = leaf.fetch("it_x")
+      leaf.tick()
+      hub.tick()
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      check "it_x" in leaf
+      check "it_x" in hub # H holds X for live L
+      # H must not evict X while L is live on it.
+      hub.tick()
+      check "it_x" in hub
+
+      # L drops its live reference but keeps caching (big limit). It demotes X.
+      f.obj = nil
+      f = nil
+      GC_full_collect()
+      leaf.tick() # reconcile: X non-live here → demote upstream
+      hub.tick() # H records X as cache-tier for L
+      check "it_x" in leaf # L still caches it
+      check "it_x" in hub
+
+      # H is over its own budget (X is 400+ bytes, limit 200) and X is now
+      # cache-tier (unprotected) — H sheds X and invalidates L.
+      for i in 1 .. 4:
+        hub.tick()
+        leaf.tick()
+      check "it_x" notin hub # H reclaimed it — not pinned by L's cache
+      check "it_x" notin leaf # ...and invalidated L's cache
+
+    test "mem_limit encoding: default budget, negative clamps, Unbounded holds":
+      # Honest byte budget: a small default cache, negatives clamp to no-cache,
+      # and Unbounded means never evict — the mirror image of the mem_limit 0
+      # case below (there the dropped object is shed; here it's kept).
+      check EdContext.init(id = "ml_def").mem_limit == DEFAULT_MEM_LIMIT
+      check EdContext.init(id = "ml_neg", mem_limit = -5).mem_limit == 0
+
+      var authority = EdContext.init(id = "ub_auth", is_authority = true)
+      var client = EdContext.init(id = "ub_client", mem_limit = Unbounded)
+      Ed.thread_ctx = authority
+      discard EdValue[string].init(ctx = authority, id = "ub_x")
+      EdValue[string](authority["ub_x"]).value = "hi"
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      var f = client.fetch("ub_x")
+      authority.tick()
+      client.tick()
+      check "ub_x" in client and f.obj != nil
+
+      f.obj = nil
+      f = nil # drop the reference — nothing is live now
+      GC_full_collect()
+      client.tick() # Unbounded: the sweep is a no-op, the cache holds it
+      check "ub_x" in client # a finite limit / no-cache would have shed it
+
+    test "evictor: mem_limit 0 evicts everything the moment it isn't live":
+      # The no-cache mode for utility clients: a fetched object survives only
+      # while a reference holds it; drop the reference and it's gone next sweep,
+      # its interest retracted upstream.
+      var authority = EdContext.init(id = "nc_auth", is_authority = true)
+      var client = EdContext.init(id = "nc_client", mem_limit = 0)
+      Ed.thread_ctx = authority
+      discard EdValue[string].init(ctx = authority, id = "nc_x")
+      EdValue[string](authority["nc_x"]).value = "hi"
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      var f = client.fetch("nc_x")
+      authority.tick()
+      client.tick()
+      check "nc_x" in client # held by the live handle
+      check f.obj != nil
+
+      f.obj = nil
+      f = nil # drop the reference — nothing is live now
+      GC_full_collect()
+      client.tick() # no-cache sweep evicts it immediately
+      check "nc_x" notin client
+
+    test "evictor: pressure sheds the least-recently-read body":
+      # mem_limit turns on the partial-replica evictor. Snapshot three bodies
+      # we don't keep open, go over budget, and watch the stalest shed first.
+      var authority = EdContext.init(id = "ev_auth", is_authority = true)
+      var client = EdContext.init(id = "ev_client", mem_limit = 250)
+      Ed.thread_ctx = authority
+      discard EdValue[string].init(ctx = authority, id = "ev_1")
+      discard EdValue[string].init(ctx = authority, id = "ev_2")
+      discard EdValue[string].init(ctx = authority, id = "ev_3")
+      EdValue[string](authority["ev_1"]).value = 'a'.repeat(100)
+      EdValue[string](authority["ev_2"]).value = 'b'.repeat(100)
+      EdValue[string](authority["ev_3"]).value = 'c'.repeat(100)
+
+      client.subscribe(authority, partial = true, fetch = [])
+      client.tick()
+      # Fetch all three. On a leaf (no downstream), an object with no live
+      # proxy is an eviction candidate regardless of our own upstream interest
+      # — so dropping the handles makes them evictable. Hold the handles until
+      # we're set up, then drop them (the app is done with them).
+      var f1 = client.fetch("ev_1")
+      var f2 = client.fetch("ev_2")
+      var f3 = client.fetch("ev_3")
+      authority.tick()
+      client.tick()
+      check "ev_1" in client and "ev_2" in client and "ev_3" in client
+      check client.used_bytes >= 300
+
+      # Read ev_2 and ev_3 (recently used); ev_1 is never read, so it stays the
+      # stalest. Drop the handles and force ORC so the bodies read as unheld
+      # (production reaches this as allocation drives collection).
+      discard EdValue[string](client["ev_2"]).value
+      discard EdValue[string](client["ev_3"]).value
+      f1.obj = nil
+      f2.obj = nil
+      f3.obj = nil
+      f1 = nil
+      f2 = nil
+      f3 = nil
+      GC_full_collect()
+      client.tick() # evict_sweep: over 250, sheds the stalest (ev_1) and stops
+      check "ev_1" notin client # least-recently-read went
+      check "ev_2" in client and "ev_3" in client # newer survive under budget
+      check client.used_bytes <= 250
+
+    test "caching hub keeps released keys; per-key LRU sheds under pressure":
+      # A ← H(cache) ← L. L pages a chunk in then out; a caching hub keeps it
+      # (so L's return is served from H, no refetch to A) until H's own budget
+      # forces it out, least-recently-served first.
+      var authority = EdContext.init(id = "ck_auth", is_authority = true)
+      var hub = EdContext.init(id = "ck_hub", mem_limit = 600)
+      var leaf = EdContext.init(id = "ck_leaf", mem_limit = 0)
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "ck_owner")
+      var tbl: EdTable[int, string]
+      owner.own:
+        tbl = EdTable[int, string].init(
+          ctx = authority, id = "ck_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
+      tbl[1] = 'a'.repeat(200)
+      tbl[2] = 'b'.repeat(200)
+      tbl[3] = 'c'.repeat(200)
+
+      hub.subscribe(authority, partial = true, fetch = [])
+      hub.tick()
+      leaf.subscribe(hub, partial = true, fetch = [])
+      leaf.tick()
+      # Both pull the owner's closure (the LAZY table arrives as a handle).
+      discard hub.fetch("ck_owner", deep = true)
+      authority.tick()
+      hub.tick()
+      discard leaf.fetch("ck_owner", deep = true) # chains to the hub
+      leaf.tick()
+      hub.tick()
+      leaf.tick()
+      let htbl = EdTable[int, string](hub["ck_tbl"])
+      let ltbl = EdTable[int, string](leaf["ck_tbl"])
+
+      # L pages key 1 in, then releases it (out of view).
+      ltbl.request(1)
+      leaf.tick()
+      hub.tick()
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      check ltbl.loaded(1)
+      check htbl.loaded(1)
+      ltbl.release(1)
+      leaf.tick()
+      hub.tick()
+      check not ltbl.loaded(1) # L (no-cache) dropped it
+      check htbl.loaded(1) # ...but the caching hub KEPT it (no refetch on return)
+
+      # Now drive H over its 600 budget: page in 2 and 3 too (still under after
+      # 1+2+3 ≈ 600+? push past it). Least-recently-served (key 1) sheds first.
+      ltbl.request(2)
+      ltbl.request(3)
+      leaf.tick()
+      hub.tick()
+      authority.tick()
+      hub.tick()
+      leaf.tick()
+      for i in 1 .. 3:
+        hub.tick()
+      check htbl.loaded(2) and htbl.loaded(3) # live (L wants them) — protected
+      check not htbl.loaded(1) # cache-tier + stalest → shed under pressure
+
     test "hub shedding: last retract releases the hub's copy upstream":
       # The enu client topology: authority (server) <- partial hub (worker)
       # <- full leaf (node ctx). The leaf drives paging; releases must shed
       # the hub's copy and chain the retract up, or the hub re-accumulates
       # a full replica and keeps paying for ops it no longer needs.
       var authority = EdContext.init(id = "hs_auth", is_authority = true)
-      var hub = EdContext.init(id = "hs_hub")
+      var hub = EdContext.init(id = "hs_hub", mem_limit = 0) # no-cache: shed now
       var leaf = EdContext.init(id = "hs_leaf")
       Ed.thread_ctx = authority
       var owner = DeepOwner(id: "hs_owner")
@@ -589,17 +804,23 @@ proc run*() =
     test "per-key replies carry nested containers (chunk-deep)":
       var authority = EdContext.init(id = "kd_auth", is_authority = true)
       var client = EdContext.init(id = "kd_client")
-      var tbl = EdTable[int, EdSeq[int]].init(ctx = authority, id = "kd_tbl")
+      Ed.thread_ctx = authority
+      var owner = DeepOwner(id: "kd_owner")
+      var tbl: EdTable[int, EdSeq[int]]
+      owner.own:
+        tbl = EdTable[int, EdSeq[int]].init(
+          ctx = authority, id = "kd_tbl", flags = DEFAULT_FLAGS + {LAZY}
+        )
       client.subscribe(authority, partial = true, fetch = [])
       client.tick()
-      discard client.fetch("kd_tbl", follow = false) # snapshot: empty, no interest
+      discard client.fetch("kd_owner", deep = true) # LAZY handle rides the closure
       authority.tick()
       client.tick()
       check "kd_tbl" in client
 
       var entry = EdSeq[int].init(ctx = authority, id = "kd_entry")
       entry.add 7
-      tbl[1] = entry # not streamed: the client holds no interest
+      tbl[1] = entry # LAZY + no per-key interest: not streamed
       client.tick()
       let ctbl = EdTable[int, EdSeq[int]](client["kd_tbl"])
       check not ctbl.loaded(1)


### PR DESCRIPTION
**Stacked on #17.** PR 5 — memory reclamation for partial replicas, built on the proxy-liveness signal from the proxy/body split.

- **Evictor** — touch/LRU sweep gated on *no live proxy* (safety) + outside live interest (policy). Only **partial replicas** evict; a full clone ignores `mem_limit` (evicting it breaks live round-trips — an enu node ctx hung the bot test and godot shutdown). `mem_limit` is an honest byte budget: `0` = no cache, `0<n<Unbounded` = LRU, `Unbounded` = never. Decoded via `evicts`/`has_budget`.
- **Interest tiers (live vs cache)** — `interest` splits into live (mandatory, eviction-protecting) and cache (streamed but reclaimable). `reconcile_tier` sends a lightweight `INTEREST` demote/promote upstream when local liveness flips, so an upstream is bounded by `live(subtree) + own budget`, never by a downstream's cache. Caching hub keeps released keys as cache-tier with per-key LRU.

Full suite + `tests/asan.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)