### PR TITLE
fix: survive upstream disconnect on partial replicas + tighten keepalives

### DIFF
--- a/ed.nimble
+++ b/ed.nimble
@@ -1,4 +1,4 @@
-version = "0.30.2"
+version = "0.30.3"
 author = "Scott Wadden"
 description = "Nothing for now"
 license = "MIT"

--- a/src/ed/components/subscriptions/core.nim
+++ b/src/ed/components/subscriptions/core.nim
@@ -81,6 +81,20 @@ proc unsubscribe*(self: EdContext, sub: Subscription, notify = true) =
     self.send(sub, Message(kind: UNSUBSCRIBE), OperationContext(), DEFAULT_FLAGS)
   self.subscribers.delete self.subscribers.find(sub)
   self.unsubscribed.add ctx_id
+  # If that was our last live upstream, fail any in-flight fetches rather than
+  # leaving them Pending forever: a disconnected partial replica can't page, and
+  # a reconnect re-pages from scratch anyway. (Without this, a blocking
+  # materialize would wait out its full deadline on a fetch that can never land.)
+  if ctx_id in self.upstream_ctx_ids:
+    var still_upstream = false
+    for s in self.subscribers:
+      if s.ctx_id in self.upstream_ctx_ids:
+        still_upstream = true
+        break
+    if not still_upstream:
+      for f in self.fetches.values:
+        if f.state == Pending:
+          f.state = NotFound
   # Purge the subscriber's chained wants so nothing is served to a dead sub.
   var empty_ids: seq[string]
   for id, wants in self.pending_obj_wants.mpairs:

--- a/src/ed/components/subscriptions/paging.nim
+++ b/src/ed/components/subscriptions/paging.nim
@@ -43,18 +43,15 @@ proc serve_key_wants(self: EdContext, object_id: string) =
 proc request_targets(self: EdContext): seq[Subscription] =
   ## Who to send a REQUEST to: our upstreams (the contexts we page from).
   ## Never downstream -- a clone's copy of us is stale-by-definition, and
-  ## letting it answer can overwrite fresher local state with its echo. Only a
-  ## non-authority forwards, and a non-authority pages from a recorded upstream,
-  ## so this is non-empty in practice. An empty result means a degenerate
-  ## topology (a non-authority with no upstream); rather than fall back to all
-  ## subscribers -- which could route the request downstream -- treat it as a bug
-  ## (assert in debug, log in release) and forward nowhere.
+  ## letting it answer can overwrite fresher local state with its echo.
+  ## Empty means no *live* upstream right now -- normally a transient reconnect
+  ## window (the link dropped and we haven't re-subscribed). Callers must handle
+  ## empty gracefully (`fetch` resolves NotFound; a disconnected partial replica
+  ## simply can't page) -- never fall back to all subscribers, which could route
+  ## a request downstream.
   for sub in self.subscribers:
     if sub.ctx_id in self.upstream_ctx_ids:
       result.add sub
-  if result.len == 0:
-    error "request_with_no_upstream", ctx = self.id
-    assert false, "request_targets: forwarding with no recorded upstream"
 
 proc forward_request(self: EdContext, requester: Subscription, msg: Message) =
   ## Chain a request we can't serve: send it to our upstream(s).
@@ -110,8 +107,15 @@ proc fetch*(
     return self.fetches[object_id]
   result = Fetch(id: object_id, state: Pending)
   self.fetches[object_id] = result
+  let targets = self.request_targets
+  if targets.len == 0:
+    # No live upstream to page from (a disconnected partial replica). Resolve the
+    # handle now instead of forwarding into the void; the data arrives via the
+    # reconnect's full resubscribe, and a later re-fetch mints a fresh handle.
+    result.state = NotFound
+    return
   var msg = Message(kind: REQUEST, object_id: object_id, deep: deep)
-  for sub in self.request_targets:
+  for sub in targets:
     self.send(sub, msg, OperationContext(), DEFAULT_FLAGS)
   self.tick_reactor
 

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -203,14 +203,13 @@ proc tick_keepalives*(self: EdContext) {.gcsafe.} =
   ## Lightweight tick that only sends keepalives if enough time has passed.
   ## Safe to call frequently - won't do anything if called too soon.
   ## Call this after long operations (file I/O, etc.) to prevent connection timeouts.
-  const keepalive_interval = 5.0  ## Seconds between keepalive pings to idle connections
-  const keepalive_tick_interval = 3.0  ## Seconds between keepalive-only ticks
+  const keepalive_interval = 3.0  ## Seconds between keepalive pings / pumps
 
   if not ?self.reactor:
     return
 
   let now = epoch_time()
-  if now - self.last_keepalive_tick < keepalive_tick_interval:
+  if now - self.last_keepalive_tick < keepalive_interval:
     return
 
   self.last_keepalive_tick = now

--- a/tests/network_tests.nim
+++ b/tests/network_tests.nim
@@ -1,10 +1,10 @@
-import std/[tables, sugar, unittest, sequtils, strutils]
+import std/[tables, sugar, unittest, sequtils, strutils, sets]
 import pkg/[flatty, chronicles, netty]
 import ed
 import ed/types {.all.}
 import ed/zens/private {.all.}
 import test_util
-from std/times import init_duration
+from std/times import init_duration, epoch_time
 
 const recv_duration = init_duration(milliseconds = 10)
 
@@ -311,6 +311,37 @@ proc run*() =
     check "wd_cli" notin server.subscribers.map_it(it.ctx_id) # connection dropped
     check "wd_cli" in server.drain_unsubscribed # ...and reported for reaping
     server.close
+
+  test "a real upstream timeout leaves fetch resolving NotFound, not crashing":
+    # A PARTIAL_ASYNC replica whose upstream times out (netty connTimeout) used to
+    # crash on the next fetch: the sub is reaped but the id stays in the append-only
+    # upstream_ctx_ids, so request_targets found a recorded-but-dead upstream. Drive
+    # a genuine timeout (clock-jump the reactor past connTimeout) and confirm fetch
+    # degrades to NotFound -- the data returns via the reconnect's resubscribe.
+    let host = free_addr()
+    var
+      authority = EdContext.init(id = "rt_auth", listen_address = host)
+      client = EdContext.init(id = "rt_cli")
+    client.subscribe host,
+      mode = PARTIAL_ASYNC,
+      callback = proc() =
+        authority.tick(blocking = false)
+    var recorded = authority.id in client.upstream_ctx_ids
+    check recorded
+    check client.subscribers.len == 1
+
+    # Jump the client's reactor clock past connTimeout (10s): a sleep/wake or a
+    # >10s starved thread reaches the same state with zero real inactivity.
+    client.reactor.debug.tick_time = epoch_time() + 11.0
+    client.tick(blocking = false) # timeoutConnections -> dead -> unsubscribe
+
+    check client.subscribers.len == 0 # upstream sub reaped...
+    recorded = authority.id in client.upstream_ctx_ids # ...but still recorded
+    check recorded
+    let handle = client.fetch("rt_missing")
+    check handle.state == NotFound # no crash
+    authority.close
+    client.close
 
 when is_main_module:
   Ed.bootstrap

--- a/tests/partial_tests.nim
+++ b/tests/partial_tests.nim
@@ -281,6 +281,42 @@ proc run*() =
       check handle.state == NotFound
       check "does_not_exist" notin client
 
+    test "disconnected partial replica: fetch resolves NotFound, doesn't crash":
+      var authority = EdContext.init(id = "dc_auth", is_authority = true)
+      var client = EdContext.init(id = "dc_client")
+      var x = EdValue[int].init(ctx = authority, id = "dc_x")
+      x.value = 7
+      client.subscribe(authority, mode = PARTIAL_ASYNC, fetch = [])
+      client.tick()
+
+      # Simulate the upstream link dropping: remove the client's subscription to
+      # the authority, leaving a partial replica with a recorded-but-gone
+      # upstream (upstream_ctx_ids is append-only).
+      for sub in client.subscribers:
+        if sub.ctx_id == "dc_auth":
+          client.unsubscribe(sub, notify = false)
+          break
+      check "dc_auth" in client.upstream_ctx_ids # still recorded, but no live sub
+
+      # A fetch now has no live upstream to page from. It must resolve NotFound,
+      # not assert (the old request_targets invariant crashed here).
+      let handle = client.fetch("dc_x")
+      check handle.state == NotFound
+
+    test "losing the upstream fails in-flight fetches instead of hanging them":
+      var authority = EdContext.init(id = "df_auth", is_authority = true)
+      var client = EdContext.init(id = "df_client")
+      client.subscribe(authority, mode = PARTIAL_ASYNC, fetch = [])
+      client.tick()
+
+      let handle = client.fetch("df_missing")
+      check handle.state == Pending # in flight, request sent upstream
+      for sub in client.subscribers:
+        if sub.ctx_id == "df_auth":
+          client.unsubscribe(sub, notify = false)
+          break
+      check handle.state == NotFound # resolved on disconnect, not left Pending
+
     test "follow (default): a missing fetch is delivered when created later":
       var authority = EdContext.init(id = "fl_auth", is_authority = true)
       var client = EdContext.init(id = "fl_client")


### PR DESCRIPTION
## Problem

A PARTIAL_ASYNC replica (e.g. enu's MCP server paging from the managed Enu authority) could crash on a `fetch` after its upstream link timed out. The flaky symptom was the `request_targets: forwarding with no recorded upstream` assert.

Root cause: when netty times out the connection (`connTimeout = 10s`), the subscription is reaped but the authority id stays in the append-only `upstream_ctx_ids`. `request_targets` then saw a *recorded-but-dead* upstream, and a later fetch asserted while forwarding into the void.

The disconnect itself is real and reproducible two ways — both reaching the exact same state (`subscribers=0`, upstream still recorded):
- a >10s wall-clock jump (netty times off `epochTime()`), and
- a real >10s gap with no reactor tick (thread starvation under load — the likely trigger of the original flake).

## Changes

**Bail gracefully instead of asserting:**
- `fetch`: empty `request_targets` → resolve the handle `NotFound` (data returns via the reconnect's full resubscribe) instead of forwarding nowhere.
- `unsubscribe`: failing the last upstream sub fails in-flight `Pending` fetches to `NotFound` so they don't hang.
- `request_targets`: drop the assert; return the (possibly empty) seq.

**Tighten keepalives:** collapse the two timers (3s pump + 5s ping) to a single 3s cadence. Keepalive spacing ~6s → ~3s against the 10s timeout, widening the margin ~4s → ~7s.

## Tests
- Two deterministic `partial_tests` (disconnected-replica fetch; in-flight fetch losing its upstream).
- A `network_tests` case driving a **real** netty timeout end to end (clock-jump past `connTimeout`).
- Full suite green.