### PR TITLE
fix(api): re-export lifecycle so new_lifetime stays public

### DIFF
--- a/ed.nimble
+++ b/ed.nimble
@@ -1,4 +1,4 @@
-version = "0.30.1"
+version = "0.30.2"
 author = "Scott Wadden"
 description = "Nothing for now"
 license = "MIT"

--- a/src/ed.nim
+++ b/src/ed.nim
@@ -23,8 +23,8 @@ export monotimes
 import pkg/[threading/channels, flatty]
 export channels, flatty
 
-import ed/[types, zens, components, utils]
-export types, zens, components, utils
+import ed/[types, zens, components, utils, lifecycle]
+export types, zens, components, utils, lifecycle
 
 import ed/client
 export client


### PR DESCRIPTION
The lifecycle split moved `new_lifetime` and the Lifetime/eviction API out of `types.nim` into `lifecycle.nim`, but `ed.nim` re-exports `types/zens/components/utils` and never added `lifecycle` — so `import ed` silently dropped `new_lifetime`, breaking downstream builds (enu's `core.nim` / `units.nim`: *undeclared identifier: 'new_lifetime'*).

Re-export `lifecycle` from `ed.nim`. ed test suite passes.