### PR TITLE
feat: single sync_mode + net/client hardening

### DIFF
--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -138,8 +138,12 @@ proc tick*(self: EdClient) =
     return
   try:
     self.ctx.tick
-  except CatchableError as e:
-    debug "EdClient tick raised; reconnecting", msg = e.msg
+  except ConnectionError as e:
+    # Only recover from a connection failure; let anything else propagate -- a
+    # logic error shouldn't be silently masked as a reconnect. (A dropped link
+    # normally surfaces as `connected == false` below, not as an exception;
+    # netty handles socket errors internally.)
+    warn "EdClient connection error; reconnecting", msg = e.msg
     self.reconnect
     return
   if self.ctx.connected:

--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -89,9 +89,9 @@ proc reconnect*(self: EdClient): EdClient {.discardable.} =
     self.ctx.close
     self.prev = self.ctx
   self.ctx = EdContext.init(buffer = false, id = self.id)
-  self.ctx.blocking = self.mode == PARTIAL
   Ed.thread_ctx = self.ctx
   try:
+    # subscribe sets ctx.sync_mode from `mode` (PARTIAL => blocking reads)
     self.ctx.subscribe(
       self.address, mode = self.mode, fetch = self.fetch, deep = self.deep
     )

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -1263,7 +1263,16 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
     # Keyed by owner id, so arrival order vs. the owner doesn't matter.
     if msg.owner_id.len > 0 and msg.object_id in self.objects and
         ?self.objects[msg.object_id]:
-      self.objects[msg.object_id].owner_id = msg.owner_id
+      let body = self.objects[msg.object_id]
+      # Ownership transfer isn't supported yet, so an object's owner shouldn't
+      # change once set. (When re-home lands, replace this with a drop from
+      # owned_by[body.owner_id] before re-indexing under the new owner.)
+      invariant(
+        body.owner_id.len == 0 or body.owner_id == msg.owner_id,
+        "owner_id changed for " & msg.object_id & ": '" & body.owner_id &
+          "' -> '" & msg.owner_id & "'",
+      )
+      body.owner_id = msg.owner_id
       self.owned_by.mget_or_put(msg.owner_id, init_hash_set[string]()).incl(
         msg.object_id
       )

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -739,7 +739,7 @@ proc subscribe*(
   if upstream:
     self.upstream_ctx_ids.incl ctx.id
   if partial:
-    self.partial_replica = true
+    self.sync_mode = mode # FULL subscribes (incl. the reverse leg) don't downgrade
   self.pack_objects
   var remote_objects: HashSet[string]
   for id in self.objects.keys:
@@ -878,9 +878,9 @@ proc evict_sweep*(self: EdContext) =
   ## LRU-to-budget; Unbounded never evict. All eviction is gated on
   ## `evict_candidate`.
   ##
-  ## ONLY partial replicas evict (`evicts`). A full clone (partial_replica =
-  ## false) mirrors everything its upstream has -- there's no safe "residue" to
-  ## drop, because anything it holds is synced state something may read back.
+  ## ONLY partial replicas evict (`evicts`). A full clone (sync_mode FULL)
+  ## mirrors everything its upstream has -- there's no safe "residue" to drop,
+  ## because anything it holds is synced state something may read back.
   ## Evicting on a full clone breaks live round-trips, so `mem_limit` is ignored
   ## there.
   if not self.evicts:
@@ -1038,9 +1038,9 @@ proc subscribe*(
   ## "host:port". When `mode` is partial, the authority only sends the objects
   ## in `fetch` (and ids fetched later); the reference graph + materialize-on-
   ## access pull the rest. Mirrors the local `subscribe(mode = ..., fetch =
-  ## ...)`. Blocking semantics (PARTIAL vs PARTIAL_ASYNC) are a property of the
-  ## context (`self.blocking`), set by the caller -- the handshake only carries
-  ## the partial filter.
+  ## ...)`. Blocking semantics (PARTIAL vs PARTIAL_ASYNC) live in the context's
+  ## `sync_mode`, set here from `mode` -- the handshake only carries the partial
+  ## filter (the authority doesn't care whether our reads block).
   var address = address
   var port = 9632
   let partial = mode != FULL
@@ -1048,7 +1048,7 @@ proc subscribe*(
   debug "remote subscribe", address
   self.materialize = materialize_impl # enable materialize-on-access
   if partial:
-    self.partial_replica = true
+    self.sync_mode = mode
   if not ?self.reactor:
     self.reactor = new_reactor()
   self.subscribing = true
@@ -1422,7 +1422,7 @@ proc process_message(self: EdContext, msg: Message, sub: Subscription = nil) =
                 self.pending_key_wants[msg.object_id][key_bin].filter_it(
                   it.ctx_id != s.ctx_id
                 )
-    if retracted and self.partial_replica and not self.is_authority and
+    if retracted and self.sync_mode != FULL and not self.is_authority and
         self.mem_limit == 0:
       # No-cache hub: shed immediately (the symmetric counterpart of request
       # chaining). When the last interest in a key retracts, drop our copy and
@@ -2023,7 +2023,7 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   if id in self and ?self.objects[id] and not self.objects[id].placeholder:
     return
   let pending_fetch = self.fetch(id)
-  if not self.blocking:
+  if self.sync_mode != PARTIAL: # only PARTIAL blocks; PARTIAL_ASYNC fills on a later tick
     return
 
   template triage(candidate: Message) =

--- a/src/ed/components/subscriptions.nim
+++ b/src/ed/components/subscriptions.nim
@@ -1760,27 +1760,35 @@ proc track*[T, O](
 proc untrack_on_destroy*(self: ref EdBase, zid: EID) =
   self.bound_eids.add(zid)
 
+type RemoteParse = enum
+  Parsed      ## decoded into a usable Message
+  Ignored     ## keepalive ping -- skip
+  Unparseable ## bad/incompatible bytes -- drop the connection if it's a real peer
+
 proc parse_remote(
     self: EdContext, raw_msg: netty.Message
-): tuple[ok: bool, msg: Message] {.gcsafe.} =
+): tuple[status: RemoteParse, msg: Message] {.gcsafe.} =
   ## Decode one raw remote packet into a Message (source short-ids + mappings
-  ## attached, body uncompressed). ok = false for keepalive pings and unparseable
-  ## bytes -- a version-skewed peer or stray packet on the same port is dropped,
-  ## not fatal. Shared by `tick` and the silent materialize pump so the wire
-  ## decode lives in exactly one place.
+  ## attached, body uncompressed). `Ignored` = a keepalive ping. `Unparseable` =
+  ## a version-skewed peer, schema mismatch, or corruption; the caller drops the
+  ## connection (if it maps to a subscription) so the peer re-handshakes/resyncs.
+  ## netty doesn't checksum content and we have no gap replay, so silently
+  ## dropping the packet could leave a divergent op gap -- a reconnect is safer.
+  ## Shared by `tick` and the silent materialize pump so the wire decode lives in
+  ## one place.
   if raw_msg.data == "PING":
-    return (false, Message())
+    return (Ignored, Message())
   if not raw_msg.data.starts_with(wire_header):
-    # A peer speaking a different wire version (or a stray packet). Reject it
-    # here: flatty is positional, so foreign bytes can decode cleanly into
-    # wrong-typed fields and corrupt or crash processing. Warn once per peer --
-    # an old client reconnect-looping would otherwise flood the log.
+    # A peer speaking a different wire version (or a stray packet). flatty is
+    # positional, so foreign bytes can decode cleanly into wrong-typed fields and
+    # corrupt or crash processing. Warn once per peer -- a stray/un-subscribed
+    # source would otherwise flood the log (a subscribed one is dropped below).
     let peer = $raw_msg.conn.address
     if peer notin self.warned_missing:
       self.warned_missing.incl peer
       warn "dropping message from incompatible peer (wire version mismatch)",
         peer, bytes = raw_msg.data.len
-    return (false, Message())
+    return (Unparseable, Message())
   try:
     # Wire format: a small per-subscriber header (source short-ids + new
     # mappings) followed by the shared, compressed body (see send_remote).
@@ -1789,11 +1797,20 @@ proc parse_remote(
     var msg = body.ed_uncompress.from_flatty(Message, self)
     msg.source = enc_source
     msg.id_mappings = mappings
-    return (true, msg)
+    return (Parsed, msg)
   except CatchableError, Defect:
     warn "dropping unparseable remote message",
       bytes = raw_msg.data.len, peer = $raw_msg.conn.address
-    return (false, Message())
+    return (Unparseable, Message())
+
+proc drop_remote_conn(self: EdContext, conn: Connection) =
+  ## A real peer sent bytes we can't parse -- tear down its subscription so it
+  ## re-handshakes/resyncs instead of us silently dropping its packets forever.
+  ## No-op for stray/pre-handshake packets that match no subscription.
+  for s in self.subscribers:
+    if s.kind == REMOTE and s.connection == conn:
+      self.unsubscribe(s)
+      break
 
 proc tick*(
     self: EdContext,
@@ -1912,7 +1929,10 @@ proc tick*(
       for raw_msg in messages:
         inc count
         let parsed = self.parse_remote(raw_msg)
-        if not parsed.ok: # keepalive ping or unparseable -- already handled
+        if parsed.status == Ignored: # keepalive ping
+          continue
+        if parsed.status == Unparseable:
+          self.drop_remote_conn(raw_msg.conn) # real peer -> tear down; noise -> ignore
           continue
         var msg = parsed.msg
         when defined(ed_debug_messages):
@@ -2060,7 +2080,10 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
       self.remote_messages = @[]
       for raw_msg in raws:
         let parsed = self.parse_remote(raw_msg)
-        if not parsed.ok:
+        if parsed.status == Ignored:
+          continue
+        if parsed.status == Unparseable:
+          self.drop_remote_conn(raw_msg.conn)
           continue
         var rmsg = parsed.msg
         for s in self.subscribers:

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -318,14 +318,15 @@ type
     latest_op_id*: Table[string, int64]  # object_id -> our highest op id (own-op reconciliation)
     # Materialize-on-access (partial replicas). `materialize` is wired up at
     # subscribe time (it needs fetch/tick) and called by the read accessors when
-    # they touch a placeholder. When `blocking`, that call pumps I/O until the
-    # object fills; otherwise it kicks a fetch and returns the empty placeholder.
+    # they touch a placeholder. In PARTIAL the call pumps I/O until the object
+    # fills; in PARTIAL_ASYNC it kicks a fetch and returns the empty placeholder.
     materialize*: proc(self: EdContext, id: string) {.gcsafe.}
-    # Blocking materialize: a read of an unmaterialized placeholder pumps I/O
-    # until it fills. Normally driven by SyncMode (EdClient sets it for PARTIAL)
-    # or scoped via the `blocking:` template -- not set on its own (a full replica
-    # never needs to block; that's why SyncMode pairs the two).
-    blocking*: bool
+    # How this context replicates its authority -- the single source of truth for
+    # partial-replica behavior. Set by `subscribe` from its `mode` (FULL by
+    # default): PARTIAL/PARTIAL_ASYNC mean a partial replica, PARTIAL also means
+    # blocking reads. The `blocking:` template raises PARTIAL_ASYNC to PARTIAL for
+    # a scope.
+    sync_mode*: SyncMode
     # Partial-replica evictor (docs/partial-replicas.md). `mem_limit` is a cache
     # budget for unclaimed bodies, in bytes -- an honest, monotonic value from
     # "no cache" up to "unlimited":
@@ -366,11 +367,6 @@ type
     # partiality inherits down a clone chain (a full clone of a full source
     # never receives one); the authority has no upstream and terminates.
     upstream_ctx_ids*: HashSet[string]
-    # This context subscribed partial somewhere: it holds data on demand, not
-    # by contract. Gates hub shedding -- a partial hub that retracts the last
-    # downstream interest in a key drops its own copy and chains the release
-    # upstream; a *full* clone never sheds (it wants everything).
-    partial_replica*: bool
     # Objects we've already logged a dropped-op notice for (once per id).
     warned_missing*: HashSet[string]
     changed_callback_eid: EID
@@ -806,7 +802,7 @@ const DEFAULT_MEM_LIMIT* = 16 * 1024 * 1024
 proc evicts*(self: EdContext): bool {.inline.} =
   ## Reclaims memory under pressure: a partial replica with a finite limit. A
   ## full clone / authority, and an `Unbounded` limit, never evict.
-  self.partial_replica and self.mem_limit < Unbounded
+  self.sync_mode != FULL and self.mem_limit < Unbounded
 
 proc has_budget*(self: EdContext): bool {.inline.} =
   ## Tracks per-body bytes against a finite cap. No-cache (0) and `Unbounded`

--- a/src/ed/utils/logging.nim
+++ b/src/ed/utils/logging.nim
@@ -56,3 +56,18 @@ else:
 
   template log_defaults*(log_topics = "") =
     discard
+
+type EdDefect* = object of Defect
+  ## Raised by `invariant` in non-release builds when a state we expect to hold
+  ## is violated.
+
+template invariant*(cond: bool, message: string) =
+  ## A state we always expect to hold. A violation is a bug, but a recoverable
+  ## one: in debug builds raise (so dev/test fails loud), in release log an error
+  ## and continue -- a long-lived process shouldn't die over a state it can
+  ## safely limp past. Use only where continuing really is safe.
+  if not cond:
+    when defined(release) or defined(danger):
+      error "invariant violated", detail = message
+    else:
+      raise newException(EdDefect, "invariant violated: " & message)

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -37,15 +37,17 @@ proc pack_objects*(self: EdContext) =
     self.objects_need_packing = false
 
 template blocking*(self: EdContext, body: untyped) =
-  ## Within this scope, a read that touches an unmaterialized placeholder blocks
-  ## (pumps I/O) until it fills, instead of returning empty and fetching async.
-  ## Just manages the `blocking` flag -- you can set `self.blocking` directly too.
-  let prev = self.blocking
-  self.blocking = true
+  ## Within this scope, raise a PARTIAL_ASYNC context to PARTIAL: a read that
+  ## touches an unmaterialized placeholder blocks (pumps I/O) until it fills
+  ## instead of returning empty. A no-op for any other `sync_mode` -- FULL has
+  ## nothing to block on, PARTIAL already blocks.
+  let prev = self.sync_mode
+  if self.sync_mode == PARTIAL_ASYNC:
+    self.sync_mode = PARTIAL
   try:
     body
   finally:
-    self.blocking = prev
+    self.sync_mode = prev
 
 proc contains*(self: EdContext, id: string): bool =
   id in self.objects and self.objects[id] != nil
@@ -156,7 +158,7 @@ proc `[]`*(self: EdContext, id: string): ref EdBase =
   ## waited for (bounded, silent pump); a NOT_FOUND NACK fails fast. Still
   ## absent afterwards -> `KeyError` as usual. A destroyed-but-unswept id keeps
   ## its old behavior (returns nil) and doesn't trigger a fetch.
-  if self.blocking and self.materialize != nil and id notin self.objects:
+  if self.sync_mode == PARTIAL and self.materialize != nil and id notin self.objects:
     self.materialize(self, id)
   result = self.resolve_proxy(self.objects[id])
 

--- a/src/ed/zens/operations.nim
+++ b/src/ed/zens/operations.nim
@@ -43,8 +43,8 @@ template touch_read(self: untyped) =
 
 template touch_placeholder(self: untyped) =
   ## Materialize-on-access: if `self` is an unmaterialized placeholder, ask its
-  ## context to materialize it (kick a fetch; block until filled when
-  ## `ctx.blocking`). No-op for a loaded object or a context without the hook.
+  ## context to materialize it (kick a fetch; block until filled when sync_mode
+  ## is PARTIAL). No-op for a loaded object or a context without the hook.
   ## LAZY containers are exempt: they're pull-only by design -- entries arrive
   ## per-key (`request`), so reading one must never materialize the whole table.
   self.touch_read
@@ -72,7 +72,7 @@ proc contains*[T, O](self: Ed[T, O], children: set[O] | seq[O]): bool =
 
 template materialize_for_write(self: untyped) =
   ## A local mutation of an unmaterialized placeholder materializes it first
-  ## (under `ctx.blocking`: pumps I/O until filled) so the in-flight fill
+  ## (in PARTIAL sync_mode: pumps I/O until filled) so the in-flight fill
   ## can't clobber the write -- a placeholder's tracked state is about to be
   ## replaced wholesale by its CREATE. Unlike `touch_placeholder` this skips
   ## `touch_read`: a write must not reset the evictor's updates-since-read

--- a/tests/materialize_tests.nim
+++ b/tests/materialize_tests.nim
@@ -240,17 +240,22 @@ proc run*() =
       check table.loaded(1)
       check table[1] == "one"
 
-    test "blocking scope toggles the flag and restores it":
+    test "blocking scope raises PARTIAL_ASYNC to PARTIAL, then restores":
       var ctx = EdContext.init(id = "mb_ctx")
-      check not ctx.blocking
+      ctx.sync_mode = PARTIAL_ASYNC
       ctx.blocking:
-        check ctx.blocking # set inside the scope
-      check not ctx.blocking # restored after
-      # Nested / manual management still composes.
-      ctx.blocking = true
+        check ctx.sync_mode == PARTIAL # raised inside the scope
+      check ctx.sync_mode == PARTIAL_ASYNC # restored after
+      # No-op for any other mode: FULL has nothing to block on, PARTIAL already
+      # blocks.
+      ctx.sync_mode = FULL
       ctx.blocking:
-        check ctx.blocking
-      check ctx.blocking # restored to the manual value, not forced off
+        check ctx.sync_mode == FULL
+      check ctx.sync_mode == FULL
+      ctx.sync_mode = PARTIAL
+      ctx.blocking:
+        check ctx.sync_mode == PARTIAL
+      check ctx.sync_mode == PARTIAL
 
     test "blocking write materializes first: the fill can't clobber the write":
       var authority = EdContext.init(id = "bw_auth", is_authority = true)

--- a/tests/network_tests.nim
+++ b/tests/network_tests.nim
@@ -272,6 +272,46 @@ proc run*() =
 
     server.close
 
+  test "a subscribed peer sending unparseable bytes is disconnected":
+    # Got past the wire header and established a subscription (same version), then
+    # sent bytes we can't decode -- schema mismatch / corruption / a bug. Tear the
+    # connection down so it re-handshakes and resyncs, rather than silently
+    # dropping its packets forever. (Stray, un-subscribed noise is left alone --
+    # see the test above.)
+    let host = free_addr()
+    var server = EdContext.init(
+      id = "wd_srv",
+      listen_address = host,
+      min_recv_duration = recv_duration,
+      blocking_recv = true,
+    )
+    var sv = EdValue[string].init(id = "wd_v", ctx = server)
+    sv.value = "x"
+
+    Ed.thread_ctx = EdContext.init(id = "wd_cli")
+    let client = Ed.thread_ctx
+    client.subscribe host,
+      callback = proc() =
+        server.tick(blocking = false)
+    check "wd_cli" in server.subscribers.map_it(it.ctx_id) # sub established
+
+    # Garbage over the established connection: valid netty framing, no wire header.
+    var conn: Connection
+    for s in client.subscribers:
+      if s.kind == REMOTE:
+        conn = s.connection
+    client.reactor.send(conn, "not an ed packet")
+    client.reactor.tick()
+
+    for _ in 0 ..< 30:
+      server.tick(blocking = false)
+      client.reactor.tick()
+      if "wd_cli" notin server.subscribers.map_it(it.ctx_id):
+        break
+    check "wd_cli" notin server.subscribers.map_it(it.ctx_id) # connection dropped
+    check "wd_cli" in server.drain_unsubscribed # ...and reported for reaping
+    server.close
+
 when is_main_module:
   Ed.bootstrap
   run()

--- a/tests/utils_tests.nim
+++ b/tests/utils_tests.nim
@@ -59,6 +59,14 @@ proc run*() =
       exc of ConnectionError
       exc of ZenError
 
+  test "invariant raises in debug, no-op when it holds":
+    # Release/danger builds log + continue instead; the suite runs in debug, so
+    # a violated invariant raises EdDefect here.
+    when not (defined(release) or defined(danger)):
+      expect EdDefect:
+        invariant(false, "should raise")
+    invariant(true, "holds -> no-op")
+
   test "stats functionality":
     # Test stats macros
     var call_count = 0


### PR DESCRIPTION
0.3 prep, part 3 of 4 (stacked on part 2). Sync-model consolidation and network/client robustness.

- **single `sync_mode` field** — drop the overlapping `blocking` + `partial_replica` flags (the FULL/PARTIAL/PARTIAL_ASYNC enum is the single source of truth).
- **narrow `EdClient.tick` catch to `ConnectionError`** — stop swallowing unrelated exceptions.
- **`invariant()` helper** — raise in debug, log+continue in release.
- **drop the connection on an unparseable packet from a real peer** — re-handshake/resync instead of silently dropping packets.

Base: `prep/style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)