### PR TITLE
fix: teardown notifications + uniform DESTROY type-gating

### DIFF
--- a/src/ed/components/private/tracking.nim
+++ b/src/ed/components/private/tracking.nim
@@ -1,7 +1,4 @@
-import
-  std/[importutils, tables, sets, sequtils, algorithm, intsets, locks, sugar]
-
-import pkg/[flatty, supersnappy, threading/channels {.all.}]
+import std/[importutils, tables, sets, sequtils, intsets, locks, sugar]
 import
   ed/
     [core, components/type_registry, zens/contexts, zens/private, types {.all.}]

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -317,11 +317,9 @@ proc fanout(
       # forever (the reload leak). A destroy for an id a peer doesn't hold is a
       # cheap no-op.
       continue
-    if sub.capabilities.len > 0 and msg.type_id != 0 and
-        msg.type_id notin sub.capabilities:
-      # Peer can't materialize this type — never send its ops. type_id == 0
-      # (DESTROY / control) isn't type-gated; it's a no-op on a peer that never
-      # got the CREATE, and must reach a peer that did.
+    if sub.capabilities.len > 0 and msg.type_id notin sub.capabilities:
+      # Peer can't materialize this type — never send its ops (incl. DESTROY: it
+      # never built the type, so it never held the object).
       continue
     if sub.kind == LOCAL:
       self.send(sub, msg, op_ctx, flags)
@@ -342,7 +340,9 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   # Build the DESTROY once and stamp it with the global LSN (authority only),
   # so every subscriber receives the same ordered op. DESTROY is ordered like
   # ASSIGN — delete-vs-update is a real conflict (see spike doc).
-  var msg = Message(kind: DESTROY, object_id: self.id)
+  # type_id rides along for the capability filter (which types a peer can hold),
+  # not for construction — DESTROY tears down by id.
+  var msg = Message(kind: DESTROY, object_id: self.id, type_id: Ed[T, O].tid)
   msg.origin =
     if op_ctx.origin != "":
       op_ctx.origin
@@ -588,8 +588,7 @@ proc publish_changes*[T, O](
             id in sub.key_interest and sub.ctx_id notin op_ctx.source:
           for msg in msgs.mitems:
             if msg.key_bin.len > 0 and msg.key_bin in sub.key_interest[id]:
-              if sub.capabilities.len > 0 and msg.type_id != 0 and
-                  msg.type_id notin sub.capabilities:
+              if sub.capabilities.len > 0 and msg.type_id notin sub.capabilities:
                 continue
               if msg.kind == ASSIGN and msg.change_object_id.len > 0 and
                   msg.change_object_id in self.ctx and

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -669,16 +669,20 @@ proc drain_unsubscribed*(self: EdContext): seq[string] =
   result = self.unsubscribed
   self.unsubscribed = @[]
 
-proc unsubscribe*(self: EdContext, sub: Subscription) =
+proc unsubscribe*(self: EdContext, sub: Subscription, notify = true) =
+  ## Drop `sub` and let the peer know it's gone. REMOTE: disconnect (the peer
+  ## sees a dead connection). LOCAL: send an `UNSUBSCRIBE` through its channel so
+  ## the peer drops its reverse subscription and stops fanning ops into our inbox
+  ## — there's no keepalive timeout to do it for us. `notify = false` when *we're*
+  ## reacting to an incoming `UNSUBSCRIBE`, so the two sides don't ping-pong.
   # Snapshot the id before the delete below: `sub` is a borrowed param (ORC
   # doesn't refcount parameters), and the seq slot is the only owner, so the
   # delete frees it -- every later read must use this local, not `sub`.
   let ctx_id = sub.ctx_id
   if sub.kind == REMOTE:
     self.reactor.disconnect(sub.connection)
-  else:
-    # ???
-    discard
+  elif notify and sub.kind == LOCAL:
+    self.send(sub, Message(kind: UNSUBSCRIBE), OperationContext(), DEFAULT_FLAGS)
   self.subscribers.delete self.subscribers.find(sub)
   self.unsubscribed.add ctx_id
   # Purge the subscriber's chained wants so nothing is served to a dead sub.
@@ -1609,6 +1613,12 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
             )
           else:
             self.add_obj_want(s, msg)
+  elif msg.kind == UNSUBSCRIBE:
+    # A LOCAL peer is leaving. Drop our reverse subscription(s) to it (without
+    # echoing UNSUBSCRIBE back) and record it in `unsubscribed` so consumers
+    # reap what it owned (drain_unsubscribed).
+    for s in self.subscribers.filter_it(it.ctx_id in source):
+      self.unsubscribe(s, notify = false)
   elif msg.kind != BLANK:
     if msg.object_id notin self:
       # An op for an object we don't hold is dropped. Usually benign

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -106,7 +106,6 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
     if not is_nil:
       var info: EdFlattyInfo
       s.from_flatty(i, info)
-      # :(
       if info.object_id in flatty_ctx:
         value = value.type()(flatty_ctx.resolve_proxy(flatty_ctx.objects[info.object_id]))
       else:
@@ -1166,27 +1165,14 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       fallback
 
   if self.id in source:
-    # Routing invariant violated: a message tagged with our own id arrived
-    # back at us. With the publish-side filter and the SUBSCRIBE-time stale
-    # subscription sweep this should be unreachable for any well-behaved
-    # client. If it fires, treat it as a bug rather than swallowing it.
-    error "own_message_assert",
-      ctx = self.id,
-      source = source.to_seq.join(","),
-      kind = $msg.kind,
-      sub_kind = (if sub.is_nil: "nil" else: $sub.kind),
-      raw_source = msg.source.map_it($it).join(","),
-      sub_ctx = (if sub.is_nil: "nil" else: sub.ctx_id)
-  assert self.id notin source
+    # Our own id in the source set means a message looped back to us — the
+    # publish-side source filter should prevent it. Skip rather than risk
+    # double-applying it, and warn so a routing regression stays visible.
+    warn "dropping message that looped back to its source",
+      ctx = self.id, kind = $msg.kind, source = source.to_seq.join(",")
+    return
 
   received_message_counter.inc(label_values = [self.metrics_label])
-  # when defined(ed_trace):
-  #   let src = self.name & "-" & source_str
-  #   if src in self.last_received_id:
-  #     if msg.id != self.last_received_id[src] + 1:
-  #       raise_check &"src={src} msg.id={msg.id} " &
-  #           &"last={self.last_received_id[src]}. Should be msg.id - 1"
-  #   self.last_received_id[src] = msg.id
   debug "receiving", msg, topics = "networking"
 
   # Ordered-op idempotency: a stamped op at or below our frontier was already
@@ -1273,7 +1259,6 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           materialize_it()
       else:
         materialize_it()
-      # :(
     # Safety net for paths where the initializer fills an existing object (a
     # placeholder) rather than running `defaults` — stamp + index after the fact.
     # Keyed by owner id, so arrival order vs. the owner doesn't matter.
@@ -1666,7 +1651,6 @@ proc untrack*[T, O](self: Ed[T, O], zid: EID) =
   log_defaults
   assert self.valid
 
-  # :(
   let body = self.typed_body
   if zid in body.changed_callbacks:
     let callback = body.changed_callbacks[zid]

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -120,6 +120,10 @@ type
                # `demote` (true) downgrades object_id to cache tier (still
                # streamed, but no longer protects it from eviction); `demote`
                # false promotes it back to live. Lightweight — no data.
+    UNSUBSCRIBE # a LOCAL peer is going away (unsubscribe or context destroy):
+                # the receiver drops its reverse subscription and fires the
+                # unsubscribed event. REMOTE peers learn this from the dead
+                # connection; cross-thread channels have no such signal.
 
   BaseChange* = ref object of RootObj
     changes*: set[ChangeKind]

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -321,6 +321,10 @@ type
     # they touch a placeholder. When `blocking`, that call pumps I/O until the
     # object fills; otherwise it kicks a fetch and returns the empty placeholder.
     materialize*: proc(self: EdContext, id: string) {.gcsafe.}
+    # Blocking materialize: a read of an unmaterialized placeholder pumps I/O
+    # until it fills. Normally driven by SyncMode (EdClient sets it for PARTIAL)
+    # or scoped via the `blocking:` template — not set on its own (a full replica
+    # never needs to block; that's why SyncMode pairs the two).
     blocking*: bool
     # Partial-replica evictor (docs/partial-replicas.md). `mem_limit` is a cache
     # budget for unclaimed bodies, in bytes — an honest, monotonic value from

--- a/src/ed/zens.nim
+++ b/src/ed/zens.nim
@@ -1,4 +1,4 @@
-import ed/[core, types]
+import ed/[types]
 export types
 
 import ed/zens/[contexts, initializers, operations, validations]

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -1,4 +1,4 @@
-import std/[net, tables, times, options, sugar, math]
+import std/[net, tables, times, options, sugar, math, sets, isolation]
 import pkg/threading/channels {.all.}
 
 import
@@ -252,6 +252,15 @@ proc destroy*(self: EdContext) =
   ## reference drops. Idempotent.
   privileged
   debug "destroying EdContext", id = self.id
+  # Notify LOCAL peers so they drop their reverse subscription and stop fanning
+  # ops into our about-to-be-freed inbox — cross-thread channels have no
+  # keepalive signal (REMOTE peers learn from the closed socket below). Enqueue
+  # directly and non-blocking: if a peer's inbox is full we skip rather than hang
+  # teardown (the peer keeps the stale sub, the pre-existing behavior).
+  for sub in self.subscribers:
+    if sub.kind == LOCAL:
+      var iso = isolate(Message(kind: UNSUBSCRIBE, source_set: [self.id].toHashSet))
+      discard sub.chan.try_take(iso)
   for id, body in self.objects:
     if ?body:
       body.release_closures

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -1,10 +1,16 @@
 import std/[typetraits, macros, macrocache, monotimes, times]
 import ed/[core, components/private/tracking]
 import ed/components/private/global_state
-import ed/types {.all.}, ed/zens/[validations, operations, contexts, private]
+import ed/types {.all.}, ed/zens/[operations, contexts, private]
 import ed/utils/misc # ZenError
 
-export new_ident_node
+# `quote do` (in create_initializer) expands to code referencing `newIdentNode`,
+# so it must be in scope here. Re-exported so it also resolves at `Ed.bootstrap`
+# expansion sites. Deprecated alias of `ident`; suppress the notice rather than
+# rewrite the macro to genAst for 0.3.
+{.push warning[Deprecated]: off.}
+export newIdentNode
+{.pop.}
 
 # Per-type registration statements collected at compile time (one per
 # instantiated `Ed[T,O]`), emitted by `Ed.bootstrap`. Each is a trivial call —
@@ -62,7 +68,6 @@ proc materialize_received*[T, O](
   ## and that's fine: it only ever runs via `subscribe`, which guards the call.
   ## `create_initializer` references it through `cast[pointer]`, which launders
   ## the effect so the reference can't poison the gcsafe defaults/init chain.
-  mixin new_ident_node
   if bin != "":
     debug "creating received object", id
     if not ctx.subscribing and id notin ctx:
@@ -290,7 +295,9 @@ proc defaults[T, O](
     when change.item is Ed:
       msg.change_object_id = change.item.id
     elif change.item is Pair[auto, Ed]:
-      # TODO: Properly sync ref keys
+      # EdTable whose value is an Ed container (e.g. EdTable[Vector3, EdSeq]):
+      # the value syncs by id, the key by value. Ref-typed keys aren't supported
+      # here — `to_flatty` nils refs, so the key wouldn't round-trip.
       {.gcsafe.}:
         msg.obj = change.item.key.to_flatty
       msg.change_object_id = change.item.value.id

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -1,9 +1,9 @@
 import
   std/[
-    tables, sequtils, sugar, macros, typetraits, sets, isolation, unittest,
+    tables, sequtils, sugar, macros, typetraits, sets, unittest,
     deques, importutils, monotimes, os
   ]
-import pkg/[pretty, chronicles, netty]
+import pkg/[chronicles, netty]
 import ed
 import test_util
 from std/times import init_duration

--- a/tests/client_tests.nim
+++ b/tests/client_tests.nim
@@ -1,5 +1,5 @@
 import test_util
-import std/[unittest, atomics, os, sets]
+import std/[unittest, atomics, os]
 import ed
 import ed/types {.all.}
 

--- a/tests/ctx_teardown_tests.nim
+++ b/tests/ctx_teardown_tests.nim
@@ -1,4 +1,4 @@
-import std/unittest
+import std/[unittest, sequtils]
 import ed
 
 # Regression gate for the context-teardown leak (branch fix/ctx-teardown-leak):
@@ -38,6 +38,26 @@ proc run*() =
     # blow far past this.
     checkpoint("occupied-mem growth over " & $ITERS & " cycles: " & $growth & " B")
     check growth < 512 * 1024
+
+  test "destroying a LOCAL peer notifies the survivor (drops its reverse sub)":
+    # enu's main↔worker shape: a long-lived survivor subscribes to a worker that
+    # is torn down on level reload. Without peer-notify the survivor keeps a
+    # stale sub to the dead worker's inbox (fanning ops into it forever) and never
+    # learns to reap what the worker owned (drain_unsubscribed).
+    var survivor = EdContext.init(id = "survivor")
+    var worker = EdContext.init(id = "worker1")
+    Ed.thread_ctx = survivor
+    survivor.subscribe(worker) # bidirectional local: survivor ⇄ worker
+    survivor.tick()
+    worker.tick()
+    check worker.id in survivor.subscribers.map_it(it.ctx_id)
+    check survivor.id in worker.subscribers.map_it(it.ctx_id)
+
+    worker.destroy() # reload tears the worker down
+    survivor.tick()  # survivor processes the worker's UNSUBSCRIBE
+
+    check worker.id notin survivor.subscribers.map_it(it.ctx_id)
+    check worker.id in survivor.drain_unsubscribed
 
 when is_main_module:
   Ed.bootstrap

--- a/tests/error_handling_tests.nim
+++ b/tests/error_handling_tests.nim
@@ -1,5 +1,5 @@
-import std/[unittest, sets, tables, times, strutils]
-import pkg/[pretty, chronicles]
+import std/[unittest, sets, tables, strutils]
+import pkg/[chronicles]
 import ed
 import ed/components/type_registry
 

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -1,5 +1,5 @@
-import std/[unittest, sets, tables, times, strutils]
-import pkg/[pretty, chronicles]
+import std/[unittest, sets, tables, strutils]
+import pkg/[chronicles]
 import ed
 import ed/components/type_registry
 

--- a/tests/network_tests.nim
+++ b/tests/network_tests.nim
@@ -1,5 +1,5 @@
 import std/[tables, sugar, unittest, sequtils, strutils]
-import pkg/[flatty, chronicles, pretty, netty]
+import pkg/[flatty, chronicles, netty]
 import ed
 import ed/types {.all.}
 import ed/zens/private {.all.}

--- a/tests/object_tests.nim
+++ b/tests/object_tests.nim
@@ -1,5 +1,4 @@
 import std/[unittest]
-import pkg/[pretty, chronicles]
 import ed
 import ./object_tests_types
 

--- a/tests/publish_tests.nim
+++ b/tests/publish_tests.nim
@@ -1,8 +1,7 @@
 import std/[tables, sugar, unittest]
-import pkg/[flatty, chronicles, pretty]
+import pkg/[flatty, chronicles]
 import ed
 import ed/[types, components/type_registry]
-from std/times import init_duration
 
 proc run*() =
   type

--- a/tests/threading_tests.nim
+++ b/tests/threading_tests.nim
@@ -1,5 +1,4 @@
-import std/[locks, os, unittest, tables]
-import pkg/[pretty, chronicles]
+import std/[locks, unittest]
 import ed
 import test_util
 

--- a/tests/utils_tests.nim
+++ b/tests/utils_tests.nim
@@ -1,5 +1,4 @@
-import std/[unittest, monotimes, sets, tables, strutils]
-import pkg/[pretty, chronicles]
+import std/[unittest, monotimes, tables, strutils]
 import ed
 import ed/utils/[stats, misc, typeids]
 from std/times import seconds, init_duration

--- a/tests/validation_tests.nim
+++ b/tests/validation_tests.nim
@@ -1,5 +1,4 @@
 import std/[unittest]
-import pkg/[pretty, chronicles]
 import ed
 import ed/zens/validations
 


### PR DESCRIPTION
0.3 prep, part 1 of 4 (stacked). Behavioral fixes around teardown and destroy.

- **notify LOCAL peers on unsubscribe/destroy** — cross-thread peers have no dead-connection signal, so a leaving LOCAL peer now sends UNSUBSCRIBE; the survivor drops its reverse sub and reports it for reaping.
- **tidy for 0.3** — clean build, safer own-message guard, comment clarity.
- **type-gate DESTROY uniformly** — drop the `type_id == 0` exemption.

Base: `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)