### PR TITLE
fix(wire): harden untrusted decode against hostile packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,12 @@
 !*.*
 
 nimbledeps/
-deps/
+# Ignore the Atlas-managed dep checkouts and machine-specific caches, but keep
+# atlas.config tracked -- it's the portable resolution policy (e.g. the flatty
+# pkgOverride). Contents-glob (not `deps/`) so the exception can re-include a
+# child; a bare directory ignore can't be negated.
+deps/*
+!deps/atlas.config
 nimcache/
 nimblecache/
 htmldocs/

--- a/deps/atlas.config
+++ b/deps/atlas.config
@@ -1,0 +1,11 @@
+{
+  "deps": "deps",
+  "nameOverrides": {},
+  "urlOverrides": {},
+  "pkgOverrides": {
+    "flatty": "https://github.com/getenu/flatty"
+  },
+  "plugins": "",
+  "resolver": "SemVer",
+  "graph": null
+}

--- a/deps/atlas.config
+++ b/deps/atlas.config
@@ -1,10 +1,11 @@
 {
   "deps": "deps",
-  "nameOverrides": {},
-  "urlOverrides": {},
-  "pkgOverrides": {
+  "nameOverrides": {
+    "nanoid": "https://github.com/getenu/nanoid.nim",
     "flatty": "https://github.com/getenu/flatty"
   },
+  "urlOverrides": {},
+  "pkgOverrides": {},
   "plugins": "",
   "resolver": "SemVer",
   "graph": null

--- a/ed.nimble
+++ b/ed.nimble
@@ -5,7 +5,7 @@ license = "MIT"
 srcDir = "src" # atlas doesn't like src_dir
 
 requires(
-  "https://github.com/treeform/pretty >= 0.2.0", "threading", "chronicles",
-  "https://github.com/getenu/flatty >= 0.4.1", "netty", "supersnappy",
-  "https://github.com/getenu/nanoid.nim >= 0.2.1", "metrics#a1296ca",
+  "pretty", "threading", "chronicles",
+  "flatty >= 0.4.1", "netty", "supersnappy",
+  "nanoid >= 0.2.1", "metrics#a1296ca",
 )

--- a/ed.nimble
+++ b/ed.nimble
@@ -1,4 +1,4 @@
-version = "0.30.3"
+version = "0.30.4"
 author = "Scott Wadden"
 description = "Nothing for now"
 license = "MIT"

--- a/ed.nimble
+++ b/ed.nimble
@@ -6,6 +6,6 @@ srcDir = "src" # atlas doesn't like src_dir
 
 requires(
   "https://github.com/treeform/pretty >= 0.2.0", "threading", "chronicles",
-  "flatty", "netty", "supersnappy",
+  "https://github.com/getenu/flatty >= 0.4.1", "netty", "supersnappy",
   "https://github.com/getenu/nanoid.nim >= 0.2.1", "metrics#a1296ca",
 )

--- a/src/ed/components/subscriptions/core.nim
+++ b/src/ed/components/subscriptions/core.nim
@@ -11,7 +11,7 @@ import
     strutils, macros, os, heapqueue,
   ]
 import pkg/threading/channels {.all.}
-import pkg/[flatty, supersnappy]
+import pkg/flatty
 import ed/[core, types {.all.}], ed/zens/[contexts, private, initializers {.all.}]
 import ed/components/private/global_state
 import ed/lifecycle
@@ -1136,13 +1136,24 @@ proc tick*(
             sub = s
             break
 
-        if msg.kind == SUBSCRIBE:
-          self.handle_subscribe(msg, raw_msg.conn)
-        else:
-          # Regular message - decode source using subscription's mappings
-          if sub != nil:
-            sub.register_mappings(msg.id_mappings)
-          self.process_message(msg, sub)
+        try:
+          if msg.kind == SUBSCRIBE:
+            self.handle_subscribe(msg, raw_msg.conn)
+          else:
+            # Regular message - decode source using subscription's mappings
+            if sub != nil:
+              sub.register_mappings(msg.id_mappings)
+            self.process_message(msg, sub)
+        except FlattyError as e:
+          # A nested wire field -- typically a registered-type payload inside
+          # msg.obj, decoded here rather than in parse_remote's envelope check --
+          # was malformed or hostile (a length prefix past the buffer). Tear the
+          # peer down like any other unparseable input instead of letting the
+          # error escape tick and crash us.
+          warn "dropping peer after undecodable payload",
+            peer = $raw_msg.conn.address, reason = e.msg
+          self.drop_remote_conn(raw_msg.conn)
+          continue
 
     if poll == false or
         ((count > 0 or not blocking) and get_mono_time() > recv_until):
@@ -1201,7 +1212,15 @@ proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
             s.register_mappings(rmsg.id_mappings)
             rmsg.source_set = s.decode_source(rmsg.source)
             break
-        triage(rmsg)
+        try:
+          triage(rmsg)
+        except FlattyError as e:
+          # Same guard as tick's remote loop: an undecodable payload during a
+          # blocking materialize drops the peer instead of escaping the read.
+          warn "dropping peer after undecodable payload",
+            peer = $raw_msg.conn.address, reason = e.msg
+          self.drop_remote_conn(raw_msg.conn)
+          continue
   self.silent = false
 
 when defined(ed_debug_messages):

--- a/src/ed/components/subscriptions/wire.nim
+++ b/src/ed/components/subscriptions/wire.nim
@@ -189,8 +189,37 @@ template ed_compress(s: string): string =
   ## so both sides agree on the (un)compressed wire format.
   when defined(ed_no_compress): s else: s.compress
 
-template ed_uncompress(s: string): string =
-  when defined(ed_no_compress): s else: s.uncompress
+const max_decompressed_body = 64 * 1024 * 1024
+  ## Ceiling on a decompressed remote body. supersnappy reads the target size
+  ## from the stream's leading varint and `setLen`s it up front, so a tiny
+  ## hostile packet could otherwise demand gigabytes before any data is
+  ## validated. Larger than any legitimate ed message; a claim past it means the
+  ## packet is malformed or hostile.
+
+proc snappy_declared_len(s: string): int =
+  ## The uncompressed length from a snappy stream's leading LEB128 varint,
+  ## without decoding the body. `-1` if the header is truncated or malformed, so
+  ## the caller can reject it before supersnappy allocates.
+  var shift = 0
+  var n = 0'i64
+  for i in 0 ..< min(s.len, 10):  # a 64-bit varint is at most 10 bytes
+    let b = s[i].uint8
+    n = n or (int64(b and 0x7f) shl shift)
+    if (b and 0x80) == 0:
+      return (if n < 0: -1 else: n.int)
+    shift += 7
+  -1
+
+proc ed_uncompress(s: string): string =
+  when defined(ed_no_compress):
+    s
+  else:
+    let declared = s.snappy_declared_len
+    if declared < 0 or declared > max_decompressed_body:
+      raise newException(
+        FlattyError, "remote body decompressed size out of range: " & $declared
+      )
+    s.uncompress
 
 proc remote_body(msg: Message, no_overwrite: bool): string =
   ## The shared, compressed wire body for a remote message -- identical across

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -2,7 +2,7 @@ import
   ed, basic_tests, threading_tests, network_tests, publish_tests,
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
   lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests,
-  lifetime_tests, ctx_teardown_tests
+  lifetime_tests, ctx_teardown_tests, wire_hardening_tests
 
 Ed.bootstrap
 
@@ -22,3 +22,4 @@ capability_tests.run()
 materialize_tests.run()
 lifetime_tests.run()
 ctx_teardown_tests.run()
+wire_hardening_tests.run()

--- a/tests/wire_hardening_tests.nim
+++ b/tests/wire_hardening_tests.nim
@@ -1,0 +1,77 @@
+## Regression tests for the wire-decode hardening (see the getenu/flatty fork).
+##
+## ed decodes flatty off the network, where a peer's bytes are untrusted. The
+## length-prefixed decoders (string, seq, table, set) must validate every count
+## against the bytes that remain, so a hostile packet is rejected with a
+## catchable `FlattyError` instead of over-allocating (OOM) or reading past the
+## buffer (SIGSEGV via copyMem, which no `try` catches). These tests pin that:
+## normal data still round-trips, and every bomb shape raises.
+
+import std/[unittest, tables, sets]
+import pkg/flatty
+import pkg/flatty/binny
+
+proc run*() =
+  test "flatty round-trips survive the length guard":
+    check "hello".toFlatty.fromFlatty(string) == "hello"
+    check "".toFlatty.fromFlatty(string) == ""
+    check @[1'u8, 2, 3].toFlatty.fromFlatty(seq[uint8]) == @[1'u8, 2, 3]
+    check (newSeq[uint8]()).toFlatty.fromFlatty(seq[uint8]).len == 0
+    check @["a", "bb"].toFlatty.fromFlatty(seq[string]) == @["a", "bb"]
+    var t = {"x": 1, "y": 2}.to_table
+    check t.toFlatty.fromFlatty(Table[string, int]) == t
+    var hs = [10, 20, 30].to_hash_set
+    check hs.toFlatty.fromFlatty(HashSet[int]) == hs
+
+  test "FlattyError is catchable at a trust boundary":
+    # A subtype of CatchableError, so existing `except CatchableError` handlers
+    # (e.g. parse_remote) catch it -- the whole point of not crashing.
+    check FlattyError is CatchableError
+
+  template rejects(name: string, body: untyped) =
+    test name:
+      var raised = false
+      try:
+        body
+      except FlattyError:
+        raised = true
+      check raised
+
+  # The critical one: a copyMem seq whose declared length dwarfs the payload.
+  # Pre-fix this over-reads the buffer via copyMem -> SIGSEGV (uncatchable).
+  rejects "huge seq[uint8] length is rejected":
+    var b = ""
+    b.addInt64(0x7fff_ffff'i64)
+    discard b.fromFlatty(seq[uint8])
+
+  rejects "seq length just past the buffer is rejected":
+    var b = ""
+    b.addInt64(64'i64)
+    b.add("only a handful of bytes")
+    discard b.fromFlatty(seq[uint8])
+
+  rejects "huge string length is rejected":
+    var b = ""
+    b.addInt64(0x7fff_ffff_ffff'i64)
+    discard b.fromFlatty(string)
+
+  rejects "huge set element count is rejected":
+    var b = ""
+    b.addInt64(0x7fff_ffff'i64)
+    discard b.fromFlatty(HashSet[int])
+
+  rejects "huge table entry count is rejected":
+    var b = ""
+    b.addInt64(0x7fff_ffff'i64)
+    discard b.fromFlatty(Table[string, int])
+
+  rejects "negative length is rejected":
+    var b = ""
+    b.addInt64(-1'i64)
+    discard b.fromFlatty(seq[uint8])
+
+  rejects "truncated length prefix is rejected":
+    discard "\x01\x02\x03".fromFlatty(seq[uint8])
+
+when isMainModule:
+  run()


### PR DESCRIPTION
## Problem

ed decodes flatty off the network, where a peer's bytes are untrusted (netty is plain UDP; enu clients are open source). flatty's length-prefixed decoders trusted the count read from the buffer, then `setLen`/`copyMem`'d against it. A single crafted packet could:

- **OOM** the process via a huge `setLen`, or
- **SIGSEGV** via a `copyMem` heap over-read (e.g. `Message.source: seq[uint8]`) — an uncatchable crash that `parse_remote`'s `try/except` does not stop.

supersnappy had a second bomb: `uncompress` allocates its declared output size up front, so a tiny packet could demand gigabytes.

## Fix

- **getenu/flatty fork (0.4.1):** treeform 0.4.0 (the version ed was pinned to) plus a bounds check — the string/seq/table/set decoders validate every count against the bytes actually remaining before allocating or copying, raising a catchable `FlattyError` instead. Holds even under `-d:danger`, where Nim's own bounds checks are off. Deliberately does **not** pull in treeform's post-0.4.0 rewrites (ed isn't tested against them); this is a minimal hardened pin ahead of the planned serializer migration.
- **`wire.nim`:** caps supersnappy's declared decompressed size before `uncompress` (kills the decompression bomb).
- **`core.nim`:** the tick and blocking-materialize remote loops catch `FlattyError` so a malformed registered-type payload inside an otherwise-valid packet drops the peer, instead of escaping `tick` and crashing.
- **`tests/wire_hardening_tests.nim`:** round-trips still work; every bomb shape (huge seq/string/set/table, negative length, truncated prefix, length-past-buffer) is rejected.

## Dependency plumbing

`netty` (also treeform) requires plain `flatty`, which resolves to treeform and collides with ed's getenu fork ("duplicate module name"). An Atlas `pkgOverrides` entry routes `flatty` → getenu everywhere. `deps/atlas.config` is now tracked (via a gitignore exception: `deps/*` + `!deps/atlas.config`) to carry that policy — it's a portable 197-byte config, unlike the machine-specific `atlas.cache*.json`, which stays ignored.

## Follow-up (enu)

When enu bumps to ed 0.30.4 it hits the same duplicate-module conflict, so enu's `deps/atlas.config` needs the same `pkgOverrides` flatty→getenu line, plus the same gitignore treatment to track it.

## Known residuals (not in this stopgap)

- binny's fixed-width numeric reads can over-read ≤8 bytes at a truncated tail (bounded, no loop/alloc, not reflected) — low severity, left to avoid `raises`-inference churn.
- Broader assert→disconnect audit and the pre-auth object-id leak in the ACK are separate tracks.

## Test

`nimble test` — all suites pass, including the new hardening tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o1niF74BvbfxYU1oWEQ38