### PR TITLE
chore: ASCII-only comments + snake_case style pass

### DIFF
--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -182,7 +182,7 @@ template every*(self: EdClient, interval: Duration, body: untyped) =
     while true:
       self.tick
       if had_session and (self.ctx != session or not self.connected):
-        raise newException(
+        raise new_exception(
           SessionLost, "the session this wait started with is gone"
         )
       body

--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -3,7 +3,7 @@
 ## A context only stays healthy if it is `tick`ed regularly: ticking drives
 ## netty's keepalives and reaps dead connections. Tick on a timer and
 ## `connected` (subscribers present) becomes an authoritative liveness
-## signal — no application-level ping needed.
+## signal -- no application-level ping needed.
 
 import std/os
 
@@ -48,12 +48,12 @@ type EdClient* = ref object
     ## wants units render-ready; a narrow utility fetches what it touches).
   on_connect*: proc()
     ## (Re)create this client's objects after each (re)connect. Runs with
-    ## `Ed.thread_ctx` set to the fresh context. Single-threaded — runs on
+    ## `Ed.thread_ctx` set to the fresh context. Single-threaded -- runs on
     ## the caller's thread, so it may touch the caller's globals.
   ctx*: EdContext
   prev*: EdContext
     ## The session before the current one (one generation only). Each reconnect
-    ## mints a fresh context, but the previous session's objects stay readable —
+    ## mints a fresh context, but the previous session's objects stay readable --
     ## state that lived in it (a bot's last transform, say) can be salvaged from
     ## here after the peer restarted and lost its copy.
   reconnect_interval*: Duration
@@ -75,7 +75,7 @@ proc reconnect*(self: EdClient): EdClient {.discardable.} =
   ##
   ## The context is NOT reused across reconnects: an existing object's CREATE
   ## never re-broadcasts, so a restarted peer would never learn about this
-  ## client's objects — they'd survive locally as ghosts whose ops the peer
+  ## client's objects -- they'd survive locally as ghosts whose ops the peer
   ## skips. Same-session resync is the body-persistence/revive work, not a
   ## client-side trick.
   result = self
@@ -102,7 +102,7 @@ proc reconnect*(self: EdClient): EdClient {.discardable.} =
       address = self.address, msg = e.msg
 
 template connect*(self: EdClient) =
-  ## Bootstrap the Ed runtime, then connect — `Ed.bootstrap` + `reconnect` in
+  ## Bootstrap the Ed runtime, then connect -- `Ed.bootstrap` + `reconnect` in
   ## one step, so apps never name `bootstrap`. Returns the client, chainable:
   ## `let c = EdClient(...).connect`.
   ##
@@ -110,7 +110,7 @@ template connect*(self: EdClient) =
   ## program has instantiated; `connect` is a template so it expands at YOUR
   ## call site, picking up everything instantiated by then (so call it after
   ## your imports). The registrations are trivial calls referencing named
-  ## procs, so — unlike before — this expands cleanly inside a `unittest test`
+  ## procs, so -- unlike before -- this expands cleanly inside a `unittest test`
   ## block. `tick`/`online` reconnect through the bootstrap-free `reconnect`.
   ##
   ## `-d:ed_disable_auto_bootstrap` makes this skip `Ed.bootstrap`; call
@@ -131,7 +131,7 @@ proc tick*(self: EdClient) =
   ## Tick the context, reconnecting if it has dropped. Call on a timer to
   ## keep an otherwise-idle connection alive. While down, keep ticking the
   ## existing context so an in-flight handshake can complete, and only
-  ## re-subscribe once per `reconnect_interval` — re-subscribing every tick
+  ## re-subscribe once per `reconnect_interval` -- re-subscribing every tick
   ## would restart the handshake before it finishes and spin the CPU.
   if self.ctx.is_nil:
     self.reconnect
@@ -165,7 +165,7 @@ template online*(self: EdClient, body: untyped): untyped =
 type SessionLost* = object of CatchableError
   ## Raised by EdClient's waiting helpers (`every` / `animate` /
   ## `tick_until`) when the live session they started with goes away
-  ## mid-wait: the link dropped, or a reconnect replaced the context —
+  ## mid-wait: the link dropped, or a reconnect replaced the context --
   ## stranding any handles the caller's loop body captured (each reconnect
   ## mints a fresh context). A loop that starts *without* a live session
   ## (waiting for the first connect) never raises.

--- a/src/ed/components/private/tracking.nim
+++ b/src/ed/components/private/tracking.nim
@@ -14,14 +14,14 @@ proc trigger_callbacks*[T, O](body: EdBody[T, O], changes: seq[Change[O]]) {.gcs
 
 proc trigger_callbacks_deferred[T, O](body: EdBody[T, O], changes: seq[Change[O]]) =
   # Silent-materialize deferral: re-fires at the next tick. Captures the body
-  # (registry-owned) in a ctx-held seq — a plain chain, dropped when replayed.
+  # (registry-owned) in a ctx-held seq -- a plain chain, dropped when replayed.
   privileged
   body.ctx.pending_fills.add proc() {.gcsafe.} =
     body.trigger_callbacks(changes)
 
 proc trigger_callbacks*[T, O](body: EdBody[T, O], changes: seq[Change[O]]) {.gcsafe.} =
   ## Body-side: callbacks are registry-owned (see EdBody). The live proxy is
-  ## resolved lazily — only when there are callbacks to fire — and passed as
+  ## resolved lazily -- only when there are callbacks to fire -- and passed as
   ## the `it` parameter, never captured.
   privileged
 
@@ -40,7 +40,7 @@ proc trigger_callbacks*[T, O](body: EdBody[T, O], changes: seq[Change[O]]) {.gcs
     for c in changes:
       c.reason = Fill
 
-  # Silent (blocking) materialize: nothing application-visible fires mid-fetch —
+  # Silent (blocking) materialize: nothing application-visible fires mid-fetch --
   # defer the callbacks to the next explicit tick (preserves tick-boundary
   # semantics and clean reentrancy). The value is already applied, so the
   # blocking read still returns real data.

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -620,7 +620,7 @@ proc publish_changes*[T, O](
         # (return-to-source) -- so writers learn the canonical order/value and
         # converge. LSN dedup in process_message keeps this idempotent and
         # loop-free (receivers won't echo back to us: we're in their source).
-        let canon_ctx = OperationContext.init(source = [self.ctx.id].toHashSet)
+        let canon_ctx = OperationContext.init(source = [self.ctx.id].to_hash_set)
         for msg in msgs:
           self.ctx.fanout(msg, canon_ctx, self.flags, self.ctx.subscribers)
       else:
@@ -752,7 +752,7 @@ proc subscribe*(
       ctx_id: self.id,
       partial: partial,
       deep: deep,
-      interest: fetch.toHashSet,
+      interest: fetch.to_hash_set,
     ),
     push_all = bidirectional,
     remote_objects,
@@ -952,7 +952,7 @@ proc evict_sweep*(self: EdContext) =
           live = true
           break
       if not live:
-        keyed.add (body.key_last_read.getOrDefault(key_bin), id, key_bin)
+        keyed.add (body.key_last_read.get_or_default(key_bin), id, key_bin)
   var key_heap = keyed.to_heap_queue # min by recency: least-recently-served first
   while self.used_bytes > self.mem_limit and key_heap.len > 0:
     let (_, id, key_bin) = key_heap.pop
@@ -961,7 +961,7 @@ proc evict_sweep*(self: EdContext) =
     if obj != nil and obj.evict_key != nil:
       let evicted = obj.evict_key(obj, key_bin) # evict_key -> forget_key_bytes
       self.drop_nested_bodies(evicted.nested)    # ...clears key_last_read too
-    self.pending_key_releases.mgetOrPut(id, @[]).add key_bin # retract upstream
+    self.pending_key_releases.mget_or_put(id, @[]).add key_bin # retract upstream
 
 proc fetch*(
     self: EdContext, object_id: string, deep = false
@@ -1068,7 +1068,7 @@ proc subscribe*(
   # three to the subscription it creates for us.
   let type_ids = block:
     {.gcsafe.}:
-      toSeq(type_initializers.keys)
+      to_seq(type_initializers.keys)
   let handshake = (type_ids, partial, @fetch, deep).to_flatty
   self.send(
     Subscription(
@@ -1194,7 +1194,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   if msg.origin == self.id:
     let superseded =
       msg.delta or
-      msg.op_id < self.latest_op_id.getOrDefault(msg.object_id, 0'i64)
+      msg.op_id < self.latest_op_id.get_or_default(msg.object_id, 0'i64)
     if superseded:
       if msg.lsn > self.applied_lsn:
         self.applied_lsn = msg.lsn
@@ -1264,7 +1264,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     if msg.owner_id.len > 0 and msg.object_id in self.objects and
         ?self.objects[msg.object_id]:
       self.objects[msg.object_id].owner_id = msg.owner_id
-      self.owned_by.mgetOrPut(msg.owner_id, initHashSet[string]()).incl(
+      self.owned_by.mget_or_put(msg.owner_id, init_hash_set[string]()).incl(
         msg.object_id
       )
     # Interest tiering (Option 2): a body materialized from an upstream CREATE
@@ -1444,7 +1444,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
             if obj.evict_key != nil:
               let evicted = obj.evict_key(obj, key_bin)
               self.drop_nested_bodies(evicted.nested)
-          self.pending_key_releases.mgetOrPut(msg.object_id, @[]).add key_bin
+          self.pending_key_releases.mget_or_put(msg.object_id, @[]).add key_bin
     if not retracted:
       var from_upstream = false
       for src in source:
@@ -1503,7 +1503,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         # future ops stream (a missing chunk pops in when someone builds
         # there). RELEASE retracts.
         for key_bin in msg.obj.from_flatty(seq[string]):
-          s.key_interest.mgetOrPut(msg.object_id, initHashSet[string]()).incl(
+          s.key_interest.mget_or_put(msg.object_id, init_hash_set[string]()).incl(
             key_bin
           )
         var missing: seq[string]
@@ -1874,11 +1874,11 @@ proc tick*(
         var latest: Table[string, int64]
         for m in batch:
           if m.kind == ASSIGN and not m.delta and m.lsn > 0 and
-              m.lsn > latest.getOrDefault(m.object_id, 0'i64):
+              m.lsn > latest.get_or_default(m.object_id, 0'i64):
             latest[m.object_id] = m.lsn
         for m in batch:
           if m.kind == ASSIGN and not m.delta and m.lsn > 0 and
-              m.lsn < latest.getOrDefault(m.object_id, 0'i64):
+              m.lsn < latest.get_or_default(m.object_id, 0'i64):
             if m.lsn > self.applied_lsn:
               self.applied_lsn = m.lsn  # superseded register update: skip effect
           else:
@@ -2063,9 +2063,9 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   self.silent = false
 
 proc find_bare_return(n: NimNode): NimNode =
-  if n.kind == nnkReturnStmt:
+  if n.kind == nnk_return_stmt:
     return n
-  if n.kind in {nnkProcDef, nnkFuncDef, nnkLambda, nnkDo}:
+  if n.kind in {nnk_proc_def, nnk_func_def, nnk_lambda, nnk_do}:
     return nil
   for child in n:
     let found = find_bare_return(child)

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -26,7 +26,7 @@ privileged
 
 proc get_or_assign_short_id(sub: Subscription, full_id: string): uint8 =
   ## Get existing short ID or assign a new one for our outgoing encoding.
-  ## Touches only the outgoing namespace — incoming shorts are tracked
+  ## Touches only the outgoing namespace -- incoming shorts are tracked
   ## separately in incoming_short_to_id.
   if full_id in sub.id_to_short:
     result = sub.id_to_short[full_id]
@@ -132,7 +132,7 @@ proc from_flatty*[T: ref RootObj](s: string, i: var int, value: var T) =
           value = value.type()(registered_type.parse(flatty_ctx, val.item))
         else:
           # Unknown ref type (version skew / type not compiled here). Leave the
-          # ref nil and carry on rather than aborting — forgiving on payload,
+          # ref nil and carry on rather than aborting -- forgiving on payload,
           # strict only on the envelope.
           debug "skipping ref for unknown type", ref_tid = val.tid
     else:
@@ -150,7 +150,7 @@ proc from_flatty*(s: string, i: var int, p: proc) =
 
 proc to_flatty*(s: var string, x: Lifetime) =
   ## A Lifetime is thread-local handle state (a set of cleanup closures), never
-  ## part of the synced value. Skip it — flatty can't serialize `seq[proc]`, and
+  ## part of the synced value. Skip it -- flatty can't serialize `seq[proc]`, and
   ## the receiver mints its own. Mirrors the `proc` override above.
   discard
 
@@ -194,7 +194,7 @@ proc flush_buffers*(self: EdContext) =
         sub.send_or_buffer(msg, true)
 
 template ed_compress(s: string): string =
-  ## Pass-through under `-d:ed_no_compress` — supersnappy's snappy fast-path
+  ## Pass-through under `-d:ed_no_compress` -- supersnappy's snappy fast-path
   ## over-reads within an allocation, which trips AddressSanitizer (it's a benign
   ## third-party over-read, not our bug). The sanitizer build defines the flag so
   ## ASan can focus on Ed's own memory behaviour; in-process sync uses one build,
@@ -205,7 +205,7 @@ template ed_uncompress(s: string): string =
   when defined(ed_no_compress): s else: s.uncompress
 
 proc remote_body(msg: Message, no_overwrite: bool): string =
-  ## The shared, compressed wire body for a remote message — identical across
+  ## The shared, compressed wire body for a remote message -- identical across
   ## subscribers (source / id_mappings travel per-subscriber, outside it), so a
   ## fanout serializes + compresses it once.
   var body_msg = msg
@@ -218,7 +218,7 @@ proc remote_body(msg: Message, no_overwrite: bool): string =
 const wire_header = "ED\x01"
   ## Magic + wire-format version, prefixed to every remote packet. flatty is
   ## positional: bytes from an older wire format can decode *cleanly* into
-  ## wrong-typed fields and blow up (or corrupt state) deep in processing — a
+  ## wrong-typed fields and blow up (or corrupt state) deep in processing -- a
   ## version-skewed peer once killed a server silently this way. The prefix
   ## rejects foreign packets at the front door instead. Bump the version byte
   ## whenever the wire format changes.
@@ -318,7 +318,7 @@ proc fanout(
       # cheap no-op.
       continue
     if sub.capabilities.len > 0 and msg.type_id notin sub.capabilities:
-      # Peer can't materialize this type — never send its ops (incl. DESTROY: it
+      # Peer can't materialize this type -- never send its ops (incl. DESTROY: it
       # never built the type, so it never held the object).
       continue
     if sub.kind == LOCAL:
@@ -339,9 +339,9 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   trace "publishing destroy", ed_id = self.id
   # Build the DESTROY once and stamp it with the global LSN (authority only),
   # so every subscriber receives the same ordered op. DESTROY is ordered like
-  # ASSIGN — delete-vs-update is a real conflict (see spike doc).
+  # ASSIGN -- delete-vs-update is a real conflict (see spike doc).
   # type_id rides along for the capability filter (which types a peer can hold),
-  # not for construction — DESTROY tears down by id.
+  # not for construction -- DESTROY tears down by id.
   var msg = Message(kind: DESTROY, object_id: self.id, type_id: Ed[T, O].tid)
   msg.origin =
     if op_ctx.origin != "":
@@ -365,7 +365,7 @@ proc publish_closure(
   ## Serve an ownership closure to `s`: BFS from `root_id` over `owned_by`,
   ## publishing every container and following member keys (tid:id) into the
   ## members' own owned sets. Used to serve deep fetches, and to push an
-  ## OWNS_MEMBERS collection's member closures *before* the collection itself —
+  ## OWNS_MEMBERS collection's member closures *before* the collection itself --
   ## so a partial subscriber's parse links member fields to real containers
   ## instead of minting unregistered husks. Returns whether anything was found.
   ## Everything published (except LAZY handles) joins `s.interest` so future ops
@@ -391,8 +391,8 @@ proc publish_closure(
       if plain notin ids:
         ids.add plain
   # Publish deepest-first (reverse BFS): a subscribing context defers value
-  # restoration and replays it in arrival order, so a collection's restore —
-  # which fires the app's ADDED watchers — must come *after* its members'
+  # restoration and replays it in arrival order, so a collection's restore --
+  # which fires the app's ADDED watchers -- must come *after* its members'
   # containers have their values, or the watchers read empty state. Mirrors
   # add_subscriber's newest-first iteration, which is what full replicas rely
   # on for the same reason.
@@ -400,7 +400,7 @@ proc publish_closure(
     let id = to_publish[j]
     let zen = self.objects[id]
     if LAZY in zen.flags:
-      # Pull-only: send a *handle* (empty-body CREATE — id, type, flags) and
+      # Pull-only: send a *handle* (empty-body CREATE -- id, type, flags) and
       # don't follow it. The receiver registers a placeholder and pages
       # entries with request/release; a whole-table push would defeat LAZY.
       zen.publish_create(s, contents = false)
@@ -409,7 +409,7 @@ proc publish_closure(
       zen.publish_create(s)
 
 proc serve_key_wants(self: EdContext, object_id: string) =
-  ## Serve chained per-key wants that can now be answered — entries for
+  ## Serve chained per-key wants that can now be answered -- entries for
   ## `object_id` may have just arrived (see forward_request).
   privileged
   if object_id notin self.pending_key_wants or object_id notin self:
@@ -425,7 +425,7 @@ proc serve_key_wants(self: EdContext, object_id: string) =
         if not obj.placeholder:
           obj.publish_create(waiter, contents = false)
         # Per-key deep: nested containers (a chunk's delta seq) go first so
-        # the receiver's parse links them — and they're followed, so their
+        # the receiver's parse links them -- and they're followed, so their
         # future ops stream.
         for nested_id in reply.nested:
           if nested_id in self and not self.objects[nested_id].placeholder:
@@ -440,12 +440,12 @@ proc serve_key_wants(self: EdContext, object_id: string) =
 
 proc request_targets(self: EdContext): seq[Subscription] =
   ## Who to send a REQUEST to: our upstreams (the contexts we page from).
-  ## Never downstream — a clone's copy of us is stale-by-definition, and
+  ## Never downstream -- a clone's copy of us is stale-by-definition, and
   ## letting it answer can overwrite fresher local state with its echo. Only a
   ## non-authority forwards, and a non-authority pages from a recorded upstream,
   ## so this is non-empty in practice. An empty result means a degenerate
   ## topology (a non-authority with no upstream); rather than fall back to all
-  ## subscribers — which could route the request downstream — treat it as a bug
+  ## subscribers -- which could route the request downstream -- treat it as a bug
   ## (assert in debug, log in release) and forward nowhere.
   for sub in self.subscribers:
     if sub.ctx_id in self.upstream_ctx_ids:
@@ -532,7 +532,7 @@ proc publish_changes*[T, O](
       # OWNS_MEMBERS + partial: a newly added member must arrive *after* its
       # ownership closure, or the subscriber's parse mints husks for the
       # member's container fields. Push the closure to each interested partial
-      # target now — these CREATEs are sent immediately, ahead of the ADD ops
+      # target now -- these CREATEs are sent immediately, ahead of the ADD ops
       # fanned out below.
       when O is ref:
         if OWNS_MEMBERS in self.flags:
@@ -577,11 +577,11 @@ proc publish_changes*[T, O](
         if originating: self.ctx.next_op_id else: op_ctx.op_id
 
       # Per-key interest (LAZY tables): a partial subscriber without
-      # whole-object interest still receives ops for keys it has requested —
+      # whole-object interest still receives ops for keys it has requested --
       # including a key that was missing at request time (an empty-space chunk
       # someone later builds in). Filtered per-sub on the pre-pack messages
       # (each sub's key set differs) and sent unordered (lsn 0), matching
-      # per-key pulls. The canonical fanout below skips these subs — the
+      # per-key pulls. The canonical fanout below skips these subs -- the
       # object isn't in their `interest`.
       for sub in self.ctx.subscribers:
         if sub.partial and id notin sub.interest and
@@ -616,8 +616,8 @@ proc publish_changes*[T, O](
 
       if self.ctx.is_authority:
         # Canonical ops originate from the authority. Re-origin the source to us
-        # and deliver to ALL subscribers — including the original writer
-        # (return-to-source) — so writers learn the canonical order/value and
+        # and deliver to ALL subscribers -- including the original writer
+        # (return-to-source) -- so writers learn the canonical order/value and
         # converge. LSN dedup in process_message keeps this idempotent and
         # loop-free (receivers won't echo back to us: we're in their source).
         let canon_ctx = OperationContext.init(source = [self.ctx.id].toHashSet)
@@ -651,7 +651,7 @@ proc add_subscriber*(
       if sub.partial and sub.deep and OWNS_MEMBERS in zen.flags:
         # Push the members' closures before the collection itself, so the
         # subscriber's parse links member fields to real containers (no husks).
-        # Members are indexed under the collection's owner — or under the
+        # Members are indexed under the collection's owner -- or under the
         # collection's own id when it's ownerless (the root units list).
         let member_owner = if zen.owner_id.len > 0: zen.owner_id else: id
         self.publish_closure(sub, member_owner)
@@ -662,7 +662,7 @@ proc add_subscriber*(
 
 proc drain_unsubscribed*(self: EdContext): seq[string] =
   ## The ctx ids of peers that unsubscribed (or died) since the last drain.
-  ## Accumulates until drained — consume with this, not by reading the field,
+  ## Accumulates until drained -- consume with this, not by reading the field,
   ## so no event is lost to tick timing.
   result = self.unsubscribed
   self.unsubscribed = @[]
@@ -671,7 +671,7 @@ proc unsubscribe*(self: EdContext, sub: Subscription, notify = true) =
   ## Drop `sub` and let the peer know it's gone. REMOTE: disconnect (the peer
   ## sees a dead connection). LOCAL: send an `UNSUBSCRIBE` through its channel so
   ## the peer drops its reverse subscription and stops fanning ops into our inbox
-  ## — there's no keepalive timeout to do it for us. `notify = false` when *we're*
+  ## -- there's no keepalive timeout to do it for us. `notify = false` when *we're*
   ## reacting to an incoming `UNSUBSCRIBE`, so the two sides don't ping-pong.
   # Snapshot the id before the delete below: `sub` is a borrowed param (ORC
   # doesn't refcount parameters), and the seq slot is the only owner, so the
@@ -726,9 +726,9 @@ proc subscribe*(
 ) =
   ## Subscribe to another local context for cross-thread sync. When `mode` is
   ## partial, we only receive the objects in `fetch` (and ids we `fetch` later)
-  ## — the authority→us direction is filtered; our own writes still flow to it.
+  ## -- the authority->us direction is filtered; our own writes still flow to it.
   ## The fetched ids land in the registry, so `ctx[id]` works for them
-  ## afterwards. `ctx` is recorded as our upstream (we're a clone of it —
+  ## afterwards. `ctx` is recorded as our upstream (we're a clone of it --
   ## eviction notices from it are honored); the internal reverse leg passes
   ## `upstream = false` because receiving a client's own writes doesn't make
   ## it our data source.
@@ -763,11 +763,11 @@ proc subscribe*(
   self.process_value_initializers
 
   if bidirectional:
-    # Reverse direction (us → authority) stays full: we push our own writes.
+    # Reverse direction (us -> authority) stays full: we push our own writes.
     ctx.subscribe(self, bidirectional = false, upstream = false)
 
 proc any_interest*(self: EdContext, object_id: string): bool =
-  ## Does any subscriber below us still hold *live* interest in this object —
+  ## Does any subscriber below us still hold *live* interest in this object --
   ## directly or via a key? Cache-tier interest (`interest_cache`) does NOT
   ## count: the subscriber only has it cached, so we may evict it and
   ## invalidate them (Option 2). Interest auto-propagates downward, so "no live
@@ -782,7 +782,7 @@ proc any_interest*(self: EdContext, object_id: string): bool =
   result = false
 
 proc cache_holders(self: EdContext, object_id: string): seq[Subscription] =
-  ## Subscribers holding `object_id` at cache tier — they need an invalidation
+  ## Subscribers holding `object_id` at cache tier -- they need an invalidation
   ## when we evict it, so they drop their now-orphaned cache.
   for s in self.subscribers:
     if s.ctx_id in self.upstream_ctx_ids:
@@ -793,7 +793,7 @@ proc cache_holders(self: EdContext, object_id: string): seq[Subscription] =
 proc evict_body*(self: EdContext, object_id: string) =
   ## Reclaim a dormant, unclaimed body: drop it locally and retract our
   ## interest upstream so its ops stop flowing (otherwise the next op would
-  ## just re-materialize it). No downstream relay — by the candidate gate
+  ## just re-materialize it). No downstream relay -- by the candidate gate
   ## nobody below us wants it. The data is safe on the authority; a later
   ## access re-fetches. Partial replicas only.
   if object_id notin self.objects or self.objects[object_id] == nil:
@@ -821,7 +821,7 @@ proc evict_body*(self: EdContext, object_id: string) =
   self.tick_reactor
 
 proc is_live_here(self: EdContext, body: ref EdBodyBase): bool =
-  ## Is this object live at our node — actively used, not merely cached?
+  ## Is this object live at our node -- actively used, not merely cached?
   ## True when we hold a live proxy, it's a piece of a live owner, or some
   ## downstream holds *live* interest. Drives the interest tier we report
   ## upstream (live vs cache) and the eviction gate.
@@ -879,7 +879,7 @@ proc evict_sweep*(self: EdContext) =
   ## `evict_candidate`.
   ##
   ## ONLY partial replicas evict (`evicts`). A full clone (partial_replica =
-  ## false) mirrors everything its upstream has — there's no safe "residue" to
+  ## false) mirrors everything its upstream has -- there's no safe "residue" to
   ## drop, because anything it holds is synced state something may read back.
   ## Evicting on a full clone breaks live round-trips, so `mem_limit` is ignored
   ## there.
@@ -887,7 +887,7 @@ proc evict_sweep*(self: EdContext) =
     return
   self.prune_dead_proxies
   # Idle fast path: nothing an eviction would act on has changed since the last
-  # sweep, and we're within budget — so there's nothing to reconcile, churn, or
+  # sweep, and we're within budget -- so there's nothing to reconcile, churn, or
   # shed. Skip the O(objects) scans entirely (a calm context pays ~nothing per
   # tick). prune_dead_proxies above may have set sweep_dirty (a liveness flip).
   if not self.sweep_dirty and self.used_bytes <= self.mem_limit:
@@ -918,7 +918,7 @@ proc evict_sweep*(self: EdContext) =
   for id in churned:
     debug "evicting (churn)", object_id = id, updates = self.objects[id].updates
     self.evict_body(id)
-  # Pressure pass — only when over budget. LRU: oldest read goes first. A heap
+  # Pressure pass -- only when over budget. LRU: oldest read goes first. A heap
   # (O(n) build, O(k log n) to pop the k we actually evict) avoids sorting the
   # whole candidate set just to drop a few off the cold end.
   if self.used_bytes <= self.mem_limit:
@@ -933,7 +933,7 @@ proc evict_sweep*(self: EdContext) =
     debug "evicting (pressure)",
       object_id = id, used = self.used_bytes, limit = self.mem_limit
     self.evict_body(id)
-  # Per-key cache pass — the bulk of a paging client's memory is in LAZY tables
+  # Per-key cache pass -- the bulk of a paging client's memory is in LAZY tables
   # (voxel chunks), which the whole-object passes skip. If still over budget,
   # shed cache-tier keys (no live downstream interest) least-recently-served
   # first, retracting each upstream so its stream stops too.
@@ -959,7 +959,7 @@ proc evict_sweep*(self: EdContext) =
     debug "evicting key (pressure)", object_id = id
     let obj = self.objects[id]
     if obj != nil and obj.evict_key != nil:
-      let evicted = obj.evict_key(obj, key_bin) # evict_key → forget_key_bytes
+      let evicted = obj.evict_key(obj, key_bin) # evict_key -> forget_key_bytes
       self.drop_nested_bodies(evicted.nested)    # ...clears key_last_read too
     self.pending_key_releases.mgetOrPut(id, @[]).add key_bin # retract upstream
 
@@ -971,14 +971,14 @@ proc fetch*(
   ## `NotFound` if the authority NACKs. Already holding it loaded resolves
   ## immediately; fetching an id already in flight returns the same handle.
   ##
-  ## Always registers interest, so future ops follow — and a *missing* id is
+  ## Always registers interest, so future ops follow -- and a *missing* id is
   ## delivered whenever something creates it (the handle still resolves NotFound
   ## for "not there right now"). To stop following, drop your reference: with no
   ## live proxy the object becomes an eviction candidate and its interest is
   ## retracted upstream when it's reclaimed (see the evictor / `mem_limit`).
   ##
   ## `deep` also fetches everything the id *owns* (the synced-ownership closure,
-  ## recursively) — so an owner id (a unit, which isn't itself a container) pulls
+  ## recursively) -- so an owner id (a unit, which isn't itself a container) pulls
   ## its whole owned state in one request. The already-loaded short-circuit is
   ## skipped for deep fetches: holding the root says nothing about the closure.
   if not deep and object_id in self and not self.objects[object_id].placeholder:
@@ -997,7 +997,7 @@ proc fetch*(
   self.tick_reactor
 
 proc flush_key_requests(self: EdContext) =
-  ## Send the per-key fetches buffered since the last tick — one REQUEST per
+  ## Send the per-key fetches buffered since the last tick -- one REQUEST per
   ## table, carrying the batch of serialized keys in `obj`. The authority replies
   ## with an ADD op per found key (see the REQUEST handler).
   if self.pending_key_requests.len == 0:
@@ -1011,7 +1011,7 @@ proc flush_key_requests(self: EdContext) =
   self.tick_reactor
 
 proc flush_key_releases(self: EdContext) =
-  ## Send the per-key releases buffered since the last tick — one RELEASE per
+  ## Send the per-key releases buffered since the last tick -- one RELEASE per
   ## table, broadcast to every peer. Upstream reads it as an interest retract
   ## (ops for those keys stop flowing); downstream clones read it as an
   ## eviction notice and drop the keys too (see the RELEASE handler).
@@ -1039,7 +1039,7 @@ proc subscribe*(
   ## in `fetch` (and ids fetched later); the reference graph + materialize-on-
   ## access pull the rest. Mirrors the local `subscribe(mode = ..., fetch =
   ## ...)`. Blocking semantics (PARTIAL vs PARTIAL_ASYNC) are a property of the
-  ## context (`self.blocking`), set by the caller — the handshake only carries
+  ## context (`self.blocking`), set by the caller -- the handshake only carries
   ## the partial filter.
   var address = address
   var port = 9632
@@ -1113,7 +1113,7 @@ proc subscribe*(
     # reactor.tick is non-blocking, so an unyielding loop pegs a core for the
     # whole connect-timeout window when the peer is down. Spin hot at first so a
     # healthy handshake (sub-ms on localhost) is timing-identical to before, then
-    # yield once we've gone a while with no traffic — the peer is gone and we're
+    # yield once we've gone a while with no traffic -- the peer is gone and we're
     # just waiting out the timeout.
     elif epoch_time() - last_progress > 0.2:
       sleep 1
@@ -1164,7 +1164,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       fallback
 
   if self.id in source:
-    # Our own id in the source set means a message looped back to us — the
+    # Our own id in the source set means a message looped back to us -- the
     # publish-side source filter should prevent it. Skip rather than risk
     # double-applying it, and warn so a routing regression stays visible.
     warn "dropping message that looped back to its source",
@@ -1175,7 +1175,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   debug "receiving", msg, topics = "networking"
 
   # Ordered-op idempotency: a stamped op at or below our frontier was already
-  # applied or superseded — drop it. lsn == 0 (CREATE / unordered) always
+  # applied or superseded -- drop it. lsn == 0 (CREATE / unordered) always
   # proceeds. Gap/reorder buffering (lsn > frontier + 1) is deferred to the
   # network phase; cross-thread delivery is FIFO from a single sequencer.
   if msg.lsn > 0 and msg.lsn <= self.applied_lsn:
@@ -1184,10 +1184,10 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     return
 
   # Own-op reconciliation: an op we originated, echoed back canonically.
-  #  - Collections (delta): already applied optimistically — skip to avoid
+  #  - Collections (delta): already applied optimistically -- skip to avoid
   #    double-applying (a seq.add would duplicate).
   #  - Registers: skip only if a *later* write of ours supersedes this echo
-  #    (op_id < our latest for this object) — that's what stops a moving entity
+  #    (op_id < our latest for this object) -- that's what stops a moving entity
   #    snapping back to its own stale echoes. Our *latest* own write (op_id ==
   #    latest) is applied, so a contended register still converges to the
   #    canonical value. (The op_id-superseded rule; see consistency.md.)
@@ -1199,7 +1199,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       if msg.lsn > self.applied_lsn:
         self.applied_lsn = msg.lsn
       return
-    # else: our latest own write — fall through and apply it.
+    # else: our latest own write -- fall through and apply it.
 
   if msg.kind == PACKED:
     let ops = msg.obj.from_flatty(seq[PackedMessageOperation])
@@ -1226,7 +1226,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     {.gcsafe.}:
       if msg.type_id notin type_initializers:
         # Unknown type: a version-skewed peer or a type this context wasn't
-        # compiled with. Skip it rather than aborting — the consistency layer no
+        # compiled with. Skip it rather than aborting -- the consistency layer no
         # longer needs every object present to trust the rest. (Relaying unknown
         # types through the authority is a separate, future step.)
         debug "skipping create for unknown type",
@@ -1237,7 +1237,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       # Stored as a raw pointer (see initializers.register_initializer); cast
       # back to the materializer proc type to call it.
       let fn = cast[CreateInitializer](type_initializers[msg.type_id])
-      # Synced ownership: materialize INSIDE the owner's scope, not after — the
+      # Synced ownership: materialize INSIDE the owner's scope, not after -- the
       # initializer (`defaults`) re-broadcasts the CREATE to our own subscribers
       # while it runs (a relay: e.g. worker -> node ctx for an object an MCP
       # client built), so owner_id must be stamped before that re-broadcast or
@@ -1259,7 +1259,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       else:
         materialize_it()
     # Safety net for paths where the initializer fills an existing object (a
-    # placeholder) rather than running `defaults` — stamp + index after the fact.
+    # placeholder) rather than running `defaults` -- stamp + index after the fact.
     # Keyed by owner id, so arrival order vs. the owner doesn't matter.
     if msg.owner_id.len > 0 and msg.object_id in self.objects and
         ?self.objects[msg.object_id]:
@@ -1268,14 +1268,14 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         msg.object_id
       )
     # Interest tiering (Option 2): a body materialized from an upstream CREATE
-    # is one we follow — mark it live-up so the sweep reconciles its tier as it
+    # is one we follow -- mark it live-up so the sweep reconciles its tier as it
     # goes live/cache here. Only on an evicting partial replica with an upstream.
     if self.evicts and self.upstream_ctx_ids.len > 0 and
         msg.object_id in self.objects and self.objects[msg.object_id] != nil:
       if self.objects[msg.object_id].up_tier == 0:
         self.objects[msg.object_id].up_tier = up_live
-    # Resolve fetch handles: the object itself and — for a deep fetch of an
-    # *owner* id — the owner its containers point back to (the owner has no
+    # Resolve fetch handles: the object itself and -- for a deep fetch of an
+    # *owner* id -- the owner its containers point back to (the owner has no
     # container of its own, so its handle resolves via the arriving closure).
     if msg.object_id in self.fetches:
       let pending_fetch = self.fetches[msg.object_id]
@@ -1287,7 +1287,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       self.fetches[msg.owner_id].state = Found
       self.fetches.del(msg.owner_id)
     # Serve chained wants (see forward_request): whoever asked while we didn't
-    # have it. Deep wants serve the closure — its CREATEs precede this one
+    # have it. Deep wants serve the closure -- its CREATEs precede this one
     # (deepest-first publish); owner-only ids resolve via msg.owner_id.
     template serve_obj_wants(id: string) =
       if id in self.pending_obj_wants:
@@ -1349,8 +1349,8 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         self.pending_obj_wants.del msg.object_id
   elif msg.kind == RELEASE and msg.obj.len == 0:
     # Whole-object release (evictor): a peer dropped object_id entirely.
-    #  - From a subscriber: an interest retract — stop streaming it to them.
-    #  - From upstream: an eviction notice — but a received drop is NEVER
+    #  - From a subscriber: an interest retract -- stop streaming it to them.
+    #  - From upstream: an eviction notice -- but a received drop is NEVER
     #    authoritative over a live local hold (Scott's rule). Evict only if we
     #    aren't using it ourselves and nobody below us wants it; otherwise keep
     #    using it and let our own evictor reclaim it when it goes dormant.
@@ -1371,7 +1371,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       self.evict_body(msg.object_id)
   elif msg.kind == INTEREST:
     # Live/cache tier change from a downstream subscriber (Option 2). Demote
-    # moves the object to that subscriber's cache tier — it still streams, but
+    # moves the object to that subscriber's cache tier -- it still streams, but
     # no longer protects the object from our eviction; promote moves it back.
     # Our own up-tier to the authority then reconciles on the next sweep (our
     # aggregate downstream liveness changed).
@@ -1386,10 +1386,10 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         s.interest_cache.excl msg.object_id
   elif msg.kind == RELEASE:
     # Per-key paging notice (see `release`). Role decides the meaning:
-    #  - From a subscriber that pages from us: an interest retract — stop
+    #  - From a subscriber that pages from us: an interest retract -- stop
     #    streaming those keys (and the nested containers that rode in with
     #    them). Our copy is untouched; we may serve others.
-    #  - From *upstream*: an eviction notice — our data source dropped the
+    #  - From *upstream*: an eviction notice -- our data source dropped the
     #    keys, and we're a clone of it, so they're gone for us too. Evict
     #    locally (REMOVED fires, watches un-render) and relay downstream.
     # A full clone of a full source never receives one (full sources don't
@@ -1427,7 +1427,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
       # No-cache hub: shed immediately (the symmetric counterpart of request
       # chaining). When the last interest in a key retracts, drop our copy and
       # chain the release upstream. A caching hub (mem_limit > 0) instead KEEPS
-      # the key — it becomes cache-tier (no live downstream wants it), stays
+      # the key -- it becomes cache-tier (no live downstream wants it), stays
       # current via the stream, and the per-key cache LRU sheds it under our
       # own pressure (so a downstream's release doesn't force us to refetch on
       # its return).
@@ -1471,14 +1471,14 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
   elif msg.kind == REQUEST:
     # A partial subscriber wants data. Two forms:
     #  - whole-object (`obj` empty): add the object to interest and publish_create
-    #    it (existing behavior — future ops then follow).
+    #    it (existing behavior -- future ops then follow).
     #  - per-key (`obj` = a batch of serialized table keys): reply with just those
     #    entries (an ADD op each), without adding the whole table to interest.
-    # The requester is whoever the message came from — match by ctx id in `source`.
+    # The requester is whoever the message came from -- match by ctx id in `source`.
     #
     # Request chaining: a hub that can't serve a request forwards it to its
     # upstream(s) (becoming the requester there) and remembers who asked; the
-    # answer — data or NOT_FOUND — relays back down hop by hop. Only misses
+    # answer -- data or NOT_FOUND -- relays back down hop by hop. Only misses
     # forward, and only the first want for an id/key does; the authority never
     # forwards (its miss is the real NOT_FOUND).
     #
@@ -1499,7 +1499,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         continue
       if msg.obj.len > 0:
         # Per-key: serve what we have, chain or NACK the rest. Every requested
-        # key joins the subscriber's key interest — found or missing — so its
+        # key joins the subscriber's key interest -- found or missing -- so its
         # future ops stream (a missing chunk pops in when someone builds
         # there). RELEASE retracts.
         for key_bin in msg.obj.from_flatty(seq[string]):
@@ -1510,7 +1510,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         if msg.object_id in self:
           let obj = self.objects[msg.object_id]
           # Handle-first: the requester (or a hub between us) may not hold the
-          # container yet — a chained request can outrun the closure push that
+          # container yet -- a chained request can outrun the closure push that
           # carries it. An ADD for an unknown object is dropped on arrival and
           # the want dangles (only the first want per key forwards), so the
           # entry would never load. The empty-body CREATE is idempotent and
@@ -1521,9 +1521,9 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
             let reply = obj.publish_key(obj, key_bin)
             if reply.found:
               if self.has_budget: # recency only feeds the cache LRU
-                obj.key_last_read[key_bin] = get_mono_time() # served → in-view
+                obj.key_last_read[key_bin] = get_mono_time() # served -> in-view
               # Per-key deep: nested containers (a chunk's delta seq) go
-              # first so the receiver's parse links them — and they're
+              # first so the receiver's parse links them -- and they're
               # followed, so their future ops (delta appends) stream.
               for nested_id in reply.nested:
                 if nested_id in self and not self.objects[nested_id].placeholder:
@@ -1562,7 +1562,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
               fwd.obj = to_forward.to_flatty
               self.forward_request(s, fwd)
       elif msg.deep:
-        # Deep fetch: the id plus its ownership closure (see publish_closure —
+        # Deep fetch: the id plus its ownership closure (see publish_closure --
         # the requested id may be an *owner*, a unit id with no container of its
         # own, and the walk recurses through owned members into their subtrees).
         let found = self.publish_closure(s, msg.object_id)
@@ -1584,7 +1584,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
           s.interest.incl msg.object_id
           self.objects[msg.object_id].publish_create(s)
         else:
-          # Missing — or held only as an unloaded placeholder, which would
+          # Missing -- or held only as an unloaded placeholder, which would
           # serve empty state; chain instead so the real data comes back. Keep
           # the interest so a later CREATE under this id is delivered.
           s.interest.incl msg.object_id
@@ -1607,10 +1607,10 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     if msg.object_id notin self:
       # An op for an object we don't hold is dropped. Usually benign
       # (partial replica, version skew), but a drop on a paging path means a
-      # requested entry silently never loads — surface the first one per
+      # requested entry silently never loads -- surface the first one per
       # object so a stalled chain is visible in the logs. DESTROY misses are
       # fully expected (destroys broadcast past the interest filter so peers
-      # holding self-minted placeholders converge) — drop them silently.
+      # holding self-minted placeholders converge) -- drop them silently.
       if msg.kind != DESTROY and msg.object_id notin self.warned_missing:
         self.warned_missing.incl msg.object_id
         notice "dropping op for missing object",
@@ -1626,7 +1626,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
         # Table entry: account per-key so per-key evict can subtract exactly.
         if msg.kind == ASSIGN:
           self.set_key_bytes(obj, msg.key_bin, msg.obj.len)
-          obj.key_last_read[msg.key_bin] = get_mono_time() # updated → recent
+          obj.key_last_read[msg.key_bin] = get_mono_time() # updated -> recent
         elif msg.kind == UNASSIGN:
           self.forget_key_bytes(obj, msg.key_bin)
       elif msg.delta and msg.kind == ASSIGN:
@@ -1665,8 +1665,8 @@ proc bind_lifetime*[T, O](self: Ed[T, O], lifetime: Lifetime, zid: EID) =
   ## Bind an already-registered callback (`zid`) to `lifetime`, so it untracks
   ## when the lifetime finishes. Lets sugar that mints its own zid (`changes`,
   ## enu's `watch`) route teardown through an owner's Lifetime without exposing
-  ## the privileged untrack path. Guarded so a manual untrack first — or the
-  ## owner dying first — is safe and idempotent.
+  ## the privileged untrack path. Guarded so a manual untrack first -- or the
+  ## owner dying first -- is safe and idempotent.
   privileged
   lifetime.add proc() {.gcsafe.} =
     if not self.destroyed and zid in self.typed_body.changed_callbacks:
@@ -1697,7 +1697,7 @@ proc track*[T, O](
   # Inside an `own` scope, route this callback's untrack through the owner's
   # lifetime too, so it's torn down when the owner is destroyed (the typical
   # case: a subscription on something the owner doesn't itself own). No scope
-  # open → no-op. Idempotent if also bound explicitly.
+  # open -> no-op. Idempotent if also bound explicitly.
   {.gcsafe.}:
     if not current_lifetime.is_nil:
       self.bind_lifetime(current_lifetime, zid)
@@ -1718,7 +1718,7 @@ proc track*[T, O](
       proc(changes: seq[Change[O]], zid: EID, it: Ed[T, O]) {.gcsafe.},
 ): EID {.discardable.} =
   ## The non-capturing form: the live proxy arrives as `it` each fire, so the
-  ## callback needs no reference to the watched object at all — a proxy
+  ## callback needs no reference to the watched object at all -- a proxy
   ## tracked this way still dies promptly when the app drops it. The sugar
   ## (`changes`/`watch`) builds on this.
   privileged
@@ -1743,7 +1743,7 @@ proc track*[T, O](
     callback: proc(changes: seq[Change[O]]) {.gcsafe.},
 ): EID {.discardable.} =
   ## Like `track`, but the callback's removal is owned by `lifetime`: when the
-  ## owner calls `lifetime.finish` the callback untracks automatically — no
+  ## owner calls `lifetime.finish` the callback untracks automatically -- no
   ## manual `zid` bookkeeping.
   result = self.track(callback)
   self.bind_lifetime(lifetime, result)
@@ -1756,7 +1756,7 @@ proc parse_remote(
 ): tuple[ok: bool, msg: Message] {.gcsafe.} =
   ## Decode one raw remote packet into a Message (source short-ids + mappings
   ## attached, body uncompressed). ok = false for keepalive pings and unparseable
-  ## bytes — a version-skewed peer or stray packet on the same port is dropped,
+  ## bytes -- a version-skewed peer or stray packet on the same port is dropped,
   ## not fatal. Shared by `tick` and the silent materialize pump so the wire
   ## decode lives in exactly one place.
   if raw_msg.data == "PING":
@@ -1764,7 +1764,7 @@ proc parse_remote(
   if not raw_msg.data.starts_with(wire_header):
     # A peer speaking a different wire version (or a stray packet). Reject it
     # here: flatty is positional, so foreign bytes can decode cleanly into
-    # wrong-typed fields and corrupt or crash processing. Warn once per peer —
+    # wrong-typed fields and corrupt or crash processing. Warn once per peer --
     # an old client reconnect-looping would otherwise flood the log.
     let peer = $raw_msg.conn.address
     if peer notin self.warned_missing:
@@ -1823,7 +1823,7 @@ proc tick*(
   var msg: Message
   # `unsubscribed` is NOT cleared here: it accumulates until the consumer
   # drains it (see drain_unsubscribed). Clearing it per-tick made the events
-  # tick-scoped transients — a consumer that polls between ticks loses any
+  # tick-scoped transients -- a consumer that polls between ticks loses any
   # event when an extra tick sneaks in between produce and consume (the enu
   # agent-bot reap missed disconnects that landed during a reload this way).
   var count = 0
@@ -1845,7 +1845,7 @@ proc tick*(
   self.flush_key_releases # ...and its batched per-key releases (paging out)
   self.evict_sweep        # reclaim dormant/over-budget bodies (partial replicas)
 
-  # Replay whatever a silent (blocking) materialize deferred — at this tick
+  # Replay whatever a silent (blocking) materialize deferred -- at this tick
   # boundary, before new traffic: first the messages it buffered (apply + fire
   # their callbacks), then the Fill callbacks for the object it materialized.
   if self.pending_msgs.len > 0:
@@ -1866,7 +1866,7 @@ proc tick*(
       # batch overwrites is frontier-advanced but its effect is skipped, so a
       # losing optimistic writer converges to the latest value without applying
       # (or showing) the intermediate one. Deltas (collections) are never
-      # coalesced — every add matters.
+      # coalesced -- every add matters.
       var batch: seq[Message]
       while get_mono_time() < timeout and self.chan.try_recv(msg):
         batch.add msg
@@ -1903,7 +1903,7 @@ proc tick*(
       for raw_msg in messages:
         inc count
         let parsed = self.parse_remote(raw_msg)
-        if not parsed.ok: # keepalive ping or unparseable — already handled
+        if not parsed.ok: # keepalive ping or unparseable -- already handled
           continue
         var msg = parsed.msg
         when defined(ed_debug_messages):
@@ -1933,13 +1933,13 @@ proc tick*(
 
           # Drop any subscription that this SUBSCRIBE supersedes. Two
           # conditions both warrant a sweep:
-          #   1. Same ctx_id — the client reused its stable id (same
+          #   1. Same ctx_id -- the client reused its stable id (same
           #      process reconnect, or a deterministically-assigned id).
           #      Without this the old subscription persists until netty's
           #      ~10s keepalive timeout, during which the publisher can
           #      route messages back to the reconnected peer via the
           #      stale route.
-          #   2. Same remote endpoint — a previous client at that
+          #   2. Same remote endpoint -- a previous client at that
           #      address/port has been replaced by a new process that
           #      happened to get the same UDP source port. Different
           #      ctx_ids, but routing to the old sub's endpoint would now
@@ -2013,7 +2013,7 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   ## Wired onto a context at subscribe time and called by the read accessors when
   ## they touch a placeholder (see operations.touch_placeholder). Kicks a fetch;
   ## when in a `blocking` scope, pumps I/O and **silently** materializes just this
-  ## object — every other received message and even this object's own Fill
+  ## object -- every other received message and even this object's own Fill
   ## callback are deferred to the next explicit `tick`, so nothing
   ## application-visible happens mid-read (clean reentrancy). Bounded by a deadline
   ## so a gone authority can't hang the caller; it then falls back to the empty
@@ -2027,8 +2027,8 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
     return
 
   template triage(candidate: Message) =
-    # Apply only the target object's CREATE — or its NOT_FOUND NACK, which
-    # resolves the fetch so we stop waiting — silently (callbacks deferred);
+    # Apply only the target object's CREATE -- or its NOT_FOUND NACK, which
+    # resolves the fetch so we stop waiting -- silently (callbacks deferred);
     # buffer everything else for the next tick. SUBSCRIBE can't be replayed
     # sub-less, but a blocking *client* shouldn't receive one.
     if candidate.object_id == id and candidate.kind in {CREATE, NOT_FOUND}:
@@ -2043,7 +2043,7 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
     var m: Message
     while self.chan.try_recv(m):
       triage(m)
-    # Remote transport — reuse the same wire decode as tick, then resolve the
+    # Remote transport -- reuse the same wire decode as tick, then resolve the
     # source eagerly so a deferred message processes correctly sub-less later.
     if ?self.reactor:
       self.tick_reactor
@@ -2074,7 +2074,7 @@ proc find_bare_return(n: NimNode): NimNode =
 
 macro check_no_return*(body: untyped): untyped =
   ## Passthrough macro: emits a compile error if body contains a bare return.
-  ## Use inside changes bodies — return exits the callback proc, not the
+  ## Use inside changes bodies -- return exits the callback proc, not the
   ## enclosing proc, and skips remaining changes in the seq.
   let ret = find_bare_return(body)
   if ret != nil:
@@ -2089,8 +2089,8 @@ macro warn_self_capture(watched: untyped, body: untyped): untyped =
   ## Bare-identifier self-capture detection for the `changes`/`watch` sugar:
   ## a callback body that references the watched *variable* captures it,
   ## pinning the object until untracked (closure cycles are not collected).
-  ## Deliberately narrow — only a bare identifier, only outside dot-RHS
-  ## positions — so it stays near-zero false positives (enu fires none).
+  ## Deliberately narrow -- only a bare identifier, only outside dot-RHS
+  ## positions -- so it stays near-zero false positives (enu fires none).
   result = new_empty_node()
   if watched.kind in {nnk_ident, nnk_sym}:
     let name = watched.str_val
@@ -2099,13 +2099,13 @@ macro warn_self_capture(watched: untyped, body: untyped): untyped =
         return true
       for i in 0 ..< n.len:
         if n.kind == nnk_dot_expr and i == 1:
-          continue # `x.foo` — foo is a field, not a capture
+          continue # `x.foo` -- foo is a field, not a capture
         if references(n[i]):
           return true
     if references(body):
       warning(
         "callback closes over '" & name &
-          "', pinning it until untracked — use `it` (the injected live " &
+          "', pinning it until untracked -- use `it` (the injected live " &
           "proxy) or bind a Lifetime",
         watched,
       )
@@ -2117,7 +2117,7 @@ template changes*[T, O](self: Ed[T, O], pause_me, body) =
       track self, proc(
           changes: seq[Change[O]], zid {.inject.}: EID, it {.inject.}: Ed[T, O]
       ) {.gcsafe.} =
-        # `it` is the live proxy, delivered as a parameter — referencing it
+        # `it` is the live proxy, delivered as a parameter -- referencing it
         # captures nothing, so sugar watchers never pin their object.
         let pause_zid = if pause_me: zid else: 0
         it.pause(pause_zid):

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -140,7 +140,7 @@ proc get_value_type(self: NimNode): NimNode =
       return self[1]
 
   error "get_value_type doesn't know how to handle type:\n\n" & self.tree_repr &
-    "\n\nThis is probably a ed bug.", self
+    "\n\n_this is probably a ed bug.", self
 
 macro build_accessors(T: type, public: bool): untyped =
   result = new_stmt_list()
@@ -275,7 +275,7 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
     # cascade. Entries are ref_pool keys (tid:id); `destroy_owned` resolves them
     # there and cascades through the EdRef `destroy` method. Runs identically on
     # every context that applies the ADD/REMOVE, so the index needs no extra sync.
-    let container = self.objects.getOrDefault(ed_id)
+    let container = self.objects.get_or_default(ed_id)
     if not container.is_nil and OWNS_MEMBERS in container.flags:
       # An ownerless flagged collection (the root units list) indexes members
       # under its own id instead: nothing cascades into them, but the closure
@@ -286,7 +286,7 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
         else:
           ed_id
       if ADDED in change.changes:
-        self.owned_by.mgetOrPut(owner, initHashSet[string]()).incl(id)
+        self.owned_by.mget_or_put(owner, init_hash_set[string]()).incl(id)
       if REMOVED in change.changes and owner in self.owned_by:
         self.owned_by[owner].excl(id)
 

--- a/src/ed/components/type_registry.nim
+++ b/src/ed/components/type_registry.nim
@@ -52,7 +52,7 @@ proc register_type(typ: type) =
         when src is Ed:
           if ?src:
             # Proxy/body split: a bare `type(src)()` has no body, and `.id`
-            # forwards there — mint a husk that carries one.
+            # forwards there -- mint a husk that carries one.
             dest = type(src).init_husk(src.id)
         elif src is ref:
           dest = nil
@@ -73,7 +73,7 @@ proc register_type(typ: type) =
       for field in self[].fields:
         when field is Ed:
           if ?field and field.id in ctx:
-            # Direct registry read — `ctx[...]` would blocking-materialize in a
+            # Direct registry read -- `ctx[...]` would blocking-materialize in a
             # `blocking` scope, which deserialization must never do (and a func
             # can't have side effects; resolve_proxy's registry upkeep is cast
             # away as the one tolerated effect).
@@ -87,7 +87,7 @@ proc register_type(typ: type) =
       # replacing it. `incoming`'s Ed fields are already resolved/relinked by
       # `parse`; copy them and the synced scalars onto `existing`, but LEAVE
       # main-side refs / `ed_ignore` state untouched (the consumer depends on
-      # them — e.g. a godot `node`). Mirrors `stringify`'s field handling.
+      # them -- e.g. a godot `node`). Mirrors `stringify`'s field handling.
       let src = typ(incoming)
       let dest = typ(existing)
       for s, d in fields(src[], dest[]):
@@ -237,12 +237,12 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
       continue
     # Only registered refs belong in `ref_pool`. It's the serialization identity
     # index (from_flatty dedup / find_ref), and now a *cursor* index, so an
-    # instance in it must carry a `RefHandle` to clean itself out on free — i.e.
+    # instance in it must carry a `RefHandle` to clean itself out on free -- i.e.
     # it must be an `EdRef`. Non-registered refs that happen to live in an Ed
     # container are never looked up and have no cleanup handle, so they must
     # never enter the pool (their cursor would dangle on free). Widen to the
     # common base first: `change.item`'s static type may be an unrelated ref
-    # (a sibling of EdRef), which can't be converted to EdRef directly — but the
+    # (a sibling of EdRef), which can't be converted to EdRef directly -- but the
     # runtime `of` check + downcast through RootRef is always valid.
     let item = RootRef(change.item)
     if not (item of EdRef):
@@ -255,13 +255,13 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
       self.ref_pool[id].obj = change.item
       # Wire the per-instance cleanup handle the first time we see this instance.
       # The pool's `obj` hold is non-owning (cursor); this handle keeps it from
-      # dangling — when ORC reclaims the instance its RefHandle.=destroy dels this
+      # dangling -- when ORC reclaims the instance its RefHandle.=destroy dels this
       # context's `ref_pool` entry. The handle carries the instance's own ctx, the
       # one thing a bare registered ref can't know under multiple contexts/thread.
       let handle_owner = EdRef(item)
       if handle_owner.ref_handle.is_nil:
         handle_owner.ref_handle = RefHandle(ctx_uid: self.uid, ref_id: id)
-      # The instance's own context, for destroy's owner cascade — the one
+      # The instance's own context, for destroy's owner cascade -- the one
       # context it lives in (see EdRef.ctx). Cursor, so no cycle.
       handle_owner.ctx = self
     # REMOVE only unlinks a container from the ref; it never frees. ORC reclaims
@@ -270,7 +270,7 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
     # re-links the same instance across any gap.
 
     # Member ownership: an OWNS_MEMBERS collection's EdRef members belong to the
-    # collection's *owner* — membership drives the `owned_by` index, and removal
+    # collection's *owner* -- membership drives the `owned_by` index, and removal
     # un-registers, so an independently-removed member just drops out of the
     # cascade. Entries are ref_pool keys (tid:id); `destroy_owned` resolves them
     # there and cascades through the EdRef `destroy` method. Runs identically on
@@ -293,7 +293,7 @@ proc ref_count*[O](self: EdContext, changes: seq[Change[O]], ed_id: string) =
 proc find_ref*[T](self: EdContext, value: var T): bool =
   privileged
 
-  # Drop entries for instances ORC already reclaimed before reading `obj` — the
+  # Drop entries for instances ORC already reclaimed before reading `obj` -- the
   # cursor would otherwise dangle (see prune_dead_refs / RefHandle).
   self.prune_dead_refs()
   if ?value:
@@ -307,8 +307,8 @@ proc find_ref*[T](self: EdContext, value: var T): bool =
         result = true
       else:
         # Dedup to the pooled instance, but REVIVE it: converge the freshly-parsed
-        # incarnation (`value`) onto it — re-linking owned fields a reload gave
-        # fresh ids — and clear any destroyed latch. This merges a same-id
+        # incarnation (`value`) onto it -- re-linking owned fields a reload gave
+        # fresh ids -- and clear any destroyed latch. This merges a same-id
         # destroy+recreate into an in-place update: identity is preserved, so a
         # consumer still holding the instance converges to the new state instead
         # of being left on dead fields.
@@ -320,7 +320,7 @@ proc find_ref*[T](self: EdContext, value: var T): bool =
           EdRef(existing).destroyed = false
         # A revived ref must come back fully alive: its lifetime was finished by
         # the destroy, and binding a new watcher to a finished lifetime untracks
-        # it immediately — every watch a consumer re-establishes on the revived
+        # it immediately -- every watch a consumer re-establishes on the revived
         # object would silently die. Fresh lifetime = watchable again.
         if EdRef(existing).lifetime != nil and EdRef(existing).lifetime.finished:
           EdRef(existing).lifetime = new_lifetime()
@@ -332,7 +332,7 @@ when defined(dump_ed_objects):
 
 proc free_refs*(self: EdContext) =
   ## Per-tick ref-pool maintenance: prune entries for instances ORC has
-  ## reclaimed (RefHandle can't touch `ref_pool` itself — see prune_dead_refs).
+  ## reclaimed (RefHandle can't touch `ref_pool` itself -- see prune_dead_refs).
   ## Memory is ORC-owned; there is no manual free.
   privileged
 

--- a/src/ed/deps.nim
+++ b/src/ed/deps.nim
@@ -2,7 +2,7 @@ import std/[tables, monotimes, times, importutils, strutils, sequtils, sets, loc
 import pkg/threading/channels
 import pkg/[flatty, netty, pretty]
 # Calendar types stay out: times' seconds/milliseconds/minutes/hours build
-# TimeInterval and times.now() is a DateTime — none of them mix with the
+# TimeInterval and times.now() is a DateTime -- none of them mix with the
 # Duration/MonoTime arithmetic ed uses. utils/timing exports the monotonic
 # versions.
 export times except seconds, milliseconds, minutes, hours, now

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -10,8 +10,8 @@ type
 
   SyncMode* = enum
     ## How a context replicates its authority. A single enum (rather than separate
-    ## partial/blocking flags) so the nonsensical combination — a full replica that
-    ## blocks waiting to materialize, when it never needs to — can't be expressed.
+    ## partial/blocking flags) so the nonsensical combination -- a full replica that
+    ## blocks waiting to materialize, when it never needs to -- can't be expressed.
     FULL          ## full replica; everything syncs, reads never block.
     PARTIAL       ## partial replica, blocking: touching an unmaterialized
                   ## id pumps I/O until it fills (synchronous semantics).
@@ -19,8 +19,8 @@ type
                   ## placeholder that fills on a later tick (frame-paced).
 
   Lifetime* = ref object
-    ## A set of teardown actions (typically untracking callbacks). An owner — a
-    ## Unit or a scope — holds a Lifetime and `finish`es it on teardown, so
+    ## A set of teardown actions (typically untracking callbacks). An owner -- a
+    ## Unit or a scope -- holds a Lifetime and `finish`es it on teardown, so
     ## everything bound to it cleans up at once with no manual `zid` bookkeeping.
     ## Standalone (not part of EdBase) so an owner holds one directly.
     cleanups: seq[proc() {.gcsafe.}]
@@ -46,7 +46,7 @@ type
   EdRef* = ref object of RootObj
     ## Base for registered (network-syncable) refs. Carries a `RefHandle` so the
     ## registry can clean up `ref_pool` when ORC reclaims the instance, keeping the
-    ## pool's non-owning (cursor) hold from dangling — the subtype's own default
+    ## pool's non-owning (cursor) hold from dangling -- the subtype's own default
     ## destructor stays intact (only the trivial `RefHandle` gets a custom one).
     id*: string
       ## The ref's identity (sync identity rides on it via `ref_id` = tid:id).
@@ -57,13 +57,13 @@ type
       ## Idempotency latch for `destroy`, set at its top. `ed_ignore`: local
       ## teardown state, never synced (a received ref must arrive un-destroyed).
     lifetime*: Lifetime
-      ## This ref's teardown actions — external subscriptions and (via `own`) its
+      ## This ref's teardown actions -- external subscriptions and (via `own`) its
       ## owned containers. `destroy` runs `lifetime.finish`. Never synced.
     ctx* {.cursor.}: EdContext
       ## The context this instance lives in, stamped on first `ref_pool` add. A
       ## registered ref belongs to exactly one context (sync mints a separate
-      ## instance per context), so `destroy` uses it — not `Ed.thread_ctx`, which
-      ## is wrong under multiple contexts per thread — to find the right
+      ## instance per context), so `destroy` uses it -- not `Ed.thread_ctx`, which
+      ## is wrong under multiple contexts per thread -- to find the right
       ## `owned_by`/`ref_pool` for the cascade. Non-owning cursor (the context
       ## outlives its refs); never synced.
 
@@ -74,14 +74,14 @@ type
     SYNC_REMOTE       ## Sync changes to remote contexts (network)
     SYNC_ALL_NO_OVERWRITE  ## Sync without overwriting existing data
     LAZY              ## Pull-only: closure pushes / deep-fetch serving skip
-                      ## this container — it syncs via explicit fetch or per-key
+                      ## this container -- it syncs via explicit fetch or per-key
                       ## requests (big voxel tables). Arrives as a placeholder
                       ## otherwise.
     OWNS_MEMBERS      ## This collection's EdRef members are *owned* by the
                       ## collection's owner: membership registers them in
                       ## `owned_by` (removal un-registers), so the owner's
                       ## `destroy_owned` cascades into them. For true child
-                      ## collections (a unit's `units`) — NOT reference
+                      ## collections (a unit's `units`) -- NOT reference
                       ## collections (a sign's owner, a selection list).
 
   ChangeKind* = enum
@@ -96,7 +96,7 @@ type
   ChangeReason* = enum
     ## Why a change fired, orthogonal to `ChangeKind`. (Unrelated to
     ## `Change.triggered_by`, which is the upstream changes that caused this one.)
-    Update    ## An ordinary live change — a mutation or touch
+    Update    ## An ordinary live change -- a mutation or touch
     Fill      ## A placeholder materialized (partial-replica fetch landed)
 
   MessageKind* = enum
@@ -113,13 +113,13 @@ type
     RELEASE    # per-key paging: a replica dropped table keys (obj = key batch).
                # Receivers decide by role: a registered partial subscriber's
                # RELEASE retracts its key interest; one arriving from *upstream*
-               # is an eviction notice — drop the keys locally and relay
+               # is an eviction notice -- drop the keys locally and relay
                # downstream. Full clones forward without evicting; the
                # authority terminates it.
-    INTEREST   # live/cache tier change (Option 2). Subscriber → upstream:
+    INTEREST   # live/cache tier change (Option 2). Subscriber -> upstream:
                # `demote` (true) downgrades object_id to cache tier (still
                # streamed, but no longer protects it from eviction); `demote`
-               # false promotes it back to live. Lightweight — no data.
+               # false promotes it back to live. Lightweight -- no data.
     UNSUBSCRIBE # a LOCAL peer is going away (unsubscribe or context destroy):
                 # the receiver drops its reverse subscription and fires the
                 # unsubscribed event. REMOTE peers learn this from the dead
@@ -175,8 +175,8 @@ type
     key_bin*: string # Table ops only: the serialized key, stamped by
                      # build_message so fanout can filter per-key (LAZY tables /
                      # key interest) without deserializing `obj`. Sender-side
-                     # only — blanked from the remote body.
-    demote*: bool    # INTEREST only: true = demote (live→cache), false = promote.
+                     # only -- blanked from the remote body.
+    demote*: bool    # INTEREST only: true = demote (live->cache), false = promote.
     when defined(ed_trace):
       trace*: string
       id*: int
@@ -208,7 +208,7 @@ type
     # a registered ref alive. Memory is ORC-owned; the real holders are the
     # containers that `track` it plus the app/Godot node. When the last real
     # reference drops, ORC reclaims the instance and its `RefHandle.=destroy` dels
-    # this entry — so the cursor can never dangle (ref_pool[id] non-nil ⟺ instance
+    # this entry -- so the cursor can never dangle (ref_pool[id] non-nil <=> instance
     # alive). Requires every registered type to inherit `EdRef`.
     obj* {.cursor.}: ref RootObj
 
@@ -218,9 +218,9 @@ type
     parse*:
       proc(ctx: EdContext, clone_from: string): ref RootObj {.no_side_effect.}
     # Revive: converge a freshly-parsed `incoming` incarnation onto an EXISTING
-    # instance (a reincarnated id whose object a consumer still holds) — copy its
+    # instance (a reincarnated id whose object a consumer still holds) -- copy its
     # synced scalars and (already-relinked) Ed fields, leaving main-side refs
-    # (e.g. a godot node) intact. Identity preserved → held references stay valid
+    # (e.g. a godot node) intact. Identity preserved -> held references stay valid
     # across destroy+recreate (eventual convergence).
     revive*:
       proc(existing: ref RootObj, incoming: ref RootObj) {.no_side_effect.}
@@ -234,11 +234,11 @@ type
     ctx_id*: string
     # Partial replicas: when `partial`, this subscriber only receives objects in
     # `interest` (its roots + ids it has fetched). Default (not partial) gets
-    # everything — the existing full-replica behavior.
+    # everything -- the existing full-replica behavior.
     partial*: bool
     # Partial + deep: push the ownership closure of OWNS_MEMBERS collection
     # members (ahead of the collection / the member ADD). A game client wants
-    # this — units arrive render-ready; a narrow utility (enu_mcp) doesn't, and
+    # this -- units arrive render-ready; a narrow utility (enu_mcp) doesn't, and
     # deep-fetches the few things it touches. Explicit per subscription for now;
     # the default may later defer to a per-object preference (an EdFlags bit),
     # making it tri-state.
@@ -246,14 +246,14 @@ type
     interest*: HashSet[string]
     # Live/cache interest tiers (Option 2; docs/partial-replicas.md).
     # `interest_cache` is a subset of `interest`: those objects still stream
-    # (the subscriber's cache stays current), but they're *cache tier* — this
+    # (the subscriber's cache stays current), but they're *cache tier* -- this
     # subscriber holds them cached, not live, so they DON'T protect against
     # eviction. We may evict a cache-tier object under our own memory pressure
     # and invalidate the subscriber. Live interest = `interest - interest_cache`
     # is mandatory: an upstream must hold what's live on a downstream.
     interest_cache*: HashSet[string]
     # Per-key interest (LAZY tables): object_id -> serialized keys this
-    # subscriber has requested. A requested key streams its future ops — even
+    # subscriber has requested. A requested key streams its future ops -- even
     # one that was missing at request time (an empty-space voxel chunk someone
     # later builds in). RELEASE retracts. Orthogonal to `interest`: a table in
     # `interest` streams *all* its keys.
@@ -262,10 +262,10 @@ type
     # materialize (its registered `type_initializers`). The authority skips any
     # object whose `type_id` isn't here, so a peer never receives an object it
     # can't construct (which would crash/drop on deserialize). Empty = unfiltered
-    # (no handshake / same-build peer) — preserves the full-replica default.
+    # (no handshake / same-build peer) -- preserves the full-replica default.
     capabilities*: HashSet[int]
     # Short ID mappings for this connection. Outgoing and incoming are
-    # *separate* namespaces — each peer independently allocates short IDs
+    # *separate* namespaces -- each peer independently allocates short IDs
     # in messages it sends. Sharing the table would let our own outgoing
     # assignments clobber an incoming mapping the peer expects us to use.
     next_short_id*: uint8  # Next outgoing short ID to assign
@@ -286,13 +286,13 @@ type
     ## Where a `fetch` stands. Resolves on a later tick (the request round-trip).
     Pending   ## request sent; no answer yet
     Found     ## the object (or, for a deep owner fetch, its closure) arrived
-    NotFound  ## the authority answered NOT_FOUND — it didn't exist *at fetch
+    NotFound  ## the authority answered NOT_FOUND -- it didn't exist *at fetch
               ## time*. With `follow` (the default) it still arrives later if
               ## something creates it; the handle stays NotFound either way.
 
   Fetch* = ref object
     ## Handle returned by `fetch`. Watch `state`; once `Found`, `obj` links the
-    ## container — except for a deep fetch of an *owner* id (a unit), which has
+    ## container -- except for a deep fetch of an *owner* id (a unit), which has
     ## no container of its own: state resolves via its arriving closure and
     ## `obj` stays nil.
     id*: string
@@ -323,17 +323,17 @@ type
     materialize*: proc(self: EdContext, id: string) {.gcsafe.}
     # Blocking materialize: a read of an unmaterialized placeholder pumps I/O
     # until it fills. Normally driven by SyncMode (EdClient sets it for PARTIAL)
-    # or scoped via the `blocking:` template — not set on its own (a full replica
+    # or scoped via the `blocking:` template -- not set on its own (a full replica
     # never needs to block; that's why SyncMode pairs the two).
     blocking*: bool
     # Partial-replica evictor (docs/partial-replicas.md). `mem_limit` is a cache
-    # budget for unclaimed bodies, in bytes — an honest, monotonic value from
+    # budget for unclaimed bodies, in bytes -- an honest, monotonic value from
     # "no cache" up to "unlimited":
-    #     0  no cache — evict everything the moment it isn't live (a utility
+    #     0  no cache -- evict everything the moment it isn't live (a utility
     #        client that holds nothing it isn't actively using). Negatives are
     #        clamped to this at init.
     #   0<n  cache up to n bytes; over budget, shed least-recently-read (LRU).
-    #   Unbounded (= int.high)  never evict — unlimited cache.
+    #   Unbounded (= int.high)  never evict -- unlimited cache.
     # Only a partial replica evicts (a full clone / authority never does, so the
     # value is moot there). `used_bytes` is the running sum of resident body
     # bytes (finite-budget mode only). See `evicts` / `has_budget`.
@@ -343,12 +343,12 @@ type
       ## Set whenever something an eviction sweep would act on changed since the
       ## last sweep: a message was processed, or a dead proxy/ref was pruned. The
       ## sweep skips its (O(objects)) reconcile/churn/pressure work when this is
-      ## false and we're under budget — so a calm context pays ~nothing per tick.
+      ## false and we're under budget -- so a calm context pays ~nothing per tick.
       ## (A pure read that mints a proxy without any message can delay a promote
       ## by a tick; harmless and self-correcting.)
     last_proxy_prune_epoch*: int # last dead_proxy_epoch this ctx pruned at
     last_ref_prune_epoch*: int   # last dead_ref_epoch this ctx pruned at
-    filling*: bool        # set while a placeholder fill applies → tags Fill changes
+    filling*: bool        # set while a placeholder fill applies -> tags Fill changes
     silent*: bool         # silent (blocking) materialize: defer callbacks to next tick
     pending_msgs*: seq[Message]            # received-but-deferred during a silent pump
     pending_fills*: seq[proc() {.gcsafe.}] # Fill callbacks deferred to the next tick
@@ -357,17 +357,17 @@ type
     # table, flushed on the next tick.
     pending_key_requests*: Table[string, seq[string]]
     # Per-key releases buffered between ticks, mirroring pending_key_requests:
-    # one RELEASE per table per tick. Broadcast to all peers — upstream reads it
+    # one RELEASE per table per tick. Broadcast to all peers -- upstream reads it
     # as an interest retract, downstream as an eviction notice.
     pending_key_releases*: Table[string, seq[string]]
     # Contexts we subscribed *to* (our data sources). An eviction notice
-    # (RELEASE) is honored only when it arrives from upstream — we are a clone
+    # (RELEASE) is honored only when it arrives from upstream -- we are a clone
     # of that context, so a key it dropped is gone for us too. This is how
     # partiality inherits down a clone chain (a full clone of a full source
     # never receives one); the authority has no upstream and terminates.
     upstream_ctx_ids*: HashSet[string]
     # This context subscribed partial somewhere: it holds data on demand, not
-    # by contract. Gates hub shedding — a partial hub that retracts the last
+    # by contract. Gates hub shedding -- a partial hub that retracts the last
     # downstream interest in a key drops its own copy and chains the release
     # upstream; a *full* clone never sheds (it wants everything).
     partial_replica*: bool
@@ -380,14 +380,14 @@ type
     # lingers as a tiny string, holding nothing alive.
     close_index: Table[EID, string]
     # The body registry: canonical, registry-owned state per id. Proxies are
-    # minted on demand over these — see `resolve_proxy`; `ctx[id]` still returns
+    # minted on demand over these -- see `resolve_proxy`; `ctx[id]` still returns
     # the proxy, so the public API is unchanged.
     objects*: OrderedTable[string, ref EdBodyBase]
     objects_need_packing*: bool
     # Ownership index: owner EdRef id -> ids of the containers it owns (whose
     # `owner_id` points back here). Built as containers are created/materialized,
     # pruned as they're destroyed. Lets an owner tear down what it owns
-    # (`destroy_owned`) in *any* context — including one that didn't construct it
+    # (`destroy_owned`) in *any* context -- including one that didn't construct it
     # (e.g. the server cleaning up an MCP-created bot after the client drops).
     owned_by*: Table[string, HashSet[string]]
     # In-flight fetches by id; resolved (Found/NotFound) as answers arrive, then
@@ -395,7 +395,7 @@ type
     fetches*: Table[string, Fetch]
     # Request chaining (hubs): wants we couldn't serve locally, forwarded
     # upstream and remembered here. Served when the data arrives; NACK-relayed
-    # when the upstream answers NOT_FOUND. The authority never forwards — a
+    # when the upstream answers NOT_FOUND. The authority never forwards -- a
     # miss there is a real NOT_FOUND.
     pending_obj_wants*:
       Table[string, seq[tuple[sub: Subscription, deep: bool]]]
@@ -437,7 +437,7 @@ type
       counts*: array[MessageKind, int]
 
   EdBodyBase* = object of RootObj
-    ## Registry-side state of a container — the *body* of the proxy/body split
+    ## Registry-side state of a container -- the *body* of the proxy/body split
     ## (docs/proxy-body.md). Carries the data and everything the wire needs; the
     ## app-facing proxy (`Ed`) forwards here via templates, so call sites read
     ## unchanged. The registry owns the body; the proxy is reached through the
@@ -447,7 +447,7 @@ type
     # container is created inside an `own` scope, and on materialize from the
     # synced CREATE envelope, so it's the same in every context. Indexed in
     # `EdContext.owned_by`; the owner's `destroy_owned` tears these down. Mutable
-    # on purpose — ownership transfer (re-home a live object) will reset it.
+    # on purpose -- ownership transfer (re-home a live object) will reset it.
     owner_id*: string
     destroyed*: bool
     # Partial replicas: a placeholder is a non-broadcasting stand-in for a
@@ -460,16 +460,16 @@ type
     # All cheap to maintain; only the partial-replica sweep reads them.
     last_read*: MonoTime  # stamped on a read-touch (value/[]/items/pairs)
     bytes*: int           # wire-weight, stamped where we serialize (drift-ok)
-    updates*: int         # arriving ops since the last read — the churn signal
+    updates*: int         # arriving ops since the last read -- the churn signal
     # Interest tier we last reported to our upstream for this object (Option 2).
     # Reconciled each sweep against `is_live_here`: when liveness flips we send
-    # a demote (live→cache) or promote (cache→live) so the upstream isn't
+    # a demote (live->cache) or promote (cache->live) so the upstream isn't
     # obligated to hold what we only have cached. 0 = none, 1 = live, 2 = cache.
     up_tier*: int
     # Per-key wire bytes for a table (key_bin -> last ASSIGN obj.len). Lets a
     # per-key evict/release subtract exactly what the entry added to `bytes`,
     # so paging out actually shrinks `used_bytes` (whole-body fill leaves this
-    # empty — only delta-grown tables populate it).
+    # empty -- only delta-grown tables populate it).
     key_bytes*: Table[string, int]
     # Per-key recency (key_bin -> last activity), for the per-key cache LRU on
     # LAZY tables: stamped when a key is served to a downstream (last in-view)
@@ -493,7 +493,7 @@ type
     # Per-key fetch (partial EdTable). Given a serialized key, build the ADD op
     # carrying that key's current value, so a partial subscriber can pull one
     # entry without the whole table. `found = false` if the key isn't present.
-    # `nested` lists Ed containers inside the value (a chunk's delta seq) — the
+    # `nested` lists Ed containers inside the value (a chunk's delta seq) -- the
     # server publishes those *before* the entry so the receiver links them
     # (per-key deep, one round trip). nil for non-table containers.
     publish_key:
@@ -502,7 +502,7 @@ type
       ): tuple[found: bool, msg: Message, nested: seq[string]] {.gcsafe.}
 
     # Per-key eviction (paging). Given a serialized key, drop the entry locally
-    # — fires REMOVED callbacks, no publish — and report whether it was present
+    # -- fires REMOVED callbacks, no publish -- and report whether it was present
     # plus the ids of Ed containers nested in its value (so the caller can shed
     # interest / relay them). The local half of `release` and the receiving half
     # of a RELEASE eviction notice. nil for non-table containers.
@@ -517,13 +517,13 @@ type
     # object<->context reference cycle so a freed object/subtree is reclaimed
     # promptly instead of waiting on ORC's cycle collector. Safe because the
     # context strictly outlives its objects (it holds the only registry refs;
-    # teardown that touches `self.ctx` — untrack/destroy — is explicit and runs
+    # teardown that touches `self.ctx` -- untrack/destroy -- is explicit and runs
     # while the context is alive, and no Ed object has an ORC `=destroy` that
     # dereferences `ctx`). Validated under AddressSanitizer (tests/asan.sh).
     ctx* {.cursor.}: EdContext
     # The live proxy for this body, or nil. Non-owning ({.cursor.}): the app
     # and containers own proxies; when the last reference drops, the proxy's
-    # ProxyHandle records the death and `prune_dead_proxies` clears this —
+    # ProxyHandle records the death and `prune_dead_proxies` clears this --
     # always *before* an identity read, so the cursor is never read dangling
     # (the RefHandle discipline, applied to containers).
     proxy {.cursor.}: ref EdBase
@@ -532,7 +532,7 @@ type
     # Ed[T, O] is known). Mints over this body, sets the backref + handle.
     mint: proc(): ref EdBase {.gcsafe.}
     # Typed context-level untrack (see EdContext.close_index): untracks `zid`
-    # on the live proxy, or no-ops — a dead proxy already took its callbacks
+    # on the live proxy, or no-ops -- a dead proxy already took its callbacks
     # with it. Captures only the body (the mint pattern).
     untrack_zid: proc(zid: EID) {.gcsafe.}
     # Sweep callbacks registered through a now-dead proxy generation; returns
@@ -544,12 +544,12 @@ type
     changes: seq[Change[O]], it: ref EdBase
   ) {.gcsafe.}
     ## Stored callback shape: the live proxy arrives as a *parameter* (`it`),
-    ## never a capture — parameters pin nothing, so a watcher written against
+    ## never a capture -- parameters pin nothing, so a watcher written against
     ## `it` lets its proxy die promptly at refcount zero. `it` is nil only for
     ## CLOSED notifications fired after the proxy is already gone.
 
   EdBody*[T, O] = ref object of EdBodyBase
-    ## Typed body: the canonical data AND the callbacks live here — registry-
+    ## Typed body: the canonical data AND the callbacks live here -- registry-
     ## owned, no reliance on cycle collection (which Nim's ORC empirically
     ## does not perform for closure environments). A closure stored here must
     ## capture nothing that reaches a body or a context, or it leaks for the
@@ -557,7 +557,7 @@ type
     tracked: T
     changed_callbacks: OrderedTable[EID, ChangeCallback[O]]
     # zid -> proxy generation that registered it. When a dead proxy's gen is
-    # pruned, its callbacks sweep with it — deterministic next-tick cleanup.
+    # pruned, its callbacks sweep with it -- deterministic next-tick cleanup.
     callback_gens: Table[EID, int]
     link_eid: EID
     paused_eids: set[EID]
@@ -565,7 +565,7 @@ type
   ProxyHandle* = ref object
     ## Per-proxy registry-cleanup handle (the container twin of `RefHandle`).
     ## When a proxy's last reference drops, ORC destroys its fields and this
-    ## handle's `=destroy` records the death for the context to prune — the
+    ## handle's `=destroy` records the death for the context to prune -- the
     ## destructor dereferences *nothing* (the context, even the body, may be
     ## reclaimed in the same ORC batch). `gen` guards out-of-order prunes: a
     ## body only clears its backref if the dead proxy was its *current* one.
@@ -574,10 +574,10 @@ type
     gen*: int
 
   EdBase* = object of RootObj
-    ## Base type for all `Ed` containers — the *proxy* side of the split: what
+    ## Base type for all `Ed` containers -- the *proxy* side of the split: what
     ## the app holds. Local, handle-scoped state only (change callbacks and
     ## their EID bookkeeping die with the proxy); everything synced forwards
-    ## to `body`. Minted by `ctx[id]`/`resolve_proxy` when none is live —
+    ## to `body`. Minted by `ctx[id]`/`resolve_proxy` when none is live --
     ## reference identity holds because the body's backref always points at
     ## *the* live proxy (prune-before-read keeps it honest).
     body*: ref EdBodyBase
@@ -604,7 +604,7 @@ type
 const DEFAULT_FLAGS* = {SYNC_LOCAL, SYNC_REMOTE}
   ## Default flags for `Ed` containers: sync both locally and remotely.
 
-# Proxy → body forwarding. Templates expand at the call site, so field accesses
+# Proxy -> body forwarding. Templates expand at the call site, so field accesses
 # (reads *and* writes) compile unchanged; private body fields still require
 # `privileged` there. The typed `tracked` forward casts through `EdBody[T]`;
 # everything else lives on the untyped base.
@@ -635,7 +635,7 @@ template ctx*(self: ref EdBase): untyped =
 proc init_husk*[T, O](_: typedesc[Ed[T, O]], id: string): Ed[T, O] =
   ## A bare serialization stand-in: proxy + body carrying only the id. Used by
   ## registered-type `stringify`, which clones a ref and reduces its Ed fields
-  ## to their ids — the receiver re-links them from its own registry. Not
+  ## to their ids -- the receiver re-links them from its own registry. Not
   ## registered anywhere; never escapes serialization.
   result = Ed[T, O]()
   result.body = EdBody[T, O](id: id)
@@ -676,7 +676,7 @@ proc evict_key*(
 var next_ctx_uid*: Atomic[int]
   ## Global source of `EdContext.uid`. Must be process-wide: the dead-handle
   ## pending tables are global (a context can be created on one thread and live
-  ## on another), so a uid colliding across threads would misattribute deaths —
+  ## on another), so a uid colliding across threads would misattribute deaths --
   ## one context draining another's records and dangling its backref cursor.
 
 var dead_handles_lock: Lock
@@ -686,7 +686,7 @@ var dead_proxy_epoch*: Atomic[int]
 var dead_ref_epoch*: Atomic[int]
   ## Bumped (under the lock) whenever a proxy/ref death is recorded. A context
   ## remembers the epoch at its last prune (`last_*_prune_epoch`) and skips the
-  ## lock entirely when the epoch hasn't moved — so a tick with no deaths does no
+  ## lock entirely when the epoch hasn't moved -- so a tick with no deaths does no
   ## locking, even though `prune_dead_*` is called from several hot paths
   ## (tick, resolve_proxy, from_flatty). Process-global, matching the pending
   ## tables (a context can be created on one thread and pruned on another).
@@ -694,7 +694,7 @@ var dead_ref_epoch*: Atomic[int]
 var pending_dead_refs*: Table[int, seq[string]]
   ## ctx uid -> ref_ids whose registered instance ORC has reclaimed. Populated by
   ## `RefHandle.=destroy`, which must NOT touch its `EdContext` (it may already be
-  ## freed — even within the same cycle-collection batch). Each context drains its
+  ## freed -- even within the same cycle-collection batch). Each context drains its
   ## own uid via `prune_dead_refs` before any `ref_pool` identity read and on tick.
   ## Entries for a context that dies without draining just linger (bounded; freed
   ## at thread exit) and can't be misattributed, since the key is the uid.
@@ -718,12 +718,12 @@ var pending_dead_proxies*: Table[int, seq[(string, int)]]
   ## ctx uid -> (object_id, gen) of container proxies ORC has reclaimed.
   ## Populated by `ProxyHandle.=destroy` (which must touch nothing); drained by
   ## `prune_dead_proxies` before any proxy-identity read and on tick. Global +
-  ## lock-guarded (NOT a threadvar): a context can be created on one thread —
-  ## minting proxies there — and then live on another (the threading tests'
+  ## lock-guarded (NOT a threadvar): a context can be created on one thread --
+  ## minting proxies there -- and then live on another (the threading tests'
   ## worker handoff), so deaths must be visible to the pruning thread.
 
 proc `=destroy`(h: var typeof(ProxyHandle()[])) =
-  ## Records a dead proxy for its context to prune. Dereferences nothing — the
+  ## Records a dead proxy for its context to prune. Dereferences nothing -- the
   ## body and even the context may be reclaimed in the same ORC batch. A custom
   ## `=destroy` replaces field destruction, so `object_id` is freed by hand.
   if h.ctx_uid != 0 and h.object_id.len > 0:
@@ -735,12 +735,12 @@ proc `=destroy`(h: var typeof(ProxyHandle()[])) =
   `=destroy`(h.object_id)
 
 proc prune_dead_proxies*(self: EdContext) =
-  ## Clear body→proxy backrefs whose proxies ORC has reclaimed. Must run before
+  ## Clear body->proxy backrefs whose proxies ORC has reclaimed. Must run before
   ## any backref read so a dangling cursor is never returned; `gen` ensures a
   ## late prune can't clear a *newer* proxy minted after the death was recorded.
   {.cast(gcsafe).}:
     # Lock-free fast path: if no proxy has died anywhere since our last prune,
-    # there's nothing for us to drain — skip the global lock entirely. (A death
+    # there's nothing for us to drain -- skip the global lock entirely. (A death
     # in another context can cost us one redundant lock; a tick with no deaths
     # costs none.)
     let epoch = dead_proxy_epoch.load
@@ -754,13 +754,13 @@ proc prune_dead_proxies*(self: EdContext) =
     dead_handles_lock.release()
     self.last_proxy_prune_epoch = epoch
     if dead.len > 0:
-      self.sweep_dirty = true # a liveness flip → the next sweep must reconcile
+      self.sweep_dirty = true # a liveness flip -> the next sweep must reconcile
     for (object_id, gen) in dead:
       if object_id in self.objects and self.objects[object_id] != nil and
           self.objects[object_id].proxy_gen == gen:
         let body = self.objects[object_id]
         body.proxy = nil
-        # The dead proxy's callbacks die with it — registered through it,
+        # The dead proxy's callbacks die with it -- registered through it,
         # cleaned when it goes (the sentinel model). Deterministic: next
         # prune, not cycle-collector cadence.
         if body.sweep_gen != nil:
@@ -770,7 +770,7 @@ proc prune_dead_proxies*(self: EdContext) =
 proc resolve_proxy*(self: EdContext, body: ref EdBodyBase): ref EdBase =
   ## The identity map: the one live proxy for `body`, minting if none. Two
   ## resolutions of the same id are reference-equal while anything holds the
-  ## proxy — honest `ref` identity (docs/proxy-body.md).
+  ## proxy -- honest `ref` identity (docs/proxy-body.md).
   if body == nil:
     return nil
   self.prune_dead_proxies
@@ -783,11 +783,11 @@ proc release_closures*(body: ref EdBodyBase) =
   ## Break the body's self-capturing closures. mint/untrack_zid/sweep_gen capture
   ## the body; `publish_create` captures both the body *and* its context (it
   ## reads `ctx.subscribers` / `ctx.send` / `ctx.tick_reactor`), so leaving it set
-  ## pins the whole context — the object<->context cycle the cursor backref was
+  ## pins the whole context -- the object<->context cycle the cursor backref was
   ## meant to break, reintroduced through the closure environment. ORC does not
   ## collect closure cycles, so an unreleased body leaks itself and its context.
   ## (build_message/change_receiver/publish_key/evict_key take `body` as a
-  ## parameter and reach ctx via `body.ctx` — they capture nothing, so they need
+  ## parameter and reach ctx via `body.ctx` -- they capture nothing, so they need
   ## no release.) Every caller removes the body from `objects` right after, so the
   ## body is leaving the registry and these will not be invoked again.
   body.mint = nil
@@ -796,7 +796,7 @@ proc release_closures*(body: ref EdBodyBase) =
   body.publish_create = nil
 
 const Unbounded* = high(int)
-  ## `mem_limit = Unbounded` means never evict — an unlimited cache. The top of
+  ## `mem_limit = Unbounded` means never evict -- an unlimited cache. The top of
   ## the byte-budget range, so the value stays an honest, monotonic size.
 
 const DEFAULT_MEM_LIMIT* = 16 * 1024 * 1024
@@ -810,13 +810,13 @@ proc evicts*(self: EdContext): bool {.inline.} =
 
 proc has_budget*(self: EdContext): bool {.inline.} =
   ## Tracks per-body bytes against a finite cap. No-cache (0) and `Unbounded`
-  ## skip the accounting — there's nothing to compare a running total against.
+  ## skip the accounting -- there's nothing to compare a running total against.
   self.evicts and self.mem_limit > 0
 
 proc set_body_bytes*(self: EdContext, body: ref EdBodyBase, n: int) =
   ## Record a body's resident wire-size and keep `used_bytes` in step. Called
   ## where we already have the serialized form (publish/fill); drift between
-  ## those points is harmless — the total only gates *when* the limit trips,
+  ## those points is harmless -- the total only gates *when* the limit trips,
   ## and LRU ordering doesn't use bytes at all. Only the finite-budget mode
   ## needs accounting; no-cache and Unbounded skip it.
   if not self.has_budget:
@@ -845,7 +845,7 @@ proc set_key_bytes*(
 proc forget_key_bytes*(self: EdContext, body: ref EdBodyBase, key_bin: string) =
   ## Drop a per-key entry's accounting on evict/release: its recency and its
   ## bytes. Called from `evict_key` (so every eviction site cleans both parallel
-  ## tables — they can't drift) and on UNASSIGN. `del` of a missing key is a
+  ## tables -- they can't drift) and on UNASSIGN. `del` of a missing key is a
   ## no-op, so recency is cleared even if bytes were never accounted.
   if not self.has_budget:
     return
@@ -859,7 +859,7 @@ proc drop_nested_bodies*(self: EdContext, nested: seq[string]) =
   ## Unregister the nested container bodies an evicted entry carried (a paged-
   ## out chunk's delta seq): the registry releases its strong hold, so the
   ## memory frees once any remaining holder drops, and the id resolves fresh
-  ## on re-page-in. Local only — eviction never destroys upstream data.
+  ## on re-page-in. Local only -- eviction never destroys upstream data.
   for id in nested:
     if id in self.objects:
       let body = self.objects[id]
@@ -893,7 +893,7 @@ proc prune_dead_refs*(self: EdContext) =
       self.ref_pool.del(ref_id)
 
 proc to_flatty*(s: var string, x: RefHandle) =
-  ## Per-context-local state (uid + id), never synced — its uid is meaningless in
+  ## Per-context-local state (uid + id), never synced -- its uid is meaningless in
   ## another context. Skip it; `ref_count` re-mints the handle on the receiver's
   ## first ADD.
   discard
@@ -939,19 +939,19 @@ proc finished*(self: Lifetime): bool =
 var current_lifetime* {.threadvar.}: Lifetime
   ## The lifetime an open `own` scope binds *callbacks* to (thread-local; nil = no
   ## scope). `track` consults it: a callback registered inside `self.own:` untracks
-  ## when `self.lifetime.finish` runs. nil outside a scope → no auto-binding.
+  ## when `self.lifetime.finish` runs. nil outside a scope -> no auto-binding.
 
 var current_owner_id* {.threadvar.}: string
   ## The id of the EdRef an open `own` scope attributes new *containers* to. A
   ## container created inside the scope records it (`owner_id` + the `owned_by`
   ## index); the owner's `destroy_owned` then tears those containers down. So
   ## `lifetime` carries callbacks while container ownership is the baked-in
-  ## `owner_id`. "" outside a scope → containers are unowned.
+  ## `owner_id`. "" outside a scope -> containers are unowned.
 
 template own*(owner_id: string, body: untyped) =
-  ## Like `self.own:`, but keyed by an owner *id* — for construction, where you
+  ## Like `self.own:`, but keyed by an owner *id* -- for construction, where you
   ## have the id but the owner object doesn't exist yet. Every Ed container created
-  ## in the block (including by procs it calls — the scope is dynamic) records
+  ## in the block (including by procs it calls -- the scope is dynamic) records
   ## `owner_id`. No lifetime is set; callbacks bind via the `EdRef` form once the
   ## owner exists.
   let prev_owner_id = current_owner_id
@@ -966,7 +966,7 @@ template own*[T: EdRef](self: T, body: untyped) =
   ## (so `self`'s teardown destroys them via `destroy_owned`), and every callback
   ## tracked binds its untrack to `self.lifetime` (lazily created). Generic on the
   ## concrete type so `self.id` resolves (EdRef has no `id` of its own). Scopes
-  ## nest by save/restore — innermost wins, control returns to the enclosing owner
+  ## nest by save/restore -- innermost wins, control returns to the enclosing owner
   ## on exit. It's a *dynamic* scope: things constructed in procs called from the
   ## body attribute here too, so keep blocks tight.
   if self.lifetime.is_nil:

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -838,7 +838,7 @@ proc set_key_bytes*(
   ## per-key evict. An update replaces the previous figure (no double-count).
   if not self.has_budget or key_bin.len == 0:
     return
-  let prev = body.key_bytes.getOrDefault(key_bin, 0)
+  let prev = body.key_bytes.get_or_default(key_bin, 0)
   self.set_body_bytes(body, body.bytes + n - prev)
   body.key_bytes[key_bin] = n
 

--- a/src/ed/utils/timing.nim
+++ b/src/ed/utils/timing.nim
@@ -1,6 +1,6 @@
 ## Monotonic time and durations, exported deliberately. std/times' `now()`
 ## is a calendar DateTime and its `seconds()`/`milliseconds()` return
-## TimeInterval — calendar types whose operators don't mix with Duration.
+## TimeInterval -- calendar types whose operators don't mix with Duration.
 ## Import this (or `ed`) instead of std/times when you mean elapsed time:
 ## `now()` is a monotonic instant, and the unit helpers below all return
 ## std Duration.

--- a/src/ed/utils/typeids.nim
+++ b/src/ed/utils/typeids.nim
@@ -1,8 +1,8 @@
 import std/[hashes]
 
 proc base_type*(obj: RootObj): cstring =
-  when not defined(nimTypeNames):
-    {.error: "you need to compile this with '-d:nimTypeNames'".}
+  when not defined(nim_type_names):
+    {.error: "you need to compile this with '-d:nim_type_names'".}
   {.emit: "result = `obj`->m_type->name;".}
 
 proc base_type*(obj: ref RootObj): cstring =

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -39,7 +39,7 @@ proc pack_objects*(self: EdContext) =
 template blocking*(self: EdContext, body: untyped) =
   ## Within this scope, a read that touches an unmaterialized placeholder blocks
   ## (pumps I/O) until it fills, instead of returning empty and fetching async.
-  ## Just manages the `blocking` flag — you can set `self.blocking` directly too.
+  ## Just manages the `blocking` flag -- you can set `self.blocking` directly too.
   let prev = self.blocking
   self.blocking = true
   try:
@@ -73,7 +73,7 @@ proc init*(
 ): EdContext =
   ## Create a new `EdContext`. Set `listen_address` to enable network sync.
   ## Set `is_authority` to make this context the sequencer (leader) that assigns
-  ## global LSNs — see docs/consistency.md.
+  ## global LSNs -- see docs/consistency.md.
   privileged
   log_scope:
     topics = "ed"
@@ -139,7 +139,7 @@ proc next_op_id*(self: EdContext): int64 =
 proc stamp_lsn*(self: EdContext, msg: var Message) =
   ## If this context is the authority, assign the op its global LSN, once.
   ## Applies to the ordered ops the authority broadcasts (self-originated or
-  ## forwarded). CREATE is intentionally not stamped — concurrent same-id
+  ## forwarded). CREATE is intentionally not stamped -- concurrent same-id
   ## creation is out of scope and the subscribe-time resend distinction needs
   ## its own step (see spike doc). DESTROY *is* stamped: delete-vs-update is a
   ## real conflict that must be ordered.
@@ -151,10 +151,10 @@ proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =
   result = Ed[T, O](self.resolve_proxy(self.objects[src.id]))
 
 proc `[]`*(self: EdContext, id: string): ref EdBase =
-  ## Container lookup by id. Raises `KeyError` when absent — except inside a
+  ## Container lookup by id. Raises `KeyError` when absent -- except inside a
   ## `blocking` scope, where an unknown id is fetched from the authority and
   ## waited for (bounded, silent pump); a NOT_FOUND NACK fails fast. Still
-  ## absent afterwards → `KeyError` as usual. A destroyed-but-unswept id keeps
+  ## absent afterwards -> `KeyError` as usual. A destroyed-but-unswept id keeps
   ## its old behavior (returns nil) and doesn't trigger a fetch.
   if self.blocking and self.materialize != nil and id notin self.objects:
     self.materialize(self, id)
@@ -241,19 +241,19 @@ proc close*(self: EdContext) =
 proc destroy*(self: EdContext) =
   ## Tear the context down and release everything it owns.
   ##
-  ## Bodies linger in the registry by design — they outlive their proxies (the
+  ## Bodies linger in the registry by design -- they outlive their proxies (the
   ## registry is a cache with its own eviction). So a dropped context can't
   ## reclaim them on its own: every body holds self-/context-capturing closures
   ## (`publish_create` et al.), and ORC doesn't collect closure cycles, so the
   ## context stays pinned through its own registry. This is the explicit
-  ## teardown that breaks those cycles — `release_closures` on each body — and
+  ## teardown that breaks those cycles -- `release_closures` on each body -- and
   ## drops the registry plus the per-context buffers. Afterwards the context
   ## holds nothing, so it (and its channel/reactor) is reclaimed when the last
   ## reference drops. Idempotent.
   privileged
   debug "destroying EdContext", id = self.id
   # Notify LOCAL peers so they drop their reverse subscription and stop fanning
-  # ops into our about-to-be-freed inbox — cross-thread channels have no
+  # ops into our about-to-be-freed inbox -- cross-thread channels have no
   # keepalive signal (REMOTE peers learn from the closed socket below). Enqueue
   # directly and non-blocking: if a peer's inbox is full we skip rather than hang
   # teardown (the peer keeps the stale sub, the pre-existing behavior).

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -259,7 +259,7 @@ proc destroy*(self: EdContext) =
   # teardown (the peer keeps the stale sub, the pre-existing behavior).
   for sub in self.subscribers:
     if sub.kind == LOCAL:
-      var iso = isolate(Message(kind: UNSUBSCRIBE, source_set: [self.id].toHashSet))
+      var iso = isolate(Message(kind: UNSUBSCRIBE, source_set: [self.id].to_hash_set))
       discard sub.chan.try_take(iso)
   for id, body in self.objects:
     if ?body:

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -13,8 +13,8 @@ export newIdentNode
 {.pop.}
 
 # Per-type registration statements collected at compile time (one per
-# instantiated `Ed[T,O]`), emitted by `Ed.bootstrap`. Each is a trivial call —
-# `register_initializer(tid, cast[pointer](materialize_received[T,O]))` — that
+# instantiated `Ed[T,O]`), emitted by `Ed.bootstrap`. Each is a trivial call --
+# `register_initializer(tid, cast[pointer](materialize_received[T,O]))` -- that
 # references a NAMED top-level proc, never an inline proc literal. That's what
 # lets `Ed.bootstrap` (hence `connect`) expand inside a `unittest test` block: an
 # inline `quote do` materializer carries gensym'd params the C codegen drops when
@@ -31,17 +31,17 @@ proc ctx(): EdContext =
 proc relay_fill*[T, O](item: Ed[T, O], op_ctx: OperationContext) =
   ## Re-broadcast a just-filled placeholder to our own subscribers: they hold
   ## the same id as a placeholder (minted from the same inline ref), and the
-  ## relayed CREATE fills theirs and clears their flag — `loaded` then means
+  ## relayed CREATE fills theirs and clears their flag -- `loaded` then means
   ## the same thing on every hop. Exported because the generated type
   ## initializer expands at the `Ed.bootstrap` call site, where the private
   ## `publish_create` field isn't reachable.
   privileged
   # The immediate fill runs inside the receive path's owner scope
   # (`msg.owner_id.own:`), but the placeholder was minted ownerless and the
-  # post-materialize stamp hasn't run yet — stamp before relaying, or second
+  # post-materialize stamp hasn't run yet -- stamp before relaying, or second
   # hops receive the fill unowned (same window as the create-relay fix). The
   # deferred (subscribe-time) fill runs after the stamp, so `owner_id` is
-  # already set there and `current_owner_id` is empty — both paths covered.
+  # already set there and `current_owner_id` is empty -- both paths covered.
   if current_owner_id.len > 0 and item.owner_id != current_owner_id:
     item.owner_id = current_owner_id
     item.ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(
@@ -64,7 +64,7 @@ proc materialize_received*[T, O](
     op_ctx: OperationContext,
 ) =
   ## Materialize or restore a received object of this concrete type. It is
-  ## (legitimately) not gcsafe — it reaches from_flatty/`value=`, which aren't —
+  ## (legitimately) not gcsafe -- it reaches from_flatty/`value=`, which aren't --
   ## and that's fine: it only ever runs via `subscribe`, which guards the call.
   ## `create_initializer` references it through `cast[pointer]`, which launders
   ## the effect so the reference can't poison the gcsafe defaults/init chain.
@@ -80,7 +80,7 @@ proc materialize_received*[T, O](
       let item = Ed[T, O](ctx[id])
       let was_placeholder = item.placeholder
       let prev_filling = ctx.filling # save: `value=` may nest a fill
-      ctx.filling = was_placeholder # fill of a placeholder → tag Fill
+      ctx.filling = was_placeholder # fill of a placeholder -> tag Fill
       item.placeholder = false # fill: real state arrived
       `value=`(item, value, op_ctx = op_ctx)
       ctx.filling = prev_filling # restore (not unconditionally false)
@@ -98,7 +98,7 @@ proc materialize_received*[T, O](
         let item = Ed[T, O](ctx[id])
         let was_placeholder = item.placeholder
         let prev_filling = ctx.filling # save: `value=` may nest a fill
-        ctx.filling = was_placeholder # fill of a placeholder → tag Fill
+        ctx.filling = was_placeholder # fill of a placeholder -> tag Fill
         item.placeholder = false # fill: real state arrived
         `value=`(item, value, op_ctx = op_ctx)
         ctx.filling = prev_filling # restore (not unconditionally false)
@@ -116,7 +116,7 @@ proc materialize_received*[T, O](
       Ed[T, O](ctx[id]).placeholder = true
   else:
     # Empty-body CREATE for an object we were holding as a placeholder:
-    # it exists for real now, just with no value yet. LAZY excepted — its
+    # it exists for real now, just with no value yet. LAZY excepted -- its
     # empty-body CREATE is a handle push and says nothing about contents.
     if LAZY notin flags:
       Ed[T, O](ctx[id]).placeholder = false
@@ -124,12 +124,12 @@ proc materialize_received*[T, O](
 proc create_initializer[T, O](self: Ed[T, O]) =
   ## Collect this concrete type's registration at COMPILE TIME (the `static`
   ## block runs when `Ed[T, O]` is instantiated). The runtime body is empty, so
-  ## this proc — and its caller `defaults`/`init` — stay gcsafe. `Ed.bootstrap`
+  ## this proc -- and its caller `defaults`/`init` -- stay gcsafe. `Ed.bootstrap`
   ## emits the collected statements at its call site.
   ##
   ## The collected statement references the named `materialize_received[T, O]`
   ## via `cast[pointer]` (subscribe casts back). Storing a raw pointer keeps the
-  ## emitted code a trivial call — template-safe, where an inline proc literal's
+  ## emitted code a trivial call -- template-safe, where an inline proc literal's
   ## gensym params would break codegen inside `unittest test` blocks.
   const ed_type_id = self.type.tid
   static:
@@ -151,8 +151,8 @@ proc defaults[T, O](
   log_defaults
 
   # The proxy/body split: the body carries the data + sync state; field access
-  # on the proxy forwards to it (types.nim templates). Minted here — before
-  # anything reads a forwarded field — since object construction can no longer
+  # on the proxy forwards to it (types.nim templates). Minted here -- before
+  # anything reads a forwarded field -- since object construction can no longer
   # set what are now body fields.
   let body = EdBody[T, O](flags: flags, placeholder: placeholder)
   self.body = body
@@ -190,14 +190,14 @@ proc defaults[T, O](
     body.proxy = proxy
     proxy
   body.untrack_zid = proc(zid: EID) {.gcsafe.} =
-    # Context-level untrack: only meaningful while a proxy is live — a dead
+    # Context-level untrack: only meaningful while a proxy is live -- a dead
     # proxy's callbacks died with it. Prune first so the backref read is safe.
     if body.ctx != nil:
       body.ctx.prune_dead_proxies
     if zid in body.changed_callbacks:
-      # Mirrors proxy-level `untrack` (defined downstream in subscriptions —
+      # Mirrors proxy-level `untrack` (defined downstream in subscriptions --
       # not importable here): CLOSED notification, then drop the callback.
-      # `it` is the live proxy or nil — callbacks are body-side now.
+      # `it` is the live proxy or nil -- callbacks are body-side now.
       let callback = body.changed_callbacks[zid]
       if zid notin body.paused_eids:
         callback(@[Change.init(O, {CLOSED})], body.proxy)
@@ -218,7 +218,7 @@ proc defaults[T, O](
   # If created inside an `own` scope, record the owner: bake its id into the
   # container and index it, so the owner's `destroy_owned` can tear this down in
   # any context (container teardown is ownership-driven; the lifetime carries
-  # callbacks). No scope open → unowned.
+  # callbacks). No scope open -> unowned.
   {.gcsafe.}:
     if current_owner_id.len > 0:
       self.owner_id = current_owner_id
@@ -235,7 +235,7 @@ proc defaults[T, O](
 
     {.gcsafe.}:
       # `contents = false` sends a handle: an empty-body CREATE (id + flags,
-      # no data). Used to push LAZY containers to partial subscribers — the
+      # no data). Used to push LAZY containers to partial subscribers -- the
       # receiver registers a placeholder and pulls entries per-key.
       let bin = if contents: body.tracked.to_flatty else: ""
     let id = body.id
@@ -288,7 +288,7 @@ proc defaults[T, O](
       TOUCHED in change.changes
     let change = Change[O](change)
     when change.item is Pair:
-      # Sender-side per-key filter tag (LAZY tables / key interest) — blanked
+      # Sender-side per-key filter tag (LAZY tables / key interest) -- blanked
       # from the remote body, so it costs nothing on the wire.
       {.gcsafe.}:
         msg.key_bin = change.item.key.to_flatty
@@ -297,7 +297,7 @@ proc defaults[T, O](
     elif change.item is Pair[auto, Ed]:
       # EdTable whose value is an Ed container (e.g. EdTable[Vector3, EdSeq]):
       # the value syncs by id, the key by value. Ref-typed keys aren't supported
-      # here — `to_flatty` nils refs, so the key wouldn't round-trip.
+      # here -- `to_flatty` nils refs, so the key wouldn't round-trip.
       {.gcsafe.}:
         msg.obj = change.item.key.to_flatty
       msg.change_object_id = change.item.value.id
@@ -339,7 +339,7 @@ proc defaults[T, O](
 
     if msg.kind == DESTROY:
       # Forward the upstream op-source so the re-broadcast (relay) filters the
-      # contexts this DESTROY already visited — otherwise it echoes back to its
+      # contexts this DESTROY already visited -- otherwise it echoes back to its
       # origin and, out of order with the reload stream, can kill a same-id
       # recreate.
       self.destroy(op_ctx = op_ctx)
@@ -348,7 +348,7 @@ proc defaults[T, O](
     when O is Ed:
       let object_id = msg.change_object_id
       if object_id notin self.ctx:
-        # Nested object not materialized yet — stand in with a non-broadcasting
+        # Nested object not materialized yet -- stand in with a non-broadcasting
         # placeholder so the container op applies and cardinality is correct.
         # Reading the placeholder later triggers a fetch (materialize-on-access).
         discard O.init_placeholder(self.ctx, object_id)
@@ -369,7 +369,7 @@ proc defaults[T, O](
         if msg.kind == UNASSIGN:
           debug "can't find ", obj = msg.change_object_id
           return
-        # Value object not materialized yet — placeholder it (see above).
+        # Value object not materialized yet -- placeholder it (see above).
         discard V.init_placeholder(self.ctx, msg.change_object_id)
       let value = V(self.ctx.resolve_proxy(self.ctx.objects[msg.change_object_id]))
       {.gcsafe.}:
@@ -389,7 +389,7 @@ proc defaults[T, O](
                 debug "item found (not restored)",
                   item = item.type.name, ref_id = item.ref_id
             else:
-              # Unknown ref type — can't parse the item, so skip this change
+              # Unknown ref type -- can't parse the item, so skip this change
               # rather than aborting. Forgiving on payload.
               debug "skipping change for unknown ref type", ref_tid = msg.ref_id
               return
@@ -415,7 +415,7 @@ proc defaults[T, O](
     # Per-key fetch: build the ADD op for one entry so a partial subscriber can
     # pull it without the whole table. `nested` carries the ids of Ed
     # containers inside the value (a chunk's delta seq) so the caller can
-    # publish them ahead of the entry — per-key deep. Only meaningful for
+    # publish them ahead of the entry -- per-key deep. Only meaningful for
     # table containers.
     when O is Pair:
       let self = Ed[T, O](body.ctx.resolve_proxy(body))
@@ -447,7 +447,7 @@ proc defaults[T, O](
       body: ref EdBodyBase, key_bin: string
   ): tuple[found: bool, nested: seq[string]] {.gcsafe.} =
     # Per-key eviction: drop the entry locally (REMOVED callbacks fire so
-    # watchers un-render; nothing publishes — the authority keeps the data) and
+    # watchers un-render; nothing publishes -- the authority keeps the data) and
     # report nested Ed containers so the caller can shed them. The local half
     # of `release` and the receiving half of an eviction notice.
     when O is Pair:

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -4,12 +4,12 @@ import ed/components/private/global_state
 import ed/types {.all.}, ed/zens/[operations, contexts, private]
 import ed/utils/misc # ZenError
 
-# `quote do` (in create_initializer) expands to code referencing `newIdentNode`,
+# `quote do` (in create_initializer) expands to code referencing `new_ident_node`,
 # so it must be in scope here. Re-exported so it also resolves at `Ed.bootstrap`
 # expansion sites. Deprecated alias of `ident`; suppress the notice rather than
-# rewrite the macro to genAst for 0.3.
+# rewrite the macro to gen_ast for 0.3.
 {.push warning[Deprecated]: off.}
-export newIdentNode
+export new_ident_node
 {.pop.}
 
 # Per-type registration statements collected at compile time (one per
@@ -44,7 +44,7 @@ proc relay_fill*[T, O](item: Ed[T, O], op_ctx: OperationContext) =
   # already set there and `current_owner_id` is empty -- both paths covered.
   if current_owner_id.len > 0 and item.owner_id != current_owner_id:
     item.owner_id = current_owner_id
-    item.ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(
+    item.ctx.owned_by.mget_or_put(current_owner_id, init_hash_set[string]()).incl(
       item.id
     )
   item.publish_create(broadcast = true, op_ctx = op_ctx)
@@ -222,7 +222,7 @@ proc defaults[T, O](
   {.gcsafe.}:
     if current_owner_id.len > 0:
       self.owner_id = current_owner_id
-      ctx.owned_by.mgetOrPut(current_owner_id, initHashSet[string]()).incl(self.id)
+      ctx.owned_by.mget_or_put(current_owner_id, init_hash_set[string]()).incl(self.id)
 
   self.body.publish_create = proc(
       sub: Subscription,

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -35,7 +35,7 @@ template touch_read(self: untyped) =
   ## Coarse eviction touch: mark the body as recently used and reset its churn
   ## counter. Every read accessor runs this (it precedes `touch_placeholder`),
   ## so the evictor's LRU clock and "updates since read" both advance on real
-  ## use — and never on the hot voxel render path, which doesn't read through
+  ## use -- and never on the hot voxel render path, which doesn't read through
   ## these accessors. Only meaningful on a context with a memory limit.
   if self.ctx != nil and self.ctx.has_budget:
     self.body.last_read = get_mono_time()
@@ -45,7 +45,7 @@ template touch_placeholder(self: untyped) =
   ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
   ## context to materialize it (kick a fetch; block until filled when
   ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
-  ## LAZY containers are exempt: they're pull-only by design — entries arrive
+  ## LAZY containers are exempt: they're pull-only by design -- entries arrive
   ## per-key (`request`), so reading one must never materialize the whole table.
   self.touch_read
   if self.placeholder and LAZY notin self.flags and self.ctx.materialize != nil:
@@ -73,7 +73,7 @@ proc contains*[T, O](self: Ed[T, O], children: set[O] | seq[O]): bool =
 template materialize_for_write(self: untyped) =
   ## A local mutation of an unmaterialized placeholder materializes it first
   ## (under `ctx.blocking`: pumps I/O until filled) so the in-flight fill
-  ## can't clobber the write — a placeholder's tracked state is about to be
+  ## can't clobber the write -- a placeholder's tracked state is about to be
   ## replaced wholesale by its CREATE. Unlike `touch_placeholder` this skips
   ## `touch_read`: a write must not reset the evictor's updates-since-read
   ## churn counter.
@@ -84,7 +84,7 @@ template materialize_for_write(self: untyped) =
 template materialize_for_write(self: untyped, op_ctx: untyped) =
   ## Gated variant for accessors the receive path also calls (via
   ## change_receiver): a received op carries a non-empty source and is
-  ## replicated state, not local intent — and materializing inside message
+  ## replicated state, not local intent -- and materializing inside message
   ## processing would re-enter the pump.
   if op_ctx.source.len == 0:
     self.materialize_for_write
@@ -150,7 +150,7 @@ proc release*[K, V](self: EdTable[K, V], key: K) =
   ## deletes on the authority; `request(key)` re-fetches. Three effects:
   ## evict locally (REMOVED fires, watches un-render), retract our per-key
   ## interest upstream (ops for this key stop flowing), and notify downstream
-  ## clones so they evict too — all via one batched RELEASE on the next tick.
+  ## clones so they evict too -- all via one batched RELEASE on the next tick.
   ## Also retracts a pending interest in a key that never loaded (a requested
   ## empty-space chunk).
   privileged
@@ -400,10 +400,10 @@ template pause*(self: Ed, body: untyped) =
 
 proc destroy*[T, O](self: Ed[T, O], publish = true, op_ctx = OperationContext()) =
   ## Destroy the container and remove it from its context. `op_ctx` carries the
-  ## source of the op that triggered this — for a *received* DESTROY (re-broadcast
+  ## source of the op that triggered this -- for a *received* DESTROY (re-broadcast
   ## by `change_receiver` so it relays past this hop) it's the upstream source, so
   ## the re-broadcast filters the contexts the op already visited and never echoes
-  ## back to its origin. Empty (a local destroy) ⇒ just this context's id.
+  ## back to its origin. Empty (a local destroy) => just this context's id.
   log_defaults
   debug "destroying", unit = self.id, stack = get_stack_trace()
   assert self.valid
@@ -435,14 +435,14 @@ method destroy*(self: EdRef) {.base, gcsafe.}
 proc set_owner*(ctx: EdContext, obj: EdRef, owner_id: string) =
   ## Attribute a standalone EdRef to `owner_id`, so `destroy_owned(owner_id)`
   ## tears it down (cascading through its own `destroy`). Unlike a container's
-  ## baked-in, synced `owner_id`, this ownership isn't sent as data — it's
+  ## baked-in, synced `owner_id`, this ownership isn't sent as data -- it's
   ## re-derived locally on each context, exactly like OWNS_MEMBERS membership
   ## (`type_registry`): call it wherever the ref is created/adopted, on every
   ## context, and the index lands the same everywhere with no extra sync.
   privileged
-  # Index by the ref_pool key ("tid:id" — `ref_id` in type_registry), matching
+  # Index by the ref_pool key ("tid:id" -- `ref_id` in type_registry), matching
   # the OWNS_MEMBERS member index: destroy_owned's member pass resolves owned
-  # ids through ctx.ref_pool, and a bare id never matches a pool key — the ref
+  # ids through ctx.ref_pool, and a bare id never matches a pool key -- the ref
   # would silently escape the cascade (and leak everything *it* owns).
   ctx.owned_by.mgetOrPut(owner_id, initHashSet[string]()).incl(
     $obj.type_id & ":" & obj.id
@@ -451,11 +451,11 @@ proc set_owner*(ctx: EdContext, obj: EdRef, owner_id: string) =
 proc destroy_owned*(ctx: EdContext, owner_id: string) =
   ## Destroy everything owned by `owner_id` (per the `owned_by` index). Two
   ## passes: first owned EdRef *members* (an OWNS_MEMBERS collection's children)
-  ## — cascaded through their `destroy` method while the containers they unlink
-  ## themselves from are still alive — then the owned containers, each firing
+  ## -- cascaded through their `destroy` method while the containers they unlink
+  ## themselves from are still alive -- then the owned containers, each firing
   ## its CLOSED, dropping from `ctx.objects`, and broadcasting DESTROY so
-  ## replicas tear down their mirrors. Works in *any* context — including one
-  ## that didn't construct the object — because ownership is synced, not derived
+  ## replicas tear down their mirrors. Works in *any* context -- including one
+  ## that didn't construct the object -- because ownership is synced, not derived
   ## from the constructing context. The owner's `lifetime.finish` handles its
   ## callbacks separately. Containers are type-erased here (`ref EdBase`), so
   ## they're destroyed via their `change_receiver` (the same path a received
@@ -480,7 +480,7 @@ proc destroy_owned*(ctx: EdContext, owner_id: string) =
 
 method destroy*(self: EdRef) {.base, gcsafe.} =
   ## Generic teardown for a registered ref: finish its callback lifetime, tear
-  ## down everything it owns — containers, and owned members recursively — then
+  ## down everything it owns -- containers, and owned members recursively -- then
   ## latch `destroyed`. Subclasses override with their type-specific cleanup and
   ## call this last (enu: unlink from the parent, clear globals, then here).
   ## Deliberately unguarded: an overriding destroy latches `destroyed` at its
@@ -489,7 +489,7 @@ method destroy*(self: EdRef) {.base, gcsafe.} =
   if not self.lifetime.is_nil:
     self.lifetime.finish()
   # The context this ref lives in (stamped on ref_pool add). Fall back to
-  # thread_ctx only for a ref that never entered a ref_pool — i.e. created and
+  # thread_ctx only for a ref that never entered a ref_pool -- i.e. created and
   # destroyed without ever being added to a collection, where it was minted on
   # the current thread anyway.
   let ctx = if self.ctx != nil: self.ctx else: Ed.thread_ctx

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -92,7 +92,7 @@ template materialize_for_write(self: untyped, op_ctx: untyped) =
 proc clear*[T, O](self: Ed[T, O]) =
   assert self.valid
   self.materialize_for_write
-  mutate(OperationContext(source: [self.ctx.id].toHashSet)):
+  mutate(OperationContext(source: [self.ctx.id].to_hash_set)):
     self.tracked = T.default
 
 proc `value=`*[T, O](self: Ed[T, O], value: T, op_ctx = OperationContext()) =
@@ -139,9 +139,9 @@ proc request*[K, V](self: EdTable[K, V], key: K) =
   privileged
   assert self.valid
   if key notin self.tracked:
-    self.ctx.pending_key_requests.mgetOrPut(self.id, @[]).add key.to_flatty
+    self.ctx.pending_key_requests.mget_or_put(self.id, @[]).add key.to_flatty
 
-proc request*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+proc request*[K, V](self: EdTable[K, V], keys: open_array[K]) =
   for key in keys:
     self.request(key)
 
@@ -161,9 +161,9 @@ proc release*[K, V](self: EdTable[K, V], key: K) =
     # The entry's nested containers (a chunk's delta seq) leave the registry
     # too, so paging out actually frees their memory.
     self.ctx.drop_nested_bodies(evicted.nested)
-  self.ctx.pending_key_releases.mgetOrPut(self.id, @[]).add key_bin
+  self.ctx.pending_key_releases.mget_or_put(self.id, @[]).add key_bin
 
-proc release*[K, V](self: EdTable[K, V], keys: openArray[K]) =
+proc release*[K, V](self: EdTable[K, V], keys: open_array[K]) =
   for key in keys:
     self.release(key)
 
@@ -244,7 +244,7 @@ proc delete*[T, O](self: Ed[T, O], value: O) =
       value,
       value,
       delete,
-      op_ctx = OperationContext(source: [self.ctx.id].toHashSet),
+      op_ctx = OperationContext(source: [self.ctx.id].to_hash_set),
     )
 
 proc delete*[K, V](self: EdTable[K, V], key: K) =
@@ -444,7 +444,7 @@ proc set_owner*(ctx: EdContext, obj: EdRef, owner_id: string) =
   # the OWNS_MEMBERS member index: destroy_owned's member pass resolves owned
   # ids through ctx.ref_pool, and a bare id never matches a pool key -- the ref
   # would silently escape the cascade (and leak everything *it* owns).
-  ctx.owned_by.mgetOrPut(owner_id, initHashSet[string]()).incl(
+  ctx.owned_by.mget_or_put(owner_id, init_hash_set[string]()).incl(
     $obj.type_id & ":" & obj.id
   )
 

--- a/src/ed/zens/private.nim
+++ b/src/ed/zens/private.nim
@@ -14,7 +14,7 @@ proc init*[T](
 
 proc init*(
     _: type OperationContext,
-    source: HashSet[string] = initHashSet[string](),
+    source: HashSet[string] = init_hash_set[string](),
     ctx: EdContext = nil,
     origin = "",
     op_id: int64 = 0,
@@ -33,7 +33,7 @@ template setup_op_ctx*(self: EdContext) =
     if ?op_ctx:
       op_ctx
     else:
-      OperationContext.init(source = [self.id].toHashSet)
+      OperationContext.init(source = [self.id].to_hash_set)
 
 template privileged*() =
   private_access EdContext

--- a/tests/asan.sh
+++ b/tests/asan.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
-# Build + run the Ed test suite under AddressSanitizer — the validation gate for
+# Build + run the Ed test suite under AddressSanitizer -- the validation gate for
 # the lifecycle memory work (`{.cursor.}` back-refs, ref_pool -> ORC + =destroy).
 # Apple Silicon runs ASan natively (no VM needed).
 #
 # Catches: use-after-free, heap-buffer-overflow, double-free, stack-use-after-
-# scope. Does NOT catch leaks (macOS has no LeakSanitizer) — see the leak note
+# scope. Does NOT catch leaks (macOS has no LeakSanitizer) -- see the leak note
 # at the bottom for the Linux path.
 #
 # Flags:
 #   -d:useMalloc       ORC allocates via malloc so ASan tracks Ed's heap.
-#   -d:ed_no_compress  Skip supersnappy — its snappy fast-path over-reads within
+#   -d:ed_no_compress  Skip supersnappy -- its snappy fast-path over-reads within
 #                      an allocation, which trips ASan (benign third-party, not our
 #                      bug). In-process sync uses one build, so the wire format
 #                      stays consistent across both sides.
 #
-# Baseline (lifecycle-80 branch): CLEAN — 0 ASan errors, all tests pass. After a
+# Baseline (lifecycle-80 branch): CLEAN -- 0 ASan errors, all tests pass. After a
 # memory change, any NEW ASan error is a real regression to fix before landing.
 set -euo pipefail
 cd "$(dirname "$0")"

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -231,16 +231,16 @@ proc run*() =
       Flag1
       Flag2
 
-    let innerSeq = EdSeq[EdSet[Flags]].init(
+    let inner_seq = EdSeq[EdSet[Flags]].init(
       @[EdSet[Flags].init({Flag1}, flags = flags), EdSet[Flags].init({Flag2}, flags = flags)],
       flags = flags
     )
-    let innerTable = EdTable[int, EdSeq[EdSet[Flags]]].init(
-      {1: innerSeq}.to_table,
+    let inner_table = EdTable[int, EdSeq[EdSet[Flags]]].init(
+      {1: inner_seq}.to_table,
       flags = flags
     )
     let buffers = EdTable[int, EdTable[int, EdSeq[EdSet[Flags]]]].init(
-      {1: innerTable}.to_table,
+      {1: inner_table}.to_table,
       flags = flags
     )
     var id = buffers.count_changes
@@ -276,15 +276,15 @@ proc run*() =
       # Added and Removed changes
     buffers.untrack(id)
 
-    let newInnerSeq = EdSeq[EdSet[Flags]].init(
+    let new_inner_seq = EdSeq[EdSet[Flags]].init(
       @[EdSet[Flags].init({Flag1}, flags = flags)],
       flags = flags
     )
-    let newInnerTable = EdTable[int, EdSeq[EdSet[Flags]]].init(
-      {1: newInnerSeq}.to_table,
+    let new_inner_table = EdTable[int, EdSeq[EdSet[Flags]]].init(
+      {1: new_inner_seq}.to_table,
       flags = flags
     )
-    buffers[1] = newInnerTable
+    buffers[1] = new_inner_table
     id = buffers[1][1][0].count_changes
     1.changes:
       buffers[1][1][0] += {Flag1, Flag2}

--- a/tests/basic_tests.nim
+++ b/tests/basic_tests.nim
@@ -479,7 +479,7 @@ proc run*() =
     # The pause-all / resume-all branches read changed_callbacks/paused_eids,
     # which the proxy/body split moved onto the body; this exercises them so a
     # regression is a test failure, not a latent compile error on first use.
-    # Relative checks (a set may emit >1 change) — what matters is that pause
+    # Relative checks (a set may emit >1 change) -- what matters is that pause
     # stops the increments and resume restarts them, for both per-eid and all.
     var s = EdValue[string].init
     var calls = 0
@@ -491,7 +491,7 @@ proc run*() =
     s.pause_changes zid # per-eid pause
     let c1 = calls
     s.value = "b"
-    check calls == c1 # paused → silent
+    check calls == c1 # paused -> silent
     s.resume_changes zid
     s.value = "c"
     check calls > c1 # resumed
@@ -718,7 +718,7 @@ proc run*() =
 
   test "refs freed when unreferenced":
     # New lifecycle contract (replaces the old 10s-grace "free refs" test). A
-    # container REMOVE only unlinks — it never schedules a free. A registered
+    # container REMOVE only unlinks -- it never schedules a free. A registered
     # ref's body persists while anything still holds it, so a remove-then-readd
     # re-links the *same* instance for any gap (move-identity, no timer). The
     # body is freed only when its last real reference drops: ORC reclaims it and
@@ -753,7 +753,7 @@ proc run*() =
       check dest.len == 0
       check id in ctx2.ref_pool
 
-      # Re-add across the gap re-links the very same instance — move-identity with
+      # Re-add across the gap re-links the very same instance -- move-identity with
       # no grace window (strictly better than the 10s timer it replaces).
       src += obj
       ctx2.tick
@@ -762,7 +762,7 @@ proc run*() =
 
       # Drop every reference to the dest-side body: unlink it from the container
       # and release the local handle. ORC reclaims it and its RefHandle records
-      # the id for the context to prune (the destructor never touches ref_pool) —
+      # the id for the context to prune (the destructor never touches ref_pool) --
       # freed exactly when unreferenced, no timer.
       src -= obj
       ctx2.tick

--- a/tests/client_tests.nim
+++ b/tests/client_tests.nim
@@ -110,7 +110,7 @@ proc run*() =
     # reaped and the link reads as down.
     stop_server()
     var dropped = false
-    for _ in 0 ..< 1000: # generous: netty connTimeout is 10s
+    for _ in 0 ..< 1000: # generous: netty conn_timeout is 10s
       client.ctx.tick
       if not client.connected:
         dropped = true

--- a/tests/client_tests.nim
+++ b/tests/client_tests.nim
@@ -7,7 +7,7 @@ import ed/types {.all.}
 # server on the host can't leak packets into the test reactor.
 let test_address = free_addr()
 
-# A listening peer on its own thread, ticking continuously — the role Enu
+# A listening peer on its own thread, ticking continuously -- the role Enu
 # plays for the MCP server (separate process, independent tick loop). An
 # in-process same-thread server would deadlock the client's blocking
 # subscribe, so a thread is the faithful setup.
@@ -72,7 +72,7 @@ proc run*() =
       sleep 5
     check received == "hello"
 
-    # Idle ticking keeps the link up — no spurious reconnect, no re-setup.
+    # Idle ticking keeps the link up -- no spurious reconnect, no re-setup.
     for _ in 0 ..< 10:
       client.tick
       sleep 5
@@ -92,7 +92,7 @@ proc run*() =
   test "EdClient reconnects after the peer goes away and returns":
     # The MCP-server-survives-an-Enu-restart path. A dropped peer must be
     # detected (netty reaps the connection after its ~10s timeout) and the
-    # client must re-subscribe under the same id once the peer is back —
+    # client must re-subscribe under the same id once the peer is back --
     # all from plain idle ticking, no manual intervention.
     setups = 0
     start_server()

--- a/tests/ctx_teardown_tests.nim
+++ b/tests/ctx_teardown_tests.nim
@@ -29,10 +29,10 @@ proc run*() =
     const ITERS = 8
     cycle(N) # warm up one-time allocations (type registries, threadvars)
     cycle(N)
-    let base = getOccupiedMem()
+    let base = get_occupied_mem()
     for _ in 1 .. ITERS:
       cycle(N)
-    let growth = getOccupiedMem() - base
+    let growth = get_occupied_mem() - base
     # Pre-fix this leaked ~2 MB/cycle (~16 MB over 8 cycles). Post-fix it's flat;
     # the slack covers reachable per-cycle caches. A regressed closure cycle would
     # blow far past this.

--- a/tests/ctx_teardown_tests.nim
+++ b/tests/ctx_teardown_tests.nim
@@ -5,7 +5,7 @@ import ed
 # EdBodyBase.publish_create captured the body + its context, an ORC-uncollectable
 # closure cycle that pinned every body and its whole context. release_closures now
 # nils publish_create, and EdContext.destroy releases all bodies. This test fails
-# if that cycle comes back: it would show steady-state growth across create→destroy
+# if that cycle comes back: it would show steady-state growth across create->destroy
 # cycles that GC_fullCollect can't reclaim.
 
 proc cycle(n: int) =
@@ -24,7 +24,7 @@ proc cycle(n: int) =
   GC_fullCollect()
 
 proc run*() =
-  test "EdContext.destroy reclaims bodies — no steady-state growth":
+  test "EdContext.destroy reclaims bodies -- no steady-state growth":
     const N = 200
     const ITERS = 8
     cycle(N) # warm up one-time allocations (type registries, threadvars)
@@ -40,14 +40,14 @@ proc run*() =
     check growth < 512 * 1024
 
   test "destroying a LOCAL peer notifies the survivor (drops its reverse sub)":
-    # enu's main↔worker shape: a long-lived survivor subscribes to a worker that
+    # enu's main<->worker shape: a long-lived survivor subscribes to a worker that
     # is torn down on level reload. Without peer-notify the survivor keeps a
     # stale sub to the dead worker's inbox (fanning ops into it forever) and never
     # learns to reap what the worker owned (drain_unsubscribed).
     var survivor = EdContext.init(id = "survivor")
     var worker = EdContext.init(id = "worker1")
     Ed.thread_ctx = survivor
-    survivor.subscribe(worker) # bidirectional local: survivor ⇄ worker
+    survivor.subscribe(worker) # bidirectional local: survivor <-> worker
     survivor.tick()
     worker.tick()
     check worker.id in survivor.subscribers.map_it(it.ctx_id)

--- a/tests/lifetime_tests.nim
+++ b/tests/lifetime_tests.nim
@@ -39,7 +39,7 @@ proc run*() =
 
       v.value = 2
       v.value = 3
-      check fired == after_finish # silent after finish — callback removed
+      check fired == after_finish # silent after finish -- callback removed
 
     test "binding to an already-finished lifetime cleans up immediately":
       var ctx = EdContext.init(id = "lt_ctx2")
@@ -80,7 +80,7 @@ proc run*() =
       check "own_items" in ctx.owned_by["owner1"]   # and indexed
 
       ctx.destroy_owned("owner1")
-      check "own_items" notin ctx                   # destroyed → out of ctx.objects
+      check "own_items" notin ctx                   # destroyed -> out of ctx.objects
       check "own_val" notin ctx
       check "owner1" notin ctx.owned_by
 
@@ -172,7 +172,7 @@ proc run*() =
       # through a synced field, and attributes it to itself via set_owner.
       # Destroying the unit must cascade: unit -> (set_owner) Shared ->
       # (own scope) its containers. Regression: set_owner indexed the BARE id
-      # while destroy_owned resolves ref_pool keys (tid:id) — the ref silently
+      # while destroy_owned resolves ref_pool keys (tid:id) -- the ref silently
       # escaped the cascade and its containers leaked on every reload.
       var ctx = EdContext.init(id = "so_ctx")
       Ed.thread_ctx = ctx
@@ -231,7 +231,7 @@ proc run*() =
       # replica, zero contention. Destroying an owner cascades a DESTROY to its
       # owned container; if that cascade DESTROY goes out with an empty
       # OperationContext (no source), the replica re-publishes it back to the
-      # authority — where it lands AFTER the authority has recreated the same id,
+      # authority -- where it lands AFTER the authority has recreated the same id,
       # killing the live recreate. A single ordered producer over FIFO can only
       # misorder if an op echoes, and the cascade is the lone sourceless op.
       var auth = EdContext.init(id = "casc_auth", is_authority = true)
@@ -259,7 +259,7 @@ proc run*() =
         rep.tick(blocking = false)
         auth.tick(blocking = false)
 
-      # The live recreate must still be valid on the authority — the stale
+      # The live recreate must still be valid on the authority -- the stale
       # DESTROY for the old incarnation must not have echoed back onto it.
       check "casc_items" in auth
       check o2.items.valid
@@ -313,7 +313,7 @@ proc run*() =
       # a synced seq (models state.units); its owned container "ri_x_items"
       # (models the build's code/units fields) carries a value that identifies
       # the incarnation. Reload = remove+destroy gen 1, recreate the SAME ids,
-      # re-add — all in one tick (no tick between destroy and recreate). The
+      # re-add -- all in one tick (no tick between destroy and recreate). The
       # replica must end up reflecting gen 2, not pinned on the dead gen 1.
       var auth = EdContext.init(id = "ri1_auth", is_authority = true)
       var rep = EdContext.init(id = "ri1_rep")
@@ -410,7 +410,7 @@ proc run*() =
       # while the replica (main) falls behind, so the replica processes a *batch*
       # spanning several reincarnations in one drain. Models that by flushing only
       # the authority between reloads, then draining the replica once at the end.
-      # The replica must converge on the LAST incarnation — valid, not a stale one.
+      # The replica must converge on the LAST incarnation -- valid, not a stale one.
       var auth = EdContext.init(id = "ri3_auth", is_authority = true)
       var rep = EdContext.init(id = "ri3_rep")
       rep.subscribe(auth)
@@ -453,7 +453,7 @@ proc run*() =
       # The enu BuildNode.model bug: the consumer holds a reference to the unit
       # and fails to release it on removal, so the object stays in ref_pool
       # across reincarnations. The replica drains every reload (no batching, no
-      # lag) — the ONLY extra ingredient vs the passing storm test is the held
+      # lag) -- the ONLY extra ingredient vs the passing storm test is the held
       # reference. If ed leaves the held object pointing at destroyed fields,
       # `held.items` goes invalid (the enu "Ed invalid" spam on self.model.code).
       var auth = EdContext.init(id = "ri4_auth", is_authority = true)
@@ -465,7 +465,7 @@ proc run*() =
       proc make(v: int): ReincUnit =
         result = ReincUnit(id: "ri4_x") # stable id (the build), reincarnated
         result.own:
-          # Fresh field id per incarnation — models enu, where a reloaded build's
+          # Fresh field id per incarnation -- models enu, where a reloaded build's
           # owned containers (code/units) get newly-generated ids each time.
           result.items = EdSeq[int].init(ctx = auth, id = "ri4_x_items_" & $v)
         result.items.add v
@@ -481,7 +481,7 @@ proc run*() =
       check held.items.valid
       check held.items.value == @[0]
 
-      # Churn, draining the replica fully each time — the consumer keeps `held`.
+      # Churn, draining the replica fully each time -- the consumer keeps `held`.
       for gen in 1 .. 20:
         units -= cur
         cur.destroy()
@@ -491,7 +491,7 @@ proc run*() =
           auth.tick(blocking = false)
           rep.tick(blocking = false)
 
-      # The held reference must still be usable — not silently left pointing at
+      # The held reference must still be usable -- not silently left pointing at
       # destroyed fields. (Crash-safe: read .value only if valid.)
       let held_usable =
         not held.is_nil and not held.items.is_nil and held.items.valid
@@ -504,7 +504,7 @@ proc run*() =
       # removal (remove_from_scene), the same instance revives on the re-add, and
       # the consumer re-establishes its watches bound to the unit's lifetime
       # (require_lifetime returns the EXISTING one). Binding to a finished
-      # lifetime untracks immediately — every re-established watch silently dies,
+      # lifetime untracks immediately -- every re-established watch silently dies,
       # so synced data arrives and nothing renders. Revive must hand back a
       # usable (unfinished) lifetime.
       var auth = EdContext.init(id = "ri6_auth", is_authority = true)
@@ -559,11 +559,11 @@ proc run*() =
 
     test "REINC fix-1: release-on-removal keeps the held ref valid":
       # Fix (1): the consumer (BuildNode) RELEASES its reference when the unit is
-      # removed and re-acquires on add — modelled as a seq watcher that clears
+      # removed and re-acquires on add -- modelled as a seq watcher that clears
       # `held` on REMOVED and sets it on ADDED. With the reference dropped on
       # removal the object prunes, so the next CREATE mints fresh; `held` is then
       # never left pointing at destroyed fields. (Same full-reload churn as the
-      # failing `REINC held ref` test — only the consumer discipline differs.)
+      # failing `REINC held ref` test -- only the consumer discipline differs.)
       var auth = EdContext.init(id = "ri5_auth", is_authority = true)
       var rep = EdContext.init(id = "ri5_rep")
       rep.subscribe(auth)
@@ -629,12 +629,12 @@ proc run*() =
       check "rd_items" notin ctx # owned containers gone
       let after = fired
       external.value = 2
-      check fired == after # lifetime finished → callback untracked
+      check fired == after # lifetime finished -> callback untracked
 
     test "EdRef.destroy uses the ref's own context, not thread_ctx":
       # A ref stamped with ctxA (it entered ctxA's ref_pool via collection
       # membership) must tear down ctxA's owned containers even when a *different*
-      # context is the active thread_ctx — destroy follows the ref's ctx backref,
+      # context is the active thread_ctx -- destroy follows the ref's ctx backref,
       # not Ed.thread_ctx (which is wrong under multiple contexts per thread).
       var ctxA = EdContext.init(id = "xd_a")
       var ctxB = EdContext.init(id = "xd_b")
@@ -647,7 +647,7 @@ proc run*() =
         parent.kids = EdSeq[OwnerTest].init(
           ctx = ctxA, id = "xd_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
         )
-      parent.kids.add child # → ctxA.ref_pool, stamps child.ctx = ctxA
+      parent.kids.add child # -> ctxA.ref_pool, stamps child.ctx = ctxA
       check child.ctx == ctxA
 
       Ed.thread_ctx = ctxB # the wrong context is now active
@@ -666,7 +666,7 @@ proc run*() =
         parent.kids = EdSeq[OwnerTest].init(
           ctx = ctx, id = "om_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
         )
-      parent.kids.add child # membership → owned by parent
+      parent.kids.add child # membership -> owned by parent
 
       parent.destroy()
       check child.destroyed # member cascaded via the destroy method

--- a/tests/lifetime_tests.nim
+++ b/tests/lifetime_tests.nim
@@ -632,28 +632,28 @@ proc run*() =
       check fired == after # lifetime finished -> callback untracked
 
     test "EdRef.destroy uses the ref's own context, not thread_ctx":
-      # A ref stamped with ctxA (it entered ctxA's ref_pool via collection
-      # membership) must tear down ctxA's owned containers even when a *different*
+      # A ref stamped with ctx_a (it entered ctx_a's ref_pool via collection
+      # membership) must tear down ctx_a's owned containers even when a *different*
       # context is the active thread_ctx -- destroy follows the ref's ctx backref,
       # not Ed.thread_ctx (which is wrong under multiple contexts per thread).
-      var ctxA = EdContext.init(id = "xd_a")
-      var ctxB = EdContext.init(id = "xd_b")
-      Ed.thread_ctx = ctxA
+      var ctx_a = EdContext.init(id = "xd_a")
+      var ctx_b = EdContext.init(id = "xd_b")
+      Ed.thread_ctx = ctx_a
       var child = OwnerTest(id: "xd_child")
       child.own:
-        child.items = EdSeq[int].init(ctx = ctxA, id = "xd_child_items")
+        child.items = EdSeq[int].init(ctx = ctx_a, id = "xd_child_items")
       var parent = OwnerTest(id: "xd_parent")
       parent.own:
         parent.kids = EdSeq[OwnerTest].init(
-          ctx = ctxA, id = "xd_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
+          ctx = ctx_a, id = "xd_kids", flags = DEFAULT_FLAGS + {OWNS_MEMBERS}
         )
-      parent.kids.add child # -> ctxA.ref_pool, stamps child.ctx = ctxA
-      check child.ctx == ctxA
+      parent.kids.add child # -> ctx_a.ref_pool, stamps child.ctx = ctx_a
+      check child.ctx == ctx_a
 
-      Ed.thread_ctx = ctxB # the wrong context is now active
+      Ed.thread_ctx = ctx_b # the wrong context is now active
       child.destroy()
       check child.destroyed
-      check "xd_child_items" notin ctxA # torn down via child.ctx, not thread_ctx
+      check "xd_child_items" notin ctx_a # torn down via child.ctx, not thread_ctx
 
     test "OWNS_MEMBERS: destroying the owner cascades into members":
       var ctx = EdContext.init(id = "om_ctx")

--- a/tests/lsn_tests.nim
+++ b/tests/lsn_tests.nim
@@ -75,7 +75,7 @@ proc run*() =
       EdValue[int](fb["lsn_obj_e"]).value = 20
 
       # Authority orders them (FIFO: fa then fb) and fans the canonical values
-      # back to everyone — including the writers (return-to-source).
+      # back to everyone -- including the writers (return-to-source).
       leader.tick()
       fa.tick()
       fb.tick()
@@ -150,7 +150,7 @@ proc run*() =
       follower.tick()
       check "lsn_seq_f" in follower
 
-      # Applied optimistically, sent to the authority, ordered, returned —
+      # Applied optimistically, sent to the authority, ordered, returned --
       # must NOT be re-applied (no duplicate).
       EdSeq[int](follower["lsn_seq_f"]).add 42
       leader.tick()
@@ -196,7 +196,7 @@ proc run*() =
       check "lsn_obj_i" in fa
       check "lsn_obj_i" in fb
 
-      # fa updates the object; fb deletes it — concurrently.
+      # fa updates the object; fb deletes it -- concurrently.
       EdValue[int](fa["lsn_obj_i"]).value = 99
       EdValue[int](fb["lsn_obj_i"]).destroy()
 

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -3,7 +3,7 @@ import ed
 import ed/zens/contexts
 import test_util
 
-# A listening authority on its own thread, ticking continuously — the role Enu
+# A listening authority on its own thread, ticking continuously -- the role Enu
 # plays for the MCP server (separate process, independent tick loop), and what a
 # blocking remote materialize needs to respond to it.
 var rmat_running: Atomic[bool]
@@ -39,7 +39,7 @@ proc run*() =
       check "parent" in client
 
       # Author a child and add it to the parent. The child's CREATE is filtered
-      # (not in interest), but the parent's ADD op — which references the child —
+      # (not in interest), but the parent's ADD op -- which references the child --
       # is delivered, so the client must stand in with a placeholder.
       var child = EdValue[string].init(ctx = authority, id = "child")
       child.value = "hi"
@@ -99,7 +99,7 @@ proc run*() =
 
       client.fetch("child")
       authority.tick()
-      client.tick() # fill applies here → callback fires, tagged Fill
+      client.tick() # fill applies here -> callback fires, tagged Fill
       check client["child"].loaded
       check fill_reason == Fill
 
@@ -175,7 +175,7 @@ proc run*() =
       check "child" in client
       check not client["child"].loaded # placeholder, contents not pulled yet
 
-      # A blocking read materializes it over the network — the server thread
+      # A blocking read materializes it over the network -- the server thread
       # answers the fetch while we pump.
       var got = ""
       client.blocking:
@@ -208,7 +208,7 @@ proc run*() =
         if added:
           arrived.add (change.item.key, change.item.value)
 
-      # Two requests in one frame → one batched REQUEST on the next tick.
+      # Two requests in one frame -> one batched REQUEST on the next tick.
       table.request(1)
       table.request(3)
       client.tick() # flush_key_requests sends the batch
@@ -217,7 +217,7 @@ proc run*() =
 
       check table.loaded(1)
       check table.loaded(3)
-      check not table.loaded(2) # never requested → not pulled
+      check not table.loaded(2) # never requested -> not pulled
       check table[1] == "one"
       check table[3] == "three"
       check arrived.len == 2 # both fills fired as ADDED changes

--- a/tests/memory_tests.nim
+++ b/tests/memory_tests.nim
@@ -169,7 +169,7 @@ proc run*() =
 
   test "dropped proxy frees promptly; its callbacks sweep on the next prune":
     # The sentinel model (callbacks live on the registry-owned body): a proxy
-    # holds nothing, so it dies at refcount zero — no cycle collector — and
+    # holds nothing, so it dies at refcount zero -- no cycle collector -- and
     # the next prune sweeps the callbacks registered through it. No GC_full_
     # collect anywhere in this test.
     var ctx = EdContext.init(id = "pc_ctx")

--- a/tests/network_tests.nim
+++ b/tests/network_tests.nim
@@ -194,7 +194,7 @@ proc run*() =
   test "resubscribe with same ctx_id drops the stale subscription":
     # Reproduces the Enu MCP reconnect scenario at the protocol level. A
     # client subscribes, then its EdContext is recreated (process didn't
-    # die — same id, fresh context) and subscribes again. The publisher
+    # die -- same id, fresh context) and subscribes again. The publisher
     # must drop the stale subscriber so it doesn't route messages to a
     # connection that now belongs to the new context.
     let host = free_addr()
@@ -223,7 +223,7 @@ proc run*() =
         publisher.tick(blocking = false)
 
     # Publisher should have swept the stale "mainA" subscriber when the
-    # new one's SUBSCRIBE arrived — exactly one REMOTE sub remains.
+    # new one's SUBSCRIBE arrived -- exactly one REMOTE sub remains.
     let remote_subs = publisher.subscribers.filter_it(it.kind == REMOTE)
     check remote_subs.len == 1
     check remote_subs[0].ctx_id == "mainA"
@@ -248,7 +248,7 @@ proc run*() =
     sv.value = "alive"
 
     # A "client" speaking a different wire format: valid netty framing,
-    # old-format-shaped payloads (no wire header) — including one that
+    # old-format-shaped payloads (no wire header) -- including one that
     # resembles the pre-header packet layout.
     var rogue = new_reactor()
     let conn = rogue.connect("127.0.0.1", port)

--- a/tests/object_tests_types.nim
+++ b/tests/object_tests_types.nim
@@ -11,7 +11,7 @@ type
     messages*: EdSeq[string]
 
   Bloop* = ref object of Beep
-    ageValue*: EdValue[int]
+    age_value*: EdValue[int]
 
 Ed.register(Boop)
 Ed.register(Bloop)

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -52,7 +52,7 @@ proc run*() =
 
     test "DESTROY reaches a partial subscriber past the interest filter":
       # The client-reload leak: a partial replica mints placeholder bodies for
-      # ids it discovers via inline refs (a parsed unit's field husks) — ids the
+      # ids it discovers via inline refs (a parsed unit's field husks) -- ids the
       # authority never learned it holds, so they're in no interest set. If the
       # interest filter drops their DESTROYs, those bodies strand forever and
       # every server reload leaks a generation of husks (~600/reload in enu).
@@ -71,7 +71,7 @@ proc run*() =
       check "pd_x" in client
 
       # The client materializes pd_y on its own (an inline-ref placeholder mint
-      # during parse — the authority doesn't know, no interest registered).
+      # during parse -- the authority doesn't know, no interest registered).
       discard EdSeq[int].init_placeholder(client, "pd_y")
       check "pd_y" in client
 
@@ -86,7 +86,7 @@ proc run*() =
 
     test "reload of a LAZY-field OWNS_MEMBERS member (full clone) keeps siblings valid":
       # The enu reload: a full-clone replica, an OWNS_MEMBERS member reused by id
-      # while its owned tables get fresh ids — destroy the old incarnation, add a
+      # while its owned tables get fresh ids -- destroy the old incarnation, add a
       # new one. This is the path where the hoist corrupted the member's `units`
       # sibling, so reproduce it minimally.
       var authority = EdContext.init(id = "lzr_auth", is_authority = true)
@@ -112,7 +112,7 @@ proc run*() =
       check EdSeq[LazyOwner](client["lzr_units"])[0].items[0] == 1
 
       # Reload: remove + destroy the old incarnation, add a fresh one (same EdRef
-      # id, fresh table/seq ids — no container id reuse).
+      # id, fresh table/seq ids -- no container id reuse).
       units -= u1
       u1.destroy()
       var u2 = LazyOwner(id: "lzr_m")
@@ -130,7 +130,7 @@ proc run*() =
       client.tick()
 
       let m = EdSeq[LazyOwner](client["lzr_units"])[0]
-      check m.items.valid # ← the corruption point in enu
+      check m.items.valid # <- the corruption point in enu
       check m.items.len == 1
       check m.items[0] == 2
 
@@ -195,7 +195,7 @@ proc run*() =
       client.tick()
       check "omd_units" in client
       # The member's container arrives only as a placeholder stand-in (the
-      # inline reference mints one) — its value was not pushed.
+      # inline reference mints one) -- its value was not pushed.
       check not client["omd_u1_items"].loaded
 
       # It pulls what it touches, explicitly.
@@ -420,7 +420,7 @@ proc run*() =
       authority.tick()
       client.tick()
       check "lz_items" in client # normal container came with the closure
-      check "lz_big" in client # LAZY came too — but only as a handle
+      check "lz_big" in client # LAZY came too -- but only as a handle
       let big = EdTable[int, string](client["lz_big"])
       check not big.loaded # placeholder: shape unknown, entries page in
       check not big.loaded(1) # the entry did NOT ride along
@@ -450,9 +450,9 @@ proc run*() =
       authority.tick()
       client.tick()
       let ctbl = EdTable[int, string](client["ki_tbl"])
-      check not ctbl.loaded(1) # handle only — entries page in on request
+      check not ctbl.loaded(1) # handle only -- entries page in on request
 
-      # Requesting a present key loads it — and subscribes to it: a later
+      # Requesting a present key loads it -- and subscribes to it: a later
       # write to that key streams without re-requesting.
       ctbl.request(1)
       client.tick()
@@ -465,7 +465,7 @@ proc run*() =
       client.tick()
       check ctbl[1] == "one, live"
 
-      # Requesting a missing key is a normal answer (empty space) — but the
+      # Requesting a missing key is a normal answer (empty space) -- but the
       # interest sticks, so the key pops in when someone builds there.
       ctbl.request(2)
       client.tick()
@@ -541,7 +541,7 @@ proc run*() =
 
     test "evictor: per-key release shrinks used_bytes (paging out frees mem)":
       # The voxel case: a LAZY table grows per-key as chunks page in, and
-      # releasing a chunk must subtract exactly what it added — otherwise the
+      # releasing a chunk must subtract exactly what it added -- otherwise the
       # memory figure only ever climbs (the bug Scott saw: ed mem up on
       # move-in, never down on move-out).
       var authority = EdContext.init(id = "pk_auth", is_authority = true)
@@ -580,7 +580,7 @@ proc run*() =
       check client.used_bytes >= 200 # the still-loaded entry remains accounted
 
     test "interest tiers: a downstream cache doesn't pin its hub (Option 2)":
-      # A ← H ← L. L caches X with a big limit; that must NOT force H to hold X.
+      # A <- H <- L. L caches X with a big limit; that must NOT force H to hold X.
       # When L demotes X (it goes non-live), H may reclaim X under its own
       # pressure and invalidate L.
       var authority = EdContext.init(id = "it_auth", is_authority = true)
@@ -595,7 +595,7 @@ proc run*() =
       leaf.subscribe(hub, mode = PARTIAL_ASYNC, fetch = [])
       leaf.tick()
 
-      # L fetches X live (chains L→H→A); H holds it because L is live on it.
+      # L fetches X live (chains L->H->A); H holds it because L is live on it.
       var f = leaf.fetch("it_x")
       leaf.tick()
       hub.tick()
@@ -612,22 +612,22 @@ proc run*() =
       f.obj = nil
       f = nil
       GC_full_collect()
-      leaf.tick() # reconcile: X non-live here → demote upstream
+      leaf.tick() # reconcile: X non-live here -> demote upstream
       hub.tick() # H records X as cache-tier for L
       check "it_x" in leaf # L still caches it
       check "it_x" in hub
 
       # H is over its own budget (X is 400+ bytes, limit 200) and X is now
-      # cache-tier (unprotected) — H sheds X and invalidates L.
+      # cache-tier (unprotected) -- H sheds X and invalidates L.
       for i in 1 .. 4:
         hub.tick()
         leaf.tick()
-      check "it_x" notin hub # H reclaimed it — not pinned by L's cache
+      check "it_x" notin hub # H reclaimed it -- not pinned by L's cache
       check "it_x" notin leaf # ...and invalidated L's cache
 
     test "mem_limit encoding: default budget, negative clamps, Unbounded holds":
       # Honest byte budget: a small default cache, negatives clamp to no-cache,
-      # and Unbounded means never evict — the mirror image of the mem_limit 0
+      # and Unbounded means never evict -- the mirror image of the mem_limit 0
       # case below (there the dropped object is shed; here it's kept).
       check EdContext.init(id = "ml_def").mem_limit == DEFAULT_MEM_LIMIT
       check EdContext.init(id = "ml_neg", mem_limit = -5).mem_limit == 0
@@ -646,7 +646,7 @@ proc run*() =
       check "ub_x" in client and f.obj != nil
 
       f.obj = nil
-      f = nil # drop the reference — nothing is live now
+      f = nil # drop the reference -- nothing is live now
       GC_full_collect()
       client.tick() # Unbounded: the sweep is a no-op, the cache holds it
       check "ub_x" in client # a finite limit / no-cache would have shed it
@@ -670,7 +670,7 @@ proc run*() =
       check f.obj != nil
 
       f.obj = nil
-      f = nil # drop the reference — nothing is live now
+      f = nil # drop the reference -- nothing is live now
       GC_full_collect()
       client.tick() # no-cache sweep evicts it immediately
       check "nc_x" notin client
@@ -692,7 +692,7 @@ proc run*() =
       client.tick()
       # Fetch all three. On a leaf (no downstream), an object with no live
       # proxy is an eviction candidate regardless of our own upstream interest
-      # — so dropping the handles makes them evictable. Hold the handles until
+      # -- so dropping the handles makes them evictable. Hold the handles until
       # we're set up, then drop them (the app is done with them).
       var f1 = client.fetch("ev_1")
       var f2 = client.fetch("ev_2")
@@ -720,7 +720,7 @@ proc run*() =
       check client.used_bytes <= 250
 
     test "caching hub keeps released keys; per-key LRU sheds under pressure":
-      # A ← H(cache) ← L. L pages a chunk in then out; a caching hub keeps it
+      # A <- H(cache) <- L. L pages a chunk in then out; a caching hub keeps it
       # (so L's return is served from H, no refetch to A) until H's own budget
       # forces it out, least-recently-served first.
       var authority = EdContext.init(id = "ck_auth", is_authority = true)
@@ -768,7 +768,7 @@ proc run*() =
       check htbl.loaded(1) # ...but the caching hub KEPT it (no refetch on return)
 
       # Now drive H over its 600 budget: page in 2 and 3 too (still under after
-      # 1+2+3 ≈ 600+? push past it). Least-recently-served (key 1) sheds first.
+      # 1+2+3 ~= 600+? push past it). Least-recently-served (key 1) sheds first.
       ltbl.request(2)
       ltbl.request(3)
       leaf.tick()
@@ -778,8 +778,8 @@ proc run*() =
       leaf.tick()
       for i in 1 .. 3:
         hub.tick()
-      check htbl.loaded(2) and htbl.loaded(3) # live (L wants them) — protected
-      check not htbl.loaded(1) # cache-tier + stalest → shed under pressure
+      check htbl.loaded(2) and htbl.loaded(3) # live (L wants them) -- protected
+      check not htbl.loaded(1) # cache-tier + stalest -> shed under pressure
 
     test "hub shedding: last retract releases the hub's copy upstream":
       # The enu client topology: authority (server) <- partial hub (worker)
@@ -896,7 +896,7 @@ proc run*() =
       # push carrying the LAZY handle hasn't landed). Without handle-first
       # replies the per-key ADD drops at the hub as an op for a missing
       # object, the want dangles (only the first want per key forwards), and
-      # the entry never loads — the invisible-tower bug.
+      # the entry never loads -- the invisible-tower bug.
       var authority = EdContext.init(id = "hf_auth", is_authority = true)
       var hub = EdContext.init(id = "hf_hub")
       var leaf = EdContext.init(id = "hf_leaf")
@@ -910,7 +910,7 @@ proc run*() =
       hub.tick()
       leaf.subscribe(hub)
       leaf.tick()
-      # The leaf knows the table only by its derived id — neither it nor the
+      # The leaf knows the table only by its derived id -- neither it nor the
       # hub holds the container.
       let ltbl = EdTable[int, string].init_placeholder(leaf, "hf_tbl")
       check "hf_tbl" notin hub
@@ -973,7 +973,7 @@ proc run*() =
       check "d_items" notin client # out of interest
       check "d_val" notin client
 
-      # The owner id isn't itself a container — a deep fetch expands its
+      # The owner id isn't itself a container -- a deep fetch expands its
       # ownership closure on the authority and sends everything it owns.
       client.fetch("d_bot", deep = true)
       authority.tick() # serves the REQUEST: walks owned_by, publishes the closure
@@ -995,7 +995,7 @@ proc run*() =
       client.subscribe(authority, mode = PARTIAL_ASYNC, fetch = ["pc_root"])
       client.tick()
 
-      # Created after the subscribe — the broadcast CREATE must still be filtered.
+      # Created after the subscribe -- the broadcast CREATE must still be filtered.
       var root = EdValue[int].init(ctx = authority, id = "pc_root")
       var other = EdValue[int].init(ctx = authority, id = "pc_other")
       client.tick()

--- a/tests/test_util.nim
+++ b/tests/test_util.nim
@@ -4,10 +4,10 @@ proc free_port*(): int =
   ## Ask the OS for a free UDP port on loopback, then release it so the caller
   ## can bind it. Avoids hard-coded ports (e.g. 9632) colliding with a running
   ## Enu instance or with other tests.
-  let s = newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+  let s = new_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
   try:
-    s.bindAddr(Port(0), "127.0.0.1")
-    result = s.getLocalAddr()[1].int
+    s.bind_addr(Port(0), "127.0.0.1")
+    result = s.get_local_addr()[1].int
   finally:
     s.close()
 


### PR DESCRIPTION
0.3 prep, part 2 of 4 (stacked on part 1). Purely mechanical — isolated into its own PR so the rename/charset churn doesn't pollute the behavioral diffs. Review per-commit:

- **ASCII-only** in code comments/strings.
- **snake_case** identifiers to match project style.

Base: `prep/teardown-destroy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)