### PR TITLE
feat(store): durable log + snapshots + restore + replay (Phase 2)

### DIFF
--- a/docs/consistency-and-partial-sync-plan.md
+++ b/docs/consistency-and-partial-sync-plan.md
@@ -4,6 +4,12 @@
 > features. We are not committing to build all of this, or any of it, now.
 > Supersedes the CRDT-leaning `DISTRIBUTED_CONSISTENCY_PLAN.md` on the old
 > `comprehensive-crdt-implementation` branch.
+>
+> This doc is the **data-layer mechanics** (roles, reconciliation, partial sync).
+> The layer above it — deployment/trust/topology/scaling and the serializer +
+> schema-evolution decision, i.e. the road to distributed enu — lives in
+> `decentralization-and-scaling.md`. The durable store it references is
+> `persistence.md`.
 
 ## Goals
 

--- a/docs/consistency-and-partial-sync-plan.md
+++ b/docs/consistency-and-partial-sync-plan.md
@@ -525,12 +525,18 @@ The axes worth holding in mind, each with a now/later verdict:
 ## Roadmap (order matters)
 
 > **Status:** Phase 1 is **done** and validated in Enu (branch
-> `feat/lsn-leader-ordering`, PR #10). Phase 0's forwarding partial subscriber is
-> still parked; Phases 2+ are future. Per-object `mode` (optimistic/confirmed)
-> and gap/replay buffering ended up **deferred** rather than landing in Phase 1 —
-> the implemented reconciliation is state-based forward correction with the
-> `op_id`-superseded rule (see `consistency.md`), not LWW-snap +
-> op-replay.
+> `feat/lsn-leader-ordering`, PR #10). Phase 2 is **done** (see
+> `persistence.md`): authority-side JSONL log + snapshot dirs + restart-restore
+> + `EdContext.replay` time-travel, with the git-shaped store layout. Reserve-now
+> items 1 (epoch+lsn on every op — epoch now real), 2 (first-class commit
+> point), 3 (idempotent-by-LSN replay), 4 (txn_id/commit/schema slots in the
+> log format), and 9 (op ids in entries) now have concrete homes; TypeSchema
+> content-versioning is still future (only the slots exist). Phase 0's
+> forwarding partial subscriber is still parked. Per-object `mode`
+> (optimistic/confirmed) and gap/replay buffering ended up **deferred** rather
+> than landing in Phase 1 — the implemented reconciliation is state-based
+> forward correction with the `op_id`-superseded rule (see `consistency.md`),
+> not LWW-snap + op-replay.
 
 - **Phase 0 — Plumbing (now, low risk).** Rebase onto main. Land forwarding
   partial subscriber (still parked). Defer / re-aim the schema work.
@@ -539,9 +545,11 @@ The axes worth holding in mind, each with a now/later verdict:
   reconciliation (op_id-superseded for registers, delta-dedup for collections);
   `authority` = host. Delivers eventual consistency + smooth optimistic writes.
   *Deferred from this phase:* durable log, per-object `mode`, gap/replay buffer.
-- **Phase 2 — Durable log + snapshots.** Persist the ordered stream; snapshot
-  for compaction; schema-versioned log format. Full-replica time-travel/replay
-  falls out — prototype early as a debug/replay tool to validate the design.
+- **Phase 2 — Durable log + snapshots. *(done — `persistence.md`)*** Persist
+  the ordered stream; snapshot for compaction; schema-versioned log format.
+  Full-replica time-travel/replay falls out (`EdContext.replay`). *Deferred
+  from this phase:* serving live fetch misses from the log (lands with
+  authority eviction), TypeSchema content versioning.
 - **Phase 3 — Interest-based partial sync.** Subscribe to subsets; filtered,
   LSN-tagged delivery; convert presence assertions → lazy-fetch hooks;
   materialize-on-access.

--- a/docs/consistency.md
+++ b/docs/consistency.md
@@ -84,6 +84,8 @@ delivery (latest canonical value per object per tick) removes optimistic flicker
 
 *Not built:* OCC/versioned writes, ack/commit callback (the `op_id` plumbing
 exists; #10), snapshot-vs-delta resync threshold, stricter delete-vs-update policy.
+The ordered stream is now also **durable** on the authority — log, snapshots,
+restart-restore, replay — see `persistence.md`.
 
 ## Transport & schema compatibility
 

--- a/docs/decentralization-and-scaling.md
+++ b/docs/decentralization-and-scaling.md
@@ -192,17 +192,20 @@ an object's serialized bytes, under whatever serializer):
 
 ## Serialization & schema evolution
 
-**Decision: a single serializer, and flatty retires at the cutover.** flatty is
-fine as a compact positional codec but wrong as a *durable/evolving* format
-(positional + name-hashed `tid` → a type change silently corrupts or safe-fails
-with loss). The forcing function is the end goal: git-hosted **long-lived** worlds
-outlive the code, so schema evolution moves from "nice, defer" to *eventually
-mandatory*. We adopt **nim-serialization** (already partly in the tree via
+**What's needed vs what's preferred.** A **schema-capable serializer for the
+durable path is needed**: flatty is fine as a compact positional codec but wrong as
+a *durable/evolving* format (positional + name-hashed `tid` → a type change silently
+corrupts or safe-fails with loss), and git-hosted **long-lived** worlds outlive the
+code, so schema evolution moves from "nice, defer" to *eventually mandatory*.
+**Dropping flatty entirely — one serializer for both jobs — is a preference, not a
+requirement.** We'd adopt **nim-serialization** (already partly in the tree via
 `json_serialization`; designed for "one type, many wire formats") for the durable
-path, and at that same cutover move the hot path onto it too rather than straddle
-two serializers. **Contingency (the only reason to keep a second codec):** validate
-nim-serialization's binary backend meets the voxel hot path's compactness/speed at
-cutover; only if it can't — not expected — would a compact codec survive there.
+path, and *ideally* move the hot path onto it too so there's a single codec — the
+expectation is it replaces flatty cleanly. But if it doesn't — if its binary backend
+can't match flatty on the voxel hot path, *or* if keeping flatty for the hot path and
+nim-serialization for the durable path is simply cleaner than shoehorning both jobs
+into one — then **two serializers is an acceptable outcome.** Single-serializer is the
+lean, not a constraint.
 
 **Keep and extend the type registry — it is the asset.** It does four jobs; only
 one is flatty-coupled:
@@ -252,9 +255,11 @@ Ordered by dependency and trigger, not calendar.
 3. **Scaling tier.** Spatial interest management (enu-side, substrate ready — do
    first, highest leverage) + relay tree (ed-side, hub primitive exists). Together:
    thousands of players.
-4. **Serializer cutover.** nim-serialization for durable path + hot path, flatty
-   retired, registry extended with the field schema. Triggered by schema-evolution
-   need (long-lived worlds breaking across updates / mixed-version play).
+4. **Serializer for the durable path.** nim-serialization + field schema for the
+   durable path (needed), registry extended to emit it; unify the hot path onto it
+   and retire flatty if that's clean, else keep flatty for the hot path (preference,
+   not a requirement). Triggered by the schema-evolution need (long-lived worlds
+   breaking across updates / mixed-version play).
 5. **Traffic split.** An "unordered, owner-distributed" object class so trusted
    client-owned ephemera (movement, effects) bypasses the sequencer — the big
    headroom win, safe only under cooperative trust.

--- a/docs/decentralization-and-scaling.md
+++ b/docs/decentralization-and-scaling.md
@@ -232,19 +232,20 @@ having the registry emit that descriptor — not a reason to drop the registry.
 The top two aren't speculative — they fall directly out of the end goal. That's why
 the switch is *eventually mandatory* rather than optional.
 
-**Timing.** Cheap safety half **now**, independent of the switch: stamp a
-schema/build fingerprint into the manifest's reserved `schema` slot and have
-`open_store` refuse-or-warn on mismatch, so Phase 2 fails *clearly* instead of
-silently dropping objects. The full nim-serialization + field-schema cutover is
-triggered by the durable need — when saved worlds start breaking across updates, or
-mixed-version play becomes real — and drops flatty in one move.
+**Timing.** Cheap safety half **done** (`persistence.md`): `ED_SCHEMA_VERSION` in
+the manifest's reserved `schema` slot, and `open_store`/`replay` refuse a
+mismatched store (overridable), so a schema-incompatible store fails *clearly*
+instead of silently dropping objects. The full nim-serialization + field-schema
+cutover is triggered by the durable need — when saved worlds start breaking across
+updates, or mixed-version play becomes real — and drops flatty in one move.
 
 ## Sequenced roadmap
 
 Ordered by dependency and trigger, not calendar.
 
-1. **Now / cheap, no trigger:** manifest schema-fingerprint gate (safe-fail on
-   incompatible store); keep the reserve-now items from the plan doc honored.
+1. **Done:** manifest schema-version gate (`ED_SCHEMA_VERSION`; safe-fail on
+   incompatible store — `persistence.md`). *Ongoing:* keep the reserve-now items
+   from the plan doc honored.
 2. **Model 1 — failover / git-hosting.** Liveness detection, deterministic
    successor, frontier-rollback, git-as-log + ref-CAS host claim. Delivers the
    serverless goal; ordering + DX untouched. The next big infrastructure step.

--- a/docs/decentralization-and-scaling.md
+++ b/docs/decentralization-and-scaling.md
@@ -1,0 +1,268 @@
+# Decentralization, Scaling & Serialization — the road to distributed enu
+
+> Status: **living design doc.** Sets direction; commits to little now. Companion
+> to `consistency-and-partial-sync-plan.md` (the data-layer mechanics — roles,
+> reconciliation, partial sync) and `persistence.md` (the durable store). This
+> doc is the layer *above* those: how enu goes from a single host to distributed,
+> community-hosted, long-lived worlds, and what that path implies for trust,
+> network topology, and serialization.
+
+## The end goal (decided)
+
+enu worlds become **git-hosted and long-lived**: an ed project is a git repo,
+git is the durability + distribution layer (cold worlds sit in the repo; a joiner
+pulls the latest and claims authority), and the mesh is the live-sync layer.
+Worlds outlive the code that made them. Scale target is **hundreds to low
+thousands** of concurrent players in a large level, reached with **relay trees**
+(distribution) + **spatial interest management** (relevance) — the latter an enu
+concern, not an ed one. Trust is **cooperative**: we defend against malformed
+input (security) but not against authorized players gaining game advantage
+(cheating). The authority model targets **Model 1** (single sequencer, but
+replaceable / serverless) with **Model 2** (federated per-object authority) left
+open as a later stop; Models 3–4 are rejected (below).
+
+## Three independent dials, not one "P2P" switch
+
+"Trustless P2P" bundles three *separable* choices. enu wants a different setting
+on each, and conflating them is what makes decentralization sound scarier — and
+more DX-damaging — than it is.
+
+1. **Deployment** — dedicated always-on server ↔ serverless (any peer, or a git
+   repo, can host). *"Do I need a box?"*
+2. **Ordering / authority** — one global sequencer ↔ per-object owners ↔ no global
+   order (leaderless). *"Who's the referee?"*
+3. **Trust** — cooperative (believe messages) ↔ authenticated (verify identity) ↔
+   Byzantine (assume lies, prove everything). *"Do I trust the other players?"*
+
+The DX fear — "won't P2P break the cross-object ordering enu depends on?" — lives
+**only on dial 2, only at its far end.** You can go serverless (dial 1) while
+keeping a single global order (dial 2 near end). Losing ordering is a *separate*
+choice from losing the server. That decoupling is the load-bearing insight of
+this whole doc.
+
+## Authority & trust models
+
+Built on the four separable roles from the plan doc (write-authority, sequencer,
+durable-log, script-execution). Single-host is the degenerate case where all four
+sit on one node.
+
+| Model | Referee (ordering) | Server needed? | Cheating stance | enu fit |
+|---|---|---|---|---|
+| **0. Single host** (today) | one host, global LSN | yes, dedicated | host validates all | *is* enu |
+| **1. Failover / git-hosted** | one host at a time, global LSN | no — any peer or a git repo | host validates | drops in, mostly reserved |
+| **2. Federated** | per-object owners; host still sequences | host as sequencer only | trust peers re: their own objects | moderate, bounded |
+| **3. Leaderless (CRDT)** | no global order; per-object causal | none | cooperative | **major rethink** |
+| **4. Byzantine** | consensus, trust no one | none | cryptographically enforced | different genre |
+
+**Model 1 is the target.** Still one authority with a global LSN at any moment —
+so cross-object order stays free and every enu dependency (ref-graph
+parent-before-child, script snapshot reads, per-tick collection order) is
+untouched. What changes is that the authority is *replaceable*: peers detect a
+dropped host, deterministically pick a successor, and the `epoch` (shipped in
+Phase 2) bumps so a returning zombie host can't corrupt anyone. The git variant
+*is* the git-hosting goal — the repo is the durable log, first joiner claims
+authority via a ref-CAS. Assumptions changed vs today: "authority is fixed" →
+"authority is replaceable," plus liveness detection and rollback of in-flight ops
+past the new host's frontier. See the plan doc's Host-failover section for the
+mechanics. **Fits without app changes.**
+
+**Model 2 is the later stop, kept open, not built.** Peers own the *writes* to
+their own objects (a client owns its avatar/bots) while ops still flow through the
+host for the global LSN and durability — "federated," host as timeline-keeper not
+decider. Global order, transactions, and time-travel all survive. The plan doc's
+four reserve-now items (`authority_of(obj)` indirection, deterministic
+reconciliation, attribute-ops-to-authority, keep sequencer/authority roles
+separate) are what keep this a *loosened constraint* rather than a rewrite.
+**Important correction:** Model 2 does **not** relieve the sequencer — the host
+still stamps every ordered op. It relieves *compute* (validation is per-owner) and
+improves *DX* (local ownership). Don't reach for it expecting a throughput win;
+reach for it for ownership.
+
+**Models 3–4 are rejected.** Leaderless (3) is exactly the DX-killer the ordering
+intuition fears: you lose free global cross-object order, transactions need 2PC,
+data types are constrained to commutative CRDTs, and memory runs 2–4× — all to buy
+leaderless convergence enu doesn't need because it has a host. Byzantine (4) is a
+different genre (signed ops, consensus latency, huge complexity) for a cooperative
+sandbox; even the far-future marketplace would answer cheating with host
+validation, not consensus.
+
+## Trust posture (decided: cooperative)
+
+The security-vs-cheating line is Ed's existing "strict on the envelope, forgiving
+on the payload" principle, extended one layer up. The two threats live at
+different layers, so the defenses do too:
+
+- **Security — defend (already done).** A client sending *malformed bytes*
+  (hostile length prefixes, version-skewed packets, garbage that could crash or
+  corrupt). Covered by the wire hardening: magic+version gate, bounds-checked
+  decode, drop-the-connection, and the `epoch` upstream-gate. Keep all of it.
+- **Cheating — ignore.** A client sending *well-formed but game-illegal* ops
+  (teleport, spawn an item). We believe it. No server re-validation, no
+  re-simulation, no sandboxing of client script output.
+
+**What cooperative trust unlocks — the traffic split.** Trusting clients lets
+high-frequency traffic bypass the central path entirely, which is the single
+biggest scaling lever after interest management:
+
+- **Sequenced shared core** — genuinely contended, multi-writer state (two people
+  editing the same voxel cell, shared counters, unique claims, structural changes
+  to the units list). Needs global order → flows through the host sequencer. Lower
+  frequency.
+- **Trusted client-owned ephemera** — avatar movement, transient effects, your own
+  bots. *Single-writer* (you own them) → no write conflict to order, just converge
+  and deliver. Because you're trusted, these can flow owner → relay/neighbors with
+  the sequencer **out of the loop** — no central validation to launder through.
+
+The second class is the bulk of high-frequency traffic. Ed doesn't do this bypass
+today (everything routes through the authority for its LSN); trust is the
+precondition that makes adding an "unordered, owner-distributed" object class
+*viable* rather than reckless. Building it is future work.
+
+**What cooperative trust does NOT remove:** input hardening (above); admission
+control at the session boundary (*which* clients are let in — a separate mechanism
+from anti-cheat, still needed); and the `from_upstream` / epoch upstream-gates —
+which are **correctness**, not anti-cheat: they answer "who is *authoritative* over
+this object's state," keeping convergence well-defined and stopping accidental /
+malformed clobbering regardless of trust.
+
+**What it takes off the table:** signatures/identity on ops, cryptographic state
+proofs (→ confirms SSZ stays out, below), server re-validation of client moves
+(thinner host), and sandboxing client script output (→ "scripts on all clients"
+gets much cheaper — client compute is simply trusted).
+
+## Scaling & topology
+
+**Sequencing is cheap; distribution is the wall.** Assigning an LSN is an integer
+increment + rebroadcast — one node orders millions/s; it will never be the
+bottleneck. The bottleneck is *distributing* each op to every interested
+subscriber. `fanout` already serializes a body once and reuses it, so the
+authority's *CPU* is fine; its *uplink* saturates. Worst case is quadratic — 100
+clustered players moving at 30 Hz, each relayed to ~99 others at ~100 B ≈ **30 MB/s
+uplink** — which no home connection hosts. Everything below attacks that number.
+
+Two escape hatches, both already latent in Ed:
+
+- **Spatial interest (relevance) — an enu concern.** Players in different areas
+  don't need each other's ops. Ed's partial replicas + interest sets are the
+  substrate; the *spatial policy* (subscribe to what's near me, drop what's far, as
+  I move) is app-level and lives in enu. Turns fanout from O(all players) into
+  O(neighbors). **Highest-leverage unbuilt feature; the substrate is ready.**
+- **Relay trees — distribution as a tree.** The hub / request-chaining primitive
+  (a hub that can't serve a request forwards upstream and relays the answer) is the
+  seed. The authority sends to a handful of full-clone relays, each fanning to a
+  subset; its uplink becomes O(relays), not O(clients). The sequencer role stays
+  central (global order intact) while *distribution* fans out. Primitive exists; a
+  full relay tier is unbuilt.
+
+**Ceilings (order-of-magnitude):** star + home host ≈ low **hundreds** spread out;
+star + cloud uplink ≈ low **thousands**; relay tree (host still sequences) ≈
+**thousands+**, at which point the ceiling shifts to the *sequencer's ordered-write
+rate* — kept high by keeping globally-ordered state small (client-owned and
+LWW-per-cell state don't need it). Beyond that you **shard the sequencer**
+(per-region authority, independent LSN streams) — the plan doc's stated trigger
+"write throughput hits the single sequencer's ceiling." The one limit no topology
+fixes: **dense clustering is inherently N²** (500 players in one room all see each
+other); the answer is *degradation* (distance-based update-rate scaling, network
+LOD), not routing. Per-tick coalescing already does part of it.
+
+## State roots without SSZ
+
+We want cheap **integrity**, whole-state **equality** ("do two replicas agree?"),
+and localized **divergence** detection — but *not* the one thing SSZ uniquely adds
+(cryptographic inclusion proofs), because that's only worth its cost under
+Byzantine trust (Model 4), which we've ruled out. SSZ also fights Ed's ref-graph /
+placeholder object model. So: **no SSZ.**
+
+Instead, build on one primitive — a **stable per-object content hash** (the hash of
+an object's serialized bytes, under whatever serializer):
+
+- **Whole-state root:** combine per-object hashes into one digest, maintained
+  incrementally at the op choke point (XOR is the cheap trick: `root ^= old ^ new`
+  per mutation — order-independent, O(1), no re-scan). Compare one number for
+  "are these replicas identical." *Caveat:* XOR catches **accidental** divergence
+  (our actual threat model), not an adversary crafting collisions.
+- **Localized divergence:** an `id → content_hash` map; a mismatch points at the
+  exact object — the granularity Ed already reconciles at, simpler than a tree.
+- **Whole-snapshot integrity + content-addressing:** git already Merkle-hashes the
+  committed snapshot directory — the tree SHA *is* the snapshot's root, for free,
+  once the git layer lands. crc32 stays for torn-write detection.
+- **Upgrade path if ever needed:** an id-keyed Merkle tree over the per-object
+  hashes you already maintain — a small addition, not a format rewrite — reached
+  only if the trust model changes (same fork that would justify SSZ).
+
+## Serialization & schema evolution
+
+**Decision: a single serializer, and flatty retires at the cutover.** flatty is
+fine as a compact positional codec but wrong as a *durable/evolving* format
+(positional + name-hashed `tid` → a type change silently corrupts or safe-fails
+with loss). The forcing function is the end goal: git-hosted **long-lived** worlds
+outlive the code, so schema evolution moves from "nice, defer" to *eventually
+mandatory*. We adopt **nim-serialization** (already partly in the tree via
+`json_serialization`; designed for "one type, many wire formats") for the durable
+path, and at that same cutover move the hot path onto it too rather than straddle
+two serializers. **Contingency (the only reason to keep a second codec):** validate
+nim-serialization's binary backend meets the voxel hot path's compactness/speed at
+cutover; only if it can't — not expected — would a compact codec survive there.
+
+**Keep and extend the type registry — it is the asset.** It does four jobs; only
+one is flatty-coupled:
+
+1. **Ed-field semantics** — nil non-synced refs/ptrs/procs, blank `ed_ignore`,
+   relink Ed-fields *by id*, and `revive`/converge. Irreplaceable, codec-independent.
+2. **Type dispatch** — reconstruct the right concrete type from a `tid` + bytes.
+3. **Capability negotiation** — which `tid`s a peer can materialize.
+4. **Codec calls** — the only flatty-coupled part; swap the `to_flatty`/`from_flatty`
+   inside stringify/parse for nim-serialization.
+
+So the registry survives as "Ed-semantics + schema + dispatch, delegating raw bytes
+to the codec," and becomes the natural home for a **per-type field descriptor** (the
+schema). The `tid = hash(name)` structure-blindness is a `tid` defect, fixed by
+having the registry emit that descriptor — not a reason to drop the registry.
+
+**What the schema (TypeSchema) unlocks**, priority order:
+
+| Use case | Need |
+|---|---|
+| Saved worlds survive enu updates (a v2 build reads a v1 world) | **needed** — direct consequence of git-hosted long-lived worlds; without it every type change breaks saved worlds |
+| Mixed-version / rolling play (v1 and v2 clients interoperate) | **needed-ish** — community-hosted worlds are never version-synchronized |
+| Human-readable, git-diffable persisted state | nice; strong DX + git-vision fit; uses the store's reserved `codec` seam |
+| Introspection / tooling / eventual read-only SQL view | nice, later |
+| Cross-language / non-Nim clients | far future (general-data-layer ambition) |
+
+The top two aren't speculative — they fall directly out of the end goal. That's why
+the switch is *eventually mandatory* rather than optional.
+
+**Timing.** Cheap safety half **now**, independent of the switch: stamp a
+schema/build fingerprint into the manifest's reserved `schema` slot and have
+`open_store` refuse-or-warn on mismatch, so Phase 2 fails *clearly* instead of
+silently dropping objects. The full nim-serialization + field-schema cutover is
+triggered by the durable need — when saved worlds start breaking across updates, or
+mixed-version play becomes real — and drops flatty in one move.
+
+## Sequenced roadmap
+
+Ordered by dependency and trigger, not calendar.
+
+1. **Now / cheap, no trigger:** manifest schema-fingerprint gate (safe-fail on
+   incompatible store); keep the reserve-now items from the plan doc honored.
+2. **Model 1 — failover / git-hosting.** Liveness detection, deterministic
+   successor, frontier-rollback, git-as-log + ref-CAS host claim. Delivers the
+   serverless goal; ordering + DX untouched. The next big infrastructure step.
+3. **Scaling tier.** Spatial interest management (enu-side, substrate ready — do
+   first, highest leverage) + relay tree (ed-side, hub primitive exists). Together:
+   thousands of players.
+4. **Serializer cutover.** nim-serialization for durable path + hot path, flatty
+   retired, registry extended with the field schema. Triggered by schema-evolution
+   need (long-lived worlds breaking across updates / mixed-version play).
+5. **Traffic split.** An "unordered, owner-distributed" object class so trusted
+   client-owned ephemera (movement, effects) bypasses the sequencer — the big
+   headroom win, safe only under cooperative trust.
+6. **Model 2 — federated authority (if/when needed).** Per-object write authority
+   for ownership DX and distributed compute; sequencer stays central. Reach for it
+   for ownership, not throughput.
+7. **Sequencer sharding (far / maybe never).** Per-region authority when a single
+   world's ordered-write rate is the wall.
+
+State roots (per-object content hash + XOR digest + id-map) slot in wherever
+divergence detection or snapshot integrity first pays off — cheap, incremental,
+serializer-agnostic.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -36,7 +36,8 @@ fields keep the log greppable), payload bins base64'd, and a `crc` field last,
 computed over the raw line prefix, so torn writes are detectable without
 canonical-JSON games. `v`/`txn`/`commit`/`schema` are reserved slots (format
 version, future atomic batches, TypeSchema version); `codec` names the payload
-encoding so a human-readable codec can slot in beside flatty later. The
+encoding so a human-readable codec can take over from flatty later (the
+single-serializer cutover — see `decentralization-and-scaling.md`). The
 manifest records platform (endianness, int width) — flatty is native-endian —
 and refuses a mismatch. Session-coupled fields (`source`, `id_mappings`)
 never persist.
@@ -183,10 +184,13 @@ engages once the first snapshot is written.
 ## Not built (deferred deliberately)
 
 Serving fetch/REQUEST misses from the log (the authority never evicts today —
-this lands with authority eviction); structure-aware tids / full TypeSchema (the
-gate above is version-level, not per-type structural — `tid = hash($T)` still
-can't detect a struct/enum change on its own, see `consistency.md`); the
-ack/commit callback (op_id plumbing ready); git integration itself. Known
+this lands with authority eviction); an opt-in `PERSIST` flag to replace the
+current persist-iff-synced rule (so a consumer marks exactly what's durable —
+needed because a synced object isn't necessarily one to save; the enu adoption
+depends on it); structure-aware tids / full TypeSchema (the gate above is
+version-level, not per-type structural — `tid = hash($T)` still can't detect a
+struct/enum change on its own, see `consistency.md`); the ack/commit callback
+(op_id plumbing ready); git integration itself. Known
 pre-existing gap surfaced by this work, not fixed here: with a single subscriber
 that originated the op, `has_eligible` is false and the echo never returns to
 the writer (a return-to-source violation) — capture is unaffected, the echo half

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -36,8 +36,8 @@ fields keep the log greppable), payload bins base64'd, and a `crc` field last,
 computed over the raw line prefix, so torn writes are detectable without
 canonical-JSON games. `v`/`txn`/`commit`/`schema` are reserved slots (format
 version, future atomic batches, TypeSchema version); `codec` names the payload
-encoding so a human-readable codec can take over from flatty later (the
-single-serializer cutover — see `decentralization-and-scaling.md`). The
+encoding so a schema-capable/human-readable codec can take over the durable path
+later — see `decentralization-and-scaling.md`. The
 manifest records platform (endianness, int width) — flatty is native-endian —
 and refuses a mismatch. Session-coupled fields (`source`, `id_mappings`)
 never persist.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,176 @@
+# Persistence — Durable Log, Snapshots, Replay
+
+How an authority makes its canonical op stream durable, compacts it with
+snapshots, restores after a restart, and materializes historical views. The
+consistency model it rides on is in `consistency.md`; the roadmap that called
+for it is `consistency-and-partial-sync-plan.md` (Phase 2).
+
+## The store
+
+`open_store(ctx, path, snapshot_every = 0, durability = FlushPerTick,
+retain_snapshots = 2)` attaches a durable store to an **authority** context —
+a post-init call, like `subscribe`, made before anything subscribes and before
+the context holds objects. Followers never persist; they replicate from the
+authority. Layout:
+
+```
+<path>/
+  HEAD                              # atomic-rename hint; recovery never trusts it blindly
+  log/000002-000000000000042.jsonl  # <epoch>-<after_lsn>; new segment per open + per snapshot
+  snapshots/000000000000042/        # <watermark lsn>, written as tmp-* then renamed
+    manifest.json                   # written last = the snapshot's commit marker
+    obj-000001-<oid>.json           # one CREATE-shaped entry per object, full contents
+```
+
+The layout is **git-shaped on purpose**: rotated segments are immutable
+appends, a snapshot is per-object files sealed by a manifest, and the store
+directory is a future repo working tree. The intended endgame is "an ed
+project is a git repo" — git supplies durability and distribution (cold
+worlds, late-joiner catch-up, forking/sharing, deep history), the mesh stays
+the live sync layer, and a host-claim ref gives first-joiner authority a CAS.
+None of that is built; the format just doesn't fight it.
+
+Entries are JSONL: one op per line, `Message` fields projected explicitly
+(*not* `Message.to_flatty` — that layout varies with `ed_trace`, and explicit
+fields keep the log greppable), payload bins base64'd, and a `crc` field last,
+computed over the raw line prefix, so torn writes are detectable without
+canonical-JSON games. `v`/`txn`/`commit`/`schema` are reserved slots (format
+version, future atomic batches, TypeSchema version); `codec` names the payload
+encoding so a human-readable codec can slot in beside flatty later. The
+manifest records platform (endianness, int width) — flatty is native-endian —
+and refuses a mismatch. Session-coupled fields (`source`, `id_mappings`)
+never persist.
+
+## What gets logged, and where
+
+Ordered ops append **at the stamp point** (`publish_changes` /
+`publish_destroy`), between `stamp_lsn` and fanout — an op's durable form is
+exactly what fans out, and no LSN is ever visible to a peer in an order the
+log doesn't have. The store behaves like a permanently-eligible subscriber:
+with a store open, build/stamp/append run even with zero subscribers (the
+headless authority is the primary durability case) and even when the only
+subscriber originated the op. Ops for objects with no SYNC flag are skipped —
+declared-ephemeral data doesn't persist — and the snapshot applies the same
+predicate, so snapshot ≡ replay(log).
+
+CREATE is unordered (lsn 0) and has no single publish point, so it's logged at
+the **creation event** instead: once in `defaults` (the CREATE bin is the
+default value; initial content follows as the stamped ops `Ed.init` produces),
+and once at placeholder-fill (`relay_fill`) for objects whose CREATE arrived
+after something referenced them. Never in `publish_create`, which re-fires per
+subscriber. PACKED logs as one entry — `handle_packed` advances the frontier
+on the envelope LSN, so splitting it would make replay drop everything after
+the first sub-op.
+
+## The commit point
+
+`EdStore.commit` is the single durability decision: appends buffer into the
+segment `File`, and *when* they become durable is policy —
+`FlushPerTick` (default), `FsyncPerTick`, `FsyncPerOp`. Future rungs (quorum
+replication) extend commit, not the append path. Under `FlushPerTick` a hard
+crash can lose ops that already fanned out to followers; the epoch reset
+(below) is what makes that window safe, so the default stays fast.
+
+## Restore and replay
+
+Restore = newest fully-valid snapshot (manifest crc + every object file crc;
+a damaged snapshot falls back to the previous one) + the log tail from its
+watermark. With **no** valid snapshot, the log must reach back to LSN 0 or
+restore raises `StoreError` — retention prunes early segments once a snapshot
+covers them, and silently replaying just the surviving tail would canonize a
+near-empty world. Everything is fed through `process_message` — the same idempotent,
+frontier-guarded apply engine live sync uses, which also rebuilds `owned_by`,
+`ref_pool`, and link wiring for free. `ctx.replaying` is set for the duration
+and does exactly three things:
+
+- bypasses the loopback guard and the **own-op superseded rule** — logged
+  entries carry our own origin, and the delta short-circuit would otherwise
+  silently drop every collection op the authority ever originated. The LSN
+  stale-drop stays active; it's what makes double-covered segments (a crash
+  between snapshot and rotation) idempotent.
+- suppresses publish/stamp/append (`publish_changes`/`publish_destroy` return
+  early) — nothing new is happening. A replayed DESTROY would otherwise
+  re-enter `publish_destroy` via `change_receiver` and re-stamp/re-append on
+  every restart.
+
+Restore runs before anything subscribes or tracks, on the context's home
+thread. Snapshot objects materialize in reverse manifest order (children
+first, so parent bins link real containers), then the registry is re-ordered
+back to manifest order — `add_subscriber` pushes newest-first, and a
+post-restart subscriber must still receive children before parents.
+Placeholders are never snapshotted (a parent's bin re-mints them; persisting
+one would restore a real-but-empty object). Pre-watermark segments are never
+replayed: their lsn-0 CREATEs bypass the frontier and would resurrect
+create/destroy pairs the snapshot already resolved.
+
+Counter hygiene: `lsn_counter` restores to the maximum stamped LSN *scanned*,
+not the frontier — replay legitimately drops some ops (a destroyed object's
+tail) without advancing `applied_lsn`, and a reused LSN would be stale-dropped
+by every surviving follower forever. `op_id_counter`/`latest_op_id` rebuild
+from the manifest + own-origin tail entries.
+
+**Type registration:** a restoring process must instantiate the store's Ed
+types (compile an `Ed[T,O].init` for each) so `Ed.bootstrap` registers their
+materializers — the same rule as any subscriber (it's what the capability
+handshake enforces on the wire). An unknown tid in the log is skipped, like an
+unknown type from a peer.
+
+`EdContext.replay(path, to_lsn)` is the time-travel view: a fresh
+non-authority context restored to a positional cut — the newest snapshot at or
+below `to_lsn`, replayed forward through the entry stamped `to_lsn` (CREATEs
+carry no LSN; file position is their order). Read-only store, no epoch bump,
+no segment: it coexists with the live authority on the same directory, and
+writes on the view are local-only.
+
+## Snapshots, rotation, retention
+
+`ctx.snapshot()` (or `snapshot_every` appended entries, checked at tick)
+writes per-object files + manifest into a tmp dir, fsyncs, renames, then
+rotates the segment at the watermark — so every non-active segment is
+immutable. A valid snapshot already at the current watermark is **kept**, not
+replaced (anything since it is lsn-0 CREATEs, which replay as tail): a
+delete-then-rewrite would open a crash window where the only retained
+snapshot is gone and its covered segments already pruned. The watermark is `lsn_counter` (the authority applies its own
+writes synchronously and appends at stamp time; `applied_lsn` never advances
+for its own stamps). Retention keeps the newest `retain_snapshots` snapshot
+dirs and drops segments fully covered by the oldest kept watermark; replay_to
+below the horizon raises `StoreError`. Time-travel depth = retention depth
+(`int.high` = keep everything, the future git mode where history lives in
+commits).
+
+Torn final line of a segment = a mid-write crash: dropped with a notice. A bad
+line anywhere else is real corruption and raises `StoreError` — silently
+skipping history would be data loss.
+
+## Epoch
+
+`EdContext.epoch` is stamped onto every ordered op (`stamp_lsn`) and bumps to
+`max(seen) + 1` on every store open — the first real use of `Message.epoch`.
+A follower that sees a stamped op with a higher epoch than any before it —
+**from an upstream** — resets its frontier (`applied_lsn`, `latest_op_id`):
+the restarted authority may legitimately reissue LSNs its predecessor fanned
+out but never made durable, and without the reset the follower would
+stale-drop the new timeline forever. The upstream gate matters: epoch is a
+bare wire field, and letting any peer zero the frontier would re-open
+non-idempotent delta ops to double-application. Within one store, LSNs stay monotonic across epochs (restore trusts
+the scanned maximum), so epoch mostly disambiguates *which incarnation* wrote
+an entry — and buys zombie-writer hygiene for the eventual failover work.
+
+## Guarded footguns
+
+`ctx.clear` raises `StoreError` while a writable store is open (a wiped
+registry with no messages would silently desync log from state — there is no
+CLEAR op). `ctx.close` detaches the store along with the reactor.
+Re-`init`ing a live id on a logging authority is likewise unsupported: the
+log would carry two CREATEs for one id and replay keeps the first incarnation.
+
+## Not built (deferred deliberately)
+
+Serving fetch/REQUEST misses from the log (the authority never evicts today —
+this lands with authority eviction); structure-aware tids / TypeSchema (the
+`schema` slot is reserved; `tid = hash($T)` still can't detect a struct/enum
+change, see `consistency.md`); the ack/commit callback (op_id plumbing ready);
+git integration itself. Known pre-existing gap surfaced by this work, not
+fixed here: with a single subscriber that originated the op, `has_eligible`
+is false and the echo never returns to the writer (a return-to-source
+violation) — capture is unaffected, the echo half is a follow-up.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -164,13 +164,30 @@ CLEAR op). `ctx.close` detaches the store along with the reactor.
 Re-`init`ing a live id on a logging authority is likewise unsupported: the
 log would carry two CREATEs for one id and replay keeps the first incarnation.
 
+## Schema gate
+
+The manifest's `schema` slot carries `ED_SCHEMA_VERSION` (a manual constant in
+`store/format.nim`), and `open_store`/`replay` refuse a store whose slot differs
+from the running build's — a `StoreError`, overridable with
+`allow_schema_mismatch = true`. **Bump `ED_SCHEMA_VERSION` whenever a persisted
+type changes shape** (a field added/removed/reordered, an enum value added):
+`tid = hash($T)` is name-only, so without the bump a mismatched build would
+deserialize such a store's objects as garbage *silently* — the gate turns that
+into a clean refusal. This is the **manual** half of schema safety until
+structure-aware tids land, at which point the same slot gains automatic
+structural detection (see `decentralization-and-scaling.md` for the serializer +
+schema-evolution plan). `schema == 0` means legacy/unset and skips the check; a
+store with only a log and no snapshot yet has no manifest to gate, so the check
+engages once the first snapshot is written.
+
 ## Not built (deferred deliberately)
 
 Serving fetch/REQUEST misses from the log (the authority never evicts today —
-this lands with authority eviction); structure-aware tids / TypeSchema (the
-`schema` slot is reserved; `tid = hash($T)` still can't detect a struct/enum
-change, see `consistency.md`); the ack/commit callback (op_id plumbing ready);
-git integration itself. Known pre-existing gap surfaced by this work, not
-fixed here: with a single subscriber that originated the op, `has_eligible`
-is false and the echo never returns to the writer (a return-to-source
-violation) — capture is unaffected, the echo half is a follow-up.
+this lands with authority eviction); structure-aware tids / full TypeSchema (the
+gate above is version-level, not per-type structural — `tid = hash($T)` still
+can't detect a struct/enum change on its own, see `consistency.md`); the
+ack/commit callback (op_id plumbing ready); git integration itself. Known
+pre-existing gap surfaced by this work, not fixed here: with a single subscriber
+that originated the op, `has_eligible` is false and the echo never returns to
+the writer (a return-to-source violation) — capture is unaffected, the echo half
+is a follow-up.

--- a/src/ed/components.nim
+++ b/src/ed/components.nim
@@ -1,2 +1,2 @@
-import components/[subscriptions, type_registry]
-export subscriptions, type_registry
+import components/[subscriptions, type_registry, store]
+export subscriptions, type_registry, store

--- a/src/ed/components/store.nim
+++ b/src/ed/components/store.nim
@@ -1,0 +1,9 @@
+## The durable store: an authority appends its canonical op stream to
+## append-only JSONL log segments and periodically snapshots full state, so a
+## restart restores from snapshot + tail and `EdContext.replay` materializes
+## historical views (docs/persistence.md). Split into parts under `store/`
+## (format -> log -> {snapshot, restore}); this facade re-exports the public
+## API. Import `ed/components/store`.
+
+import ./store/[format, log, snapshot, restore]
+export format, log, snapshot, restore

--- a/src/ed/components/store/format.nim
+++ b/src/ed/components/store/format.nim
@@ -1,0 +1,255 @@
+import std/[json, base64, strutils]
+import ed/types {.all.}
+import ed/utils/crc32
+
+# On-disk encodings for the durable store: JSONL log entries, snapshot object
+# files (one entry line each), the snapshot manifest, and HEAD. Entries project
+# Message fields explicitly rather than dumping `Message.to_flatty` -- the
+# flatty layout varies with `ed_trace`, and explicit fields keep the log
+# greppable. Payload bins (`obj`/`key`) stay flatty, base64'd; `codec` names
+# their encoding so a readable codec can slot in later. Session-coupled fields
+# (source, id_mappings) never persist. Every line ends with a `crc` field
+# computed over the raw bytes before it, so a torn tail is detectable without
+# canonical-JSON games.
+
+const
+  STORE_VERSION* = 1
+  CODEC_FLATTY* = "flatty"
+  LOGGED_KINDS* = {CREATE, DESTROY, ASSIGN, UNASSIGN, TOUCH, PACKED}
+
+type
+  ManifestEntry* = object
+    file*: string
+    oid*: string
+    tid*: int
+    crc*: string
+
+  Manifest* = object
+    version*: int
+    epoch*: int64
+    lsn*: int64 ## watermark: state as of this LSN inclusive
+    op_id_counter*: int64
+    codec*: string
+    schema*: int ## reserved TypeSchema version (always 0 today)
+    endian*: string
+    int_bits*: int
+    objects*: seq[ManifestEntry] ## registry insertion order = dependency order
+
+  Head* = object
+    snapshot*: string
+    segment*: string
+    epoch*: int64
+
+const
+  host_endian = when cpu_endian == little_endian: "little" else: "big"
+  host_int_bits = sizeof(int) * 8
+  crc_marker = ",\"crc\":\""
+
+proc init*(
+    _: type Manifest, epoch, lsn, op_id_counter: int64
+): Manifest =
+  Manifest(
+    version: STORE_VERSION,
+    epoch: epoch,
+    lsn: lsn,
+    op_id_counter: op_id_counter,
+    codec: CODEC_FLATTY,
+    endian: host_endian,
+    int_bits: host_int_bits,
+  )
+
+proc platform_ok*(m: Manifest): bool =
+  m.endian == host_endian and m.int_bits == host_int_bits
+
+proc seal(line: sink string): string =
+  ## Append the crc field computed over everything before it.
+  result = line
+  result.add crc_marker & crc32_hex(line) & "\"}"
+
+proc check_seal(line: string): bool =
+  let idx = line.rfind(crc_marker)
+  if idx <= 0:
+    return false
+  let start = idx + crc_marker.len
+  if start + 8 > line.len:
+    return false
+  line[start ..< start + 8] == crc32_hex(line.to_open_array(0, idx - 1))
+
+proc to_entry_line*(msg: Message): string =
+  ## One JSONL line (no trailing newline). Fixed field order, defaults omitted,
+  ## crc last.
+  result = "{\"v\":" & $STORE_VERSION
+  result.add ",\"epoch\":" & $msg.epoch
+  result.add ",\"lsn\":" & $msg.lsn
+  result.add ",\"txn\":0,\"commit\":true"
+  result.add ",\"kind\":\"" & $msg.kind & "\""
+  result.add ",\"oid\":" & escape_json(msg.object_id)
+  if msg.change_object_id.len > 0:
+    result.add ",\"coid\":" & escape_json(msg.change_object_id)
+  result.add ",\"tid\":" & $msg.type_id
+  if msg.ref_id != 0:
+    result.add ",\"rid\":" & $msg.ref_id
+  if msg.owner_id.len > 0:
+    result.add ",\"owner\":" & escape_json(msg.owner_id)
+  if msg.flags != {}:
+    result.add ",\"flags\":["
+    var first = true
+    for flag in msg.flags:
+      if not first:
+        result.add ","
+      result.add "\"" & $flag & "\""
+      first = false
+    result.add "]"
+  if msg.delta:
+    result.add ",\"delta\":true"
+  if msg.key_bin.len > 0:
+    result.add ",\"key\":\"" & encode(msg.key_bin) & "\""
+  if msg.obj.len > 0:
+    result.add ",\"obj\":\"" & encode(msg.obj) & "\""
+  result.add ",\"codec\":\"" & CODEC_FLATTY & "\""
+  if msg.origin.len > 0:
+    result.add ",\"origin\":" & escape_json(msg.origin)
+  if msg.op_id != 0:
+    result.add ",\"op\":" & $msg.op_id
+  result = seal(result)
+
+proc parse_entry*(line: string): tuple[ok: bool, msg: Message] =
+  ## ok = false on any JSON/crc/schema failure. Unknown fields are ignored
+  ## (forward compat); an unknown version or codec is a refusal, not a crash.
+  if not check_seal(line):
+    return
+  var node: JsonNode
+  try:
+    node = parse_json(line)
+    if node{"v"}.get_int(int.high) > STORE_VERSION:
+      return
+    var msg = Message(
+      epoch: node{"epoch"}.get_biggest_int,
+      lsn: node{"lsn"}.get_biggest_int,
+      kind: parse_enum[MessageKind](node["kind"].get_str),
+      object_id: node["oid"].get_str,
+      change_object_id: node{"coid"}.get_str,
+      type_id: node{"tid"}.get_int,
+      ref_id: node{"rid"}.get_int,
+      owner_id: node{"owner"}.get_str,
+      delta: node{"delta"}.get_bool,
+      origin: node{"origin"}.get_str,
+      op_id: node{"op"}.get_biggest_int,
+    )
+    if "flags" in node:
+      for flag in node["flags"]:
+        msg.flags.incl parse_enum[EdFlags](flag.get_str)
+    if "key" in node:
+      msg.key_bin = decode(node["key"].get_str)
+    if "obj" in node:
+      msg.obj = decode(node["obj"].get_str)
+    if node{"codec"}.get_str(CODEC_FLATTY) != CODEC_FLATTY:
+      return
+    result = (true, msg)
+  except CatchableError:
+    return
+
+proc to_manifest*(m: Manifest): string =
+  result = "{\"v\":" & $m.version
+  result.add ",\"epoch\":" & $m.epoch
+  result.add ",\"lsn\":" & $m.lsn
+  result.add ",\"op_id_counter\":" & $m.op_id_counter
+  result.add ",\"codec\":\"" & m.codec & "\""
+  result.add ",\"schema\":" & $m.schema
+  result.add ",\"endian\":\"" & m.endian & "\""
+  result.add ",\"int_bits\":" & $m.int_bits
+  result.add ",\"objects\":["
+  for i, entry in m.objects:
+    if i > 0:
+      result.add ","
+    result.add "{\"file\":" & escape_json(entry.file)
+    result.add ",\"oid\":" & escape_json(entry.oid)
+    result.add ",\"tid\":" & $entry.tid
+    result.add ",\"crc\":\"" & entry.crc & "\"}"
+  result.add "]"
+  result = seal(result)
+
+proc parse_manifest*(s: string): tuple[ok: bool, manifest: Manifest] =
+  if not check_seal(s):
+    return
+  try:
+    let node = parse_json(s)
+    if node{"v"}.get_int(int.high) > STORE_VERSION:
+      return
+    var m = Manifest(
+      version: node["v"].get_int,
+      epoch: node{"epoch"}.get_biggest_int,
+      lsn: node{"lsn"}.get_biggest_int,
+      op_id_counter: node{"op_id_counter"}.get_biggest_int,
+      codec: node{"codec"}.get_str(CODEC_FLATTY),
+      schema: node{"schema"}.get_int,
+      endian: node{"endian"}.get_str,
+      int_bits: node{"int_bits"}.get_int,
+    )
+    if m.codec != CODEC_FLATTY:
+      return
+    for entry in node["objects"]:
+      m.objects.add ManifestEntry(
+        file: entry["file"].get_str,
+        oid: entry["oid"].get_str,
+        tid: entry{"tid"}.get_int,
+        crc: entry{"crc"}.get_str,
+      )
+    result = (true, m)
+  except CatchableError:
+    return
+
+proc to_head*(h: Head): string =
+  "{\"snapshot\":" & escape_json(h.snapshot) & ",\"segment\":" &
+    escape_json(h.segment) & ",\"epoch\":" & $h.epoch & "}"
+
+proc parse_head*(s: string): tuple[ok: bool, head: Head] =
+  try:
+    let node = parse_json(s)
+    result = (
+      true,
+      Head(
+        snapshot: node{"snapshot"}.get_str,
+        segment: node{"segment"}.get_str,
+        epoch: node{"epoch"}.get_biggest_int,
+      ),
+    )
+  except CatchableError:
+    return
+
+# Path/name conventions. Segment and snapshot names zero-pad epoch/lsn so
+# lexical order = numeric order.
+
+proc segment_file*(epoch, after_lsn: int64): string =
+  align($epoch, 6, '0') & "-" & align($after_lsn, 15, '0') & ".jsonl"
+
+proc parse_segment_file*(
+    name: string
+): tuple[ok: bool, epoch, after_lsn: int64] =
+  if not name.ends_with(".jsonl"):
+    return
+  let parts = name[0 ..< ^6].split('-')
+  if parts.len != 2:
+    return
+  try:
+    result = (true, parse_biggest_int(parts[0]), parse_biggest_int(parts[1]))
+  except ValueError:
+    return
+
+proc snapshot_dir*(lsn: int64): string =
+  align($lsn, 15, '0')
+
+proc parse_snapshot_dir*(name: string): tuple[ok: bool, lsn: int64] =
+  try:
+    result = (true, parse_biggest_int(name))
+  except ValueError:
+    return
+
+proc object_file*(idx: int, oid: string): string =
+  var sanitized = ""
+  for ch in oid:
+    if ch in {'a' .. 'z', 'A' .. 'Z', '0' .. '9', '_', '-'}:
+      sanitized.add ch
+    if sanitized.len == 40:
+      break
+  "obj-" & align($idx, 6, '0') & "-" & sanitized & ".json"

--- a/src/ed/components/store/format.nim
+++ b/src/ed/components/store/format.nim
@@ -16,6 +16,17 @@ const
   STORE_VERSION* = 1
   CODEC_FLATTY* = "flatty"
   LOGGED_KINDS* = {CREATE, DESTROY, ASSIGN, UNASSIGN, TOUCH, PACKED}
+  ED_SCHEMA_VERSION* = 1
+    ## App-schema version stamped into every manifest's `schema` slot and gated
+    ## at open (see restore.nim). **Bump this whenever a persisted type changes
+    ## in a way that makes an older store unreadable** -- a field added / removed
+    ## / reordered, or an enum value added. `tid = hash($T)` is name-only and
+    ## can't see such a change, so a mismatched build would otherwise deserialize
+    ## garbage silently; the gate turns that into a clean refusal. This is the
+    ## manual half of schema safety until structure-aware tids land, at which
+    ## point the check gains automatic structural detection (docs/persistence.md,
+    ## decentralization-and-scaling.md). `0` in a manifest means legacy/unset ->
+    ## the gate is skipped.
 
 type
   ManifestEntry* = object
@@ -30,7 +41,7 @@ type
     lsn*: int64 ## watermark: state as of this LSN inclusive
     op_id_counter*: int64
     codec*: string
-    schema*: int ## reserved TypeSchema version (always 0 today)
+    schema*: int ## ED_SCHEMA_VERSION at write time (0 = legacy/unset)
     endian*: string
     int_bits*: int
     objects*: seq[ManifestEntry] ## registry insertion order = dependency order
@@ -54,6 +65,7 @@ proc init*(
     lsn: lsn,
     op_id_counter: op_id_counter,
     codec: CODEC_FLATTY,
+    schema: ED_SCHEMA_VERSION,
     endian: host_endian,
     int_bits: host_int_bits,
   )

--- a/src/ed/components/store/log.nim
+++ b/src/ed/components/store/log.nim
@@ -1,0 +1,141 @@
+import std/[os, algorithm, strutils]
+import ed/types {.all.}
+import ed/utils/[misc, logging]
+import ./format
+
+# The append/segment half of the durable store (docs/persistence.md). A segment
+# is append-only JSONL; a fresh one opens on every store open (epoch bump) and
+# on every snapshot, so all non-active segments are immutable. `commit` is the
+# single durability decision point: appends buffer into the File, and when they
+# become durable is policy (`StoreDurability`), not mechanism.
+
+const
+  LOG_DIR* = "log"
+  SNAPSHOTS_DIR* = "snapshots"
+
+when defined(posix):
+  import std/posix
+
+  proc fsync_file*(f: File) =
+    f.flush_file
+    discard fsync(f.get_os_file_handle)
+
+else:
+  proc fsync_file*(f: File) =
+    f.flush_file
+
+proc commit*(store: EdStore) =
+  ## Make buffered appends durable per the store's durability level. The
+  ## first-class commit point: future rungs (quorum replication) extend this,
+  ## not the append path.
+  if store.segment == nil or not store.dirty:
+    return
+  if store.durability in {FsyncPerTick, FsyncPerOp}:
+    store.segment.fsync_file
+  else:
+    store.segment.flush_file
+  store.dirty = false
+
+proc append*(
+    store: EdStore, msg: Message, epoch: int64, flags: set[EdFlags]
+) =
+  ## Append one canonical op. `flags` are the container's -- an object synced
+  ## nowhere (no SYNC flag) is ephemeral by contract and doesn't persist either.
+  ## The entry is a copy: the fanned-out message is never mutated here.
+  do_assert not store.read_only, "can't append to a read-only store"
+  assert msg.kind in LOGGED_KINDS
+  if flags * {SYNC_LOCAL, SYNC_REMOTE} == {}:
+    return
+  var entry = msg
+  entry.epoch = epoch
+  entry.flags = flags
+  store.segment.write_line entry.to_entry_line
+  store.dirty = true
+  inc store.entries_since_snapshot
+  if store.durability == FsyncPerOp:
+    store.commit
+
+proc open_segment*(store: EdStore, after_lsn: int64) =
+  ## Open a fresh append segment whose entries all follow `after_lsn`. The
+  ## previous segment (if any) becomes immutable.
+  do_assert not store.read_only
+  if store.segment != nil:
+    store.commit
+    store.segment.close
+  create_dir(store.path / LOG_DIR)
+  store.segment_name = LOG_DIR / segment_file(store.epoch, after_lsn)
+  store.segment = open(store.path / store.segment_name, fm_append)
+  store.dirty = false
+
+proc close_store*(store: EdStore) =
+  ## Flush and close. Idempotent.
+  if store.segment != nil:
+    store.commit
+    store.segment.close
+    store.segment = nil
+
+proc write_head*(store: EdStore) =
+  ## HEAD is a hint rewritten atomically at open/rotate; recovery validates
+  ## manifests/segments itself and never trusts HEAD blindly.
+  let head =
+    Head(
+      snapshot: store.snapshot_name,
+      segment: store.segment_name,
+      epoch: store.epoch,
+    )
+  write_file(store.path / "HEAD.tmp", head.to_head)
+  move_file(store.path / "HEAD.tmp", store.path / "HEAD")
+
+proc scan_segments*(
+    root: string
+): seq[tuple[path: string, epoch, after_lsn: int64]] =
+  ## All segments, name-sorted (zero-padded names make lexical = numeric order).
+  let dir = root / LOG_DIR
+  if not dir_exists(dir):
+    return
+  for kind, path in walk_dir(dir):
+    if kind == pc_file:
+      let (ok, epoch, after_lsn) = parse_segment_file(path.extract_filename)
+      if ok:
+        result.add((path, epoch, after_lsn))
+  result.sort
+
+proc scan_snapshots*(root: string): seq[tuple[dir: string, lsn: int64]] =
+  ## Snapshot dirs, oldest first. tmp-* (crashed mid-write) never parse and are
+  ## skipped; open_store deletes them.
+  let dir = root / SNAPSHOTS_DIR
+  if not dir_exists(dir):
+    return
+  for kind, path in walk_dir(dir):
+    if kind == pc_dir:
+      let (ok, lsn) = parse_snapshot_dir(path.extract_filename)
+      if ok:
+        result.add((path, lsn))
+  result.sort
+
+iterator read_entries*(path: string): Message =
+  ## Entries of one segment in file order, streamed a line at a time (a segment
+  ## can grow large between snapshots). A torn final line (mid-write crash) is
+  ## dropped with a notice; a bad line anywhere else is real corruption and
+  ## raises StoreError -- silently skipping history would be data loss.
+  log_defaults
+  let f = open(path, fm_read)
+  try:
+    var line = ""
+    var line_num = 0
+    while f.read_line(line):
+      inc line_num
+      let (ok, msg) = parse_entry(line)
+      if not ok:
+        # Only EOF distinguishes a torn tail from mid-file corruption; the
+        # stdio EOF flag isn't set until a read past the end fails, so probe.
+        var lookahead = ""
+        if f.read_line(lookahead):
+          raise StoreError.init(
+            "corrupt store entry at " & path & ":" & $line_num
+          )
+        notice "dropping torn tail entry", path, line = line_num
+        break
+      yield msg
+  finally:
+    f.close

--- a/src/ed/components/store/restore.nim
+++ b/src/ed/components/store/restore.nim
@@ -1,0 +1,235 @@
+import std/[os, algorithm, tables, sets, strutils]
+import ed/types {.all.}
+import ed/zens/[contexts, private]
+import ed/utils/[misc, logging, crc32]
+import ed/components/subscriptions/core {.all.}
+import ./format
+import ./log as store_log
+
+# Store open + restore + time-travel (docs/persistence.md). Restore feeds the
+# newest valid snapshot and the log tail through `process_message` -- the same
+# idempotent, frontier-guarded apply engine live sync uses -- with
+# `ctx.replaying` set so the loopback/own-op guards stand down (entries carry
+# our own id) and nothing re-publishes or re-appends. It must run before any
+# subscriber attaches or type watcher registers, on the context's home thread.
+
+privileged
+log_defaults
+
+proc load_snapshot(
+    path: string, to_lsn: int64
+): tuple[found: bool, manifest: Manifest, lines: seq[string]] =
+  ## The newest fully-valid snapshot at or below `to_lsn`: manifest parses,
+  ## every object file present with a matching crc. A damaged snapshot falls
+  ## back to the previous one -- the log tail covers the gap.
+  var snaps = scan_snapshots(path)
+  snaps.reverse
+  for (dir, lsn) in snaps.items:
+    if lsn > to_lsn:
+      continue
+    let manifest_path = dir / "manifest.json"
+    if not file_exists(manifest_path):
+      continue
+    let (ok, manifest) = parse_manifest(read_file(manifest_path))
+    if not ok:
+      warn "skipping snapshot with invalid manifest", dir
+      continue
+    if not manifest.platform_ok:
+      raise StoreError.init(
+        "store snapshot written on an incompatible platform: " & dir
+      )
+    var lines = new_seq[string](manifest.objects.len)
+    var valid = true
+    for i, entry in manifest.objects:
+      let file = dir / entry.file
+      if not file_exists(file):
+        valid = false
+        break
+      let line = read_file(file).strip(leading = false, chars = {'\n'})
+      if crc32_hex(line) != entry.crc:
+        valid = false
+        break
+      lines[i] = line
+    if not valid:
+      warn "skipping snapshot with damaged object files", dir
+      continue
+    return (true, manifest, lines)
+
+proc restore_state(
+    self: EdContext, path: string, to_lsn: int64
+): tuple[max_lsn: int64, max_own_op: int64] =
+  ## Snapshot + tail replay onto a fresh context, bounded by `to_lsn`
+  ## (int64.high = everything). Caller sets/clears `replaying`.
+  assert self.replaying
+  var watermark = 0'i64
+  let (found, manifest, lines) = load_snapshot(path, to_lsn)
+  if not found:
+    # No usable snapshot means the log must reach back to genesis, or the
+    # restore would silently canonize a truncated world (retention prunes
+    # early segments once a snapshot covers them; if every retained snapshot
+    # is damaged, refusing to start is the only honest answer).
+    let segments = scan_segments(path)
+    if segments.len > 0 and segments[0].after_lsn > 0:
+      raise StoreError.init(
+        "no valid snapshot, and log history starts after lsn " &
+          $segments[0].after_lsn & "; refusing a partial restore"
+      )
+  if found:
+    # Children before parents (reverse manifest order), mirroring
+    # add_subscriber's newest-first push: a parent's bin then links real
+    # containers instead of placeholders.
+    for i in countdown(lines.high, 0):
+      let (ok, msg) = parse_entry(lines[i])
+      if not ok:
+        raise StoreError.init(
+          "corrupt snapshot entry: " & manifest.objects[i].file
+        )
+      self.process_message(msg)
+    watermark = manifest.lsn
+    self.applied_lsn = manifest.lsn
+    self.op_id_counter = manifest.op_id_counter
+    result.max_lsn = manifest.lsn
+
+  # Log tail: segments starting at or after the watermark, in (epoch, lsn)
+  # name order. Segments from before it hold only covered ops -- and replaying
+  # them would resurrect create/destroy pairs the snapshot already resolved
+  # (a CREATE is unordered, so the frontier can't drop it; its DESTROY at
+  # lsn <= watermark would be dropped -> zombie object).
+  block tail:
+    for seg in scan_segments(path):
+      if found and seg.after_lsn < watermark:
+        continue
+      for msg in read_entries(seg.path):
+        if msg.lsn > to_lsn:
+          # Positional cut: state as of `to_lsn` is everything the log
+          # recorded up to (and including) that stamped op.
+          break tail
+        if msg.lsn > 0:
+          result.max_lsn = max(result.max_lsn, msg.lsn)
+        if msg.origin == self.id and msg.op_id > 0:
+          # Rebuild own-op reconciliation state (a later DESTROY deletes its
+          # entry again -- set before applying).
+          result.max_own_op = max(result.max_own_op, msg.op_id)
+          self.latest_op_id[msg.object_id] = msg.op_id
+        self.process_message(msg)
+
+  # Counter hygiene. lsn_counter must clear every LSN the log ever stamped --
+  # ops dropped during replay (a destroyed object's tail ops) never advanced
+  # applied_lsn, so trust the scanned maximum, not the frontier. A reused LSN
+  # would be stale-dropped by every surviving follower forever.
+  self.applied_lsn = max(self.applied_lsn, result.max_lsn)
+  self.lsn_counter = max(self.lsn_counter, result.max_lsn)
+  self.op_id_counter = max(self.op_id_counter, result.max_own_op)
+
+  # Registry order: restore materialized children-first, inverting insertion
+  # order. add_subscriber pushes newest-first (reversed), so leave it inverted
+  # and a post-restart subscriber gets parents before children -- breaking the
+  # deferred-fill invariant (publish.nim). Rebuild manifest order, tail
+  # arrivals after.
+  if found:
+    self.pack_objects
+    var ordered: OrderedTable[string, ref EdBodyBase]
+    for entry in manifest.objects:
+      if entry.oid in self.objects:
+        ordered[entry.oid] = self.objects[entry.oid]
+    for id, body in self.objects:
+      if id notin ordered:
+        ordered[id] = body
+    self.objects = ordered
+
+proc open_store*(
+    self: EdContext,
+    path: string,
+    snapshot_every = 0,
+    durability = FlushPerTick,
+    retain_snapshots = 2,
+): EdStore {.discardable.} =
+  ## Attach a durable store to an authority context, restoring any existing
+  ## state from it first. A post-init call, before anything subscribes and
+  ## before the context holds objects (mirrors `subscribe`); everything the
+  ## context does afterwards is logged. The registered-type set must match the
+  ## build that wrote the store.
+  do_assert self.is_authority,
+    "only the authority context persists; a follower replicates from it"
+  do_assert self.store == nil, "store already open"
+  do_assert self.subscribers.len == 0,
+    "open the store before anything subscribes"
+  do_assert self.objects.len == 0,
+    "open the store before creating objects"
+
+  create_dir(path)
+  create_dir(path / LOG_DIR)
+  create_dir(path / SNAPSHOTS_DIR)
+  for kind, p in walk_dir(path / SNAPSHOTS_DIR):
+    if kind == pc_dir and p.extract_filename.starts_with("tmp-"):
+      remove_dir(p) # crashed mid-snapshot; the manifest never sealed it
+
+  # Epoch: strictly above anything this store has seen, so a zombie
+  # incarnation's ops can never be mistaken for ours.
+  var epoch = 0'i64
+  for seg in scan_segments(path):
+    epoch = max(epoch, seg.epoch)
+  let head_path = path / "HEAD"
+  if file_exists(head_path):
+    let (ok, head) = parse_head(read_file(head_path))
+    if ok:
+      epoch = max(epoch, head.epoch)
+
+  let store = EdStore(
+    path: path,
+    epoch: epoch + 1,
+    durability: durability,
+    snapshot_every: snapshot_every,
+    retain_snapshots: max(1, retain_snapshots),
+  )
+
+  self.replaying = true
+  try:
+    discard self.restore_state(path, to_lsn = int64.high)
+  finally:
+    self.replaying = false
+
+  self.epoch = store.epoch
+  self.seen_epoch = store.epoch
+  let snaps = scan_snapshots(path)
+  if snaps.len > 0:
+    store.snapshot_name = SNAPSHOTS_DIR / snapshot_dir(snaps[^1].lsn)
+  store.open_segment(after_lsn = self.lsn_counter)
+  self.store = store
+  store.write_head
+  debug "store opened",
+    path, epoch = store.epoch, objects = self.objects.len,
+    lsn = self.lsn_counter
+  result = store
+
+proc replay*(
+    _: type EdContext,
+    path: string,
+    to_lsn: int64 = int64.high,
+    id = "replay-" & generate_id(),
+): EdContext =
+  ## A read-only historical view of a store as of `to_lsn` -- the time-travel
+  ## debug tool. Fresh non-authority context, no segment opened, no epoch
+  ## bump, no HEAD write: it can coexist with the live authority on the same
+  ## store directory. Writes on the view are local-only and never persisted.
+  ## History below the retention horizon raises StoreError.
+  let snaps = scan_snapshots(path)
+  let segments = scan_segments(path)
+  if to_lsn != int64.high:
+    var reachable = segments.len > 0 and segments[0].after_lsn == 0
+    for (_, lsn) in snaps.items:
+      if lsn <= to_lsn:
+        reachable = true
+    if not reachable:
+      raise StoreError.init(
+        "lsn " & $to_lsn & " is below retained history; " &
+          "increase retain_snapshots"
+      )
+
+  result = EdContext.init(id = id)
+  result.store = EdStore(path: path, read_only: true)
+  result.replaying = true
+  try:
+    discard result.restore_state(path, to_lsn)
+  finally:
+    result.replaying = false

--- a/src/ed/components/store/restore.nim
+++ b/src/ed/components/store/restore.nim
@@ -56,13 +56,24 @@ proc load_snapshot(
     return (true, manifest, lines)
 
 proc restore_state(
-    self: EdContext, path: string, to_lsn: int64
+    self: EdContext, path: string, to_lsn: int64, allow_schema_mismatch = false
 ): tuple[max_lsn: int64, max_own_op: int64] =
   ## Snapshot + tail replay onto a fresh context, bounded by `to_lsn`
   ## (int64.high = everything). Caller sets/clears `replaying`.
   assert self.replaying
   var watermark = 0'i64
   let (found, manifest, lines) = load_snapshot(path, to_lsn)
+  if found and manifest.schema != 0 and manifest.schema != ED_SCHEMA_VERSION and
+      not allow_schema_mismatch:
+    # The store was written by a build with a different app-schema version
+    # (a persisted type changed shape). tid = hash(name) can't detect that per
+    # object, so materializing would deserialize garbage silently. Refuse
+    # loudly; `allow_schema_mismatch` is the "I know it's compatible" override.
+    raise StoreError.init(
+      "store schema version " & $manifest.schema & " != build's " &
+        $ED_SCHEMA_VERSION & " (a persisted type changed); pass " &
+        "allow_schema_mismatch = true to open anyway"
+    )
   if not found:
     # No usable snapshot means the log must reach back to genesis, or the
     # restore would silently canonize a truncated world (retention prunes
@@ -143,12 +154,14 @@ proc open_store*(
     snapshot_every = 0,
     durability = FlushPerTick,
     retain_snapshots = 2,
+    allow_schema_mismatch = false,
 ): EdStore {.discardable.} =
   ## Attach a durable store to an authority context, restoring any existing
   ## state from it first. A post-init call, before anything subscribes and
   ## before the context holds objects (mirrors `subscribe`); everything the
   ## context does afterwards is logged. The registered-type set must match the
-  ## build that wrote the store.
+  ## build that wrote the store; opening a store whose `schema` slot differs
+  ## from `ED_SCHEMA_VERSION` raises unless `allow_schema_mismatch` is set.
   do_assert self.is_authority,
     "only the authority context persists; a follower replicates from it"
   do_assert self.store == nil, "store already open"
@@ -185,7 +198,7 @@ proc open_store*(
 
   self.replaying = true
   try:
-    discard self.restore_state(path, to_lsn = int64.high)
+    discard self.restore_state(path, int64.high, allow_schema_mismatch)
   finally:
     self.replaying = false
 
@@ -207,12 +220,15 @@ proc replay*(
     path: string,
     to_lsn: int64 = int64.high,
     id = "replay-" & generate_id(),
+    allow_schema_mismatch = false,
 ): EdContext =
   ## A read-only historical view of a store as of `to_lsn` -- the time-travel
   ## debug tool. Fresh non-authority context, no segment opened, no epoch
   ## bump, no HEAD write: it can coexist with the live authority on the same
   ## store directory. Writes on the view are local-only and never persisted.
-  ## History below the retention horizon raises StoreError.
+  ## History below the retention horizon raises StoreError. A schema-version
+  ## mismatch raises unless `allow_schema_mismatch` is set (inspecting an
+  ## older-build store is a legitimate reason to override).
   let snaps = scan_snapshots(path)
   let segments = scan_segments(path)
   if to_lsn != int64.high:
@@ -230,6 +246,6 @@ proc replay*(
   result.store = EdStore(path: path, read_only: true)
   result.replaying = true
   try:
-    discard result.restore_state(path, to_lsn)
+    discard result.restore_state(path, to_lsn, allow_schema_mismatch)
   finally:
     result.replaying = false

--- a/src/ed/components/store/snapshot.nim
+++ b/src/ed/components/store/snapshot.nim
@@ -1,0 +1,126 @@
+import std/[os, algorithm, tables]
+import ed/[core, types {.all.}]
+import ed/zens/[contexts, private]
+import ed/utils/[logging, crc32]
+import ./format, ./log
+
+# Snapshot writing + retention (docs/persistence.md). A snapshot is a
+# directory of per-object files (each one CREATE-shaped entry line, full
+# contents) sealed by a manifest written last -- the manifest is the commit
+# marker, so a crash mid-snapshot leaves an ignorable tmp dir, never a
+# half-trusted snapshot. The active segment rotates at the watermark, so every
+# non-active segment is immutable.
+
+privileged
+
+proc write_file_synced(path, content: string) =
+  var f = open(path, fm_write)
+  try:
+    f.write(content)
+    f.fsync_file
+  finally:
+    f.close
+
+when defined(posix):
+  import std/posix
+
+  proc fsync_dir(path: string) =
+    let fd = posix.open(path.cstring, O_RDONLY)
+    if fd >= 0:
+      discard fsync(fd)
+      discard close(fd)
+
+else:
+  proc fsync_dir(path: string) =
+    discard
+
+proc prune_retention(store: EdStore) =
+  ## Keep the newest `retain_snapshots` snapshot dirs; older ones go, along
+  ## with every segment fully covered by the oldest retained watermark.
+  ## Retention bounds replay_to: history below it is gone.
+  let snaps = scan_snapshots(store.path)
+  if snaps.len <= store.retain_snapshots:
+    return
+  let oldest_kept = snaps[snaps.len - store.retain_snapshots].lsn
+  for (dir, lsn) in snaps.items:
+    if lsn < oldest_kept:
+      remove_dir(dir)
+  let segments = scan_segments(store.path)
+  for i, seg in segments:
+    # A segment is disposable once a *later* segment starts at or below the
+    # oldest retained watermark -- everything in it predates retained history.
+    # The active segment is never a candidate (nothing starts after it).
+    if i + 1 < segments.len and segments[i + 1].after_lsn <= oldest_kept:
+      remove_file(seg.path)
+
+proc snapshot*(self: EdContext): string {.discardable.} =
+  ## Write a full-state snapshot at the current watermark, rotate the segment,
+  ## prune retention. Returns the snapshot directory.
+  log_defaults
+  do_assert self.logs_ops,
+    "snapshot requires an authority with a writable store"
+  self.pack_objects
+  let store = self.store
+  # The authority applies its own writes synchronously and appends at stamp
+  # time, so every op <= lsn_counter is already in the log -- lsn_counter *is*
+  # the watermark. (applied_lsn is wrong here: the authority never advances it
+  # for its own stamps.)
+  let watermark = self.lsn_counter
+  # The log must durably contain everything <= watermark before a snapshot
+  # claims to cover it.
+  store.commit
+
+  var manifest = Manifest.init(store.epoch, watermark, self.op_id_counter)
+  let final_name = SNAPSHOTS_DIR / snapshot_dir(watermark)
+  let tmp_dir = store.path / SNAPSHOTS_DIR / ("tmp-" & snapshot_dir(watermark))
+  let final_dir = store.path / final_name
+
+  # A valid snapshot at this watermark already covers current state: anything
+  # since it (lsn-0 CREATEs -- stamped ops would have moved the watermark)
+  # lives in the post-rotation segments and replays as tail. Keep it --
+  # replacing it would open a crash window between delete and rename where the
+  # only retained snapshot is gone and its covered segments are already pruned.
+  if dir_exists(final_dir) and
+      file_exists(final_dir / "manifest.json") and
+      parse_manifest(read_file(final_dir / "manifest.json")).ok:
+    store.entries_since_snapshot = 0
+    return final_dir
+  remove_dir(final_dir) # invalid/damaged leftover; was never trusted
+  remove_dir(tmp_dir)
+  create_dir(tmp_dir)
+
+  var idx = 0
+  for id, body in self.objects:
+    if body == nil or body.destroyed:
+      continue
+    if body.placeholder:
+      # Placeholders self-heal: a parent's bin re-mints them on restore.
+      # Persisting one as a normal record would restore a real-but-empty
+      # object -- silent corruption.
+      continue
+    if body.flags * {SYNC_LOCAL, SYNC_REMOTE} == {}:
+      # Same predicate as append: what the log never sees, the snapshot must
+      # not contain, or snapshot != replay(log).
+      continue
+    inc idx
+    var msg = body.build_create(body, true)
+    msg.epoch = store.epoch
+    let line = msg.to_entry_line
+    let file = object_file(idx, id)
+    write_file_synced(tmp_dir / file, line & "\n")
+    manifest.objects.add ManifestEntry(
+      file: file, oid: id, tid: msg.type_id, crc: crc32_hex(line)
+    )
+
+  write_file_synced(tmp_dir / "manifest.json", manifest.to_manifest & "\n")
+  fsync_dir(tmp_dir)
+  move_dir(tmp_dir, final_dir)
+  fsync_dir(store.path / SNAPSHOTS_DIR)
+
+  store.snapshot_name = final_name
+  store.open_segment(after_lsn = watermark)
+  store.write_head
+  store.entries_since_snapshot = 0
+  store.prune_retention
+  debug "snapshot written", watermark, objects = manifest.objects.len
+  result = final_dir

--- a/src/ed/components/subscriptions/core.nim
+++ b/src/ed/components/subscriptions/core.nim
@@ -16,6 +16,8 @@ import ed/[core, types {.all.}], ed/zens/[contexts, private, initializers {.all.
 import ed/components/private/global_state
 import ed/lifecycle
 import ../type_registry
+import ../store/log as store_log
+import ../store/snapshot as store_snapshot
 import ./[wire {.all.}, publish {.all.}, eviction {.all.}, paging {.all.}]
 
 privileged
@@ -803,16 +805,41 @@ proc process_message(
         fallback.incl $id
       fallback
 
-  if self.id in source:
+  if self.id in source and not self.replaying:
     # Our own id in the source set means a message looped back to us -- the
     # publish-side source filter should prevent it. Skip rather than risk
     # double-applying it, and warn so a routing regression stays visible.
+    # (Replay is the sanctioned exception: logged entries are our own ops.)
     warn "dropping message that looped back to its source",
       ctx = self.id, kind = $msg.kind, source = source.to_seq.join(",")
     return
 
   received_message_counter.inc(label_values = [self.metrics_label])
   debug "receiving", msg, topics = "networking"
+
+  # A stamped op from a newer authority epoch: the authority restarted from its
+  # store (or a successor took over). It may legitimately reissue LSNs its
+  # predecessor fanned out but never made durable, so adopt the new timeline --
+  # reset the frontier instead of stale-dropping everything the new incarnation
+  # sends (docs/persistence.md). Trusted only from an upstream (the same rule
+  # as content overwrites): epoch is a bare wire field, and letting any peer
+  # zero the frontier re-opens delta ops to double-application. Not during
+  # replay: a restored authority's own log spans epochs, but its LSNs are
+  # monotonic across them by construction.
+  if msg.lsn > 0 and msg.epoch > self.seen_epoch and not self.replaying:
+    var from_up = false
+    for src in source:
+      if src in self.upstream_ctx_ids:
+        from_up = true
+        break
+    if from_up:
+      if self.seen_epoch > 0:
+        debug "authority epoch advanced; resetting frontier",
+          seen = self.seen_epoch, epoch = msg.epoch,
+          frontier = self.applied_lsn
+        self.applied_lsn = 0
+        self.latest_op_id.clear
+      self.seen_epoch = msg.epoch
 
   # Ordered-op idempotency: a stamped op at or below our frontier was already
   # applied or superseded -- drop it. lsn == 0 (CREATE / unordered) always
@@ -831,7 +858,11 @@ proc process_message(
   #    snapping back to its own stale echoes. Our *latest* own write (op_id ==
   #    latest) is applied, so a contended register still converges to the
   #    canonical value. (The op_id-superseded rule; see consistency.md.)
-  if msg.origin == self.id:
+  # Replay bypasses this entirely: logged entries carry our own origin, but
+  # nothing was "already applied optimistically" on a fresh registry -- the
+  # delta short-circuit would silently drop every collection op we ever
+  # originated. The LSN frontier above still dedups double-covered segments.
+  if msg.origin == self.id and not self.replaying:
     let superseded =
       msg.delta or
       msg.op_id < self.latest_op_id.get_or_default(msg.object_id, 0'i64)
@@ -1158,6 +1189,15 @@ proc tick*(
     if poll == false or
         ((count > 0 or not blocking) and get_mono_time() > recv_until):
       break
+
+  # Durable-store maintenance: auto-snapshot on the ops-since-snapshot
+  # threshold, then make this tick's buffered appends durable (the per-tick
+  # commit point -- see StoreDurability).
+  if self.logs_ops:
+    if self.store.snapshot_every > 0 and
+        self.store.entries_since_snapshot >= self.store.snapshot_every:
+      self.snapshot()
+    self.store.commit
 
 proc materialize_impl(self: EdContext, id: string) {.gcsafe.} =
   ## Wired onto a context at subscribe time and called by the read accessors when

--- a/src/ed/components/subscriptions/publish.nim
+++ b/src/ed/components/subscriptions/publish.nim
@@ -11,6 +11,7 @@ import pkg/flatty
 import ed/[core, types {.all.}], ed/zens/[contexts, private, initializers {.all.}]
 import ed/components/private/global_state
 import ed/lifecycle
+import ed/components/store/log as store_log
 import ./wire {.all.}
 
 privileged
@@ -56,6 +57,13 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   privileged
   log_defaults("ed publishing")
 
+  # A replayed DESTROY re-enters here via change_receiver; publishing it again
+  # would stamp a fresh LSN and re-append it to the log every restart. Nothing
+  # new is happening during replay -- skip. (No subscribers exist then either;
+  # restore runs before anything attaches.)
+  if self.ctx.replaying:
+    return
+
   trace "publishing destroy", ed_id = self.id
   # Build the DESTROY once and stamp it with the global LSN (authority only),
   # so every subscriber receives the same ordered op. DESTROY is ordered like
@@ -73,6 +81,8 @@ proc publish_destroy*[T, O](self: Ed[T, O], op_ctx: OperationContext) =
   when defined(ed_trace):
     msg.trace = \"{get_stack_trace()}\n\nop:\n{op_ctx.trace}"
   self.ctx.stamp_lsn(msg)
+  if self.ctx.logs_ops:
+    self.ctx.store.append(msg, self.ctx.epoch, self.flags)
 
   let targets = self.ctx.subscribers.filter_it(it.ctx_id notin op_ctx.source)
   self.ctx.fanout(msg, op_ctx, self.flags, targets)
@@ -164,8 +174,16 @@ proc publish_changes*[T, O](
   privileged
   log_defaults("ed publishing")
   trace "publish_changes", op_ctx
-  if self.ctx.subscribers.len > 0:
-    var has_eligible = false
+  # Replay feeds logged ops back through the apply machinery; re-publishing
+  # them would re-stamp and re-append. Nothing new is happening -- skip.
+  if self.ctx.replaying:
+    return
+  if self.ctx.subscribers.len > 0 or self.ctx.logs_ops:
+    # The store counts as a permanently-eligible subscriber: a headless
+    # authority (no subscribers yet, or only the op's originator) must still
+    # build, stamp, and append its canonical ops or they'd never become
+    # durable. Only the fanout below stays gated on real subscribers.
+    var has_eligible = self.ctx.logs_ops
     for sub in self.ctx.subscribers:
       if sub.ctx_id notin op_ctx.source:
         has_eligible = true
@@ -261,6 +279,14 @@ proc publish_changes*[T, O](
         if originating:
           self.ctx.latest_op_id[msg.object_id] = out_op_id
         self.ctx.stamp_lsn(msg)
+
+      # Append between stamp and fanout: an op's durable form is exactly what
+      # fans out, and an op is never visible to peers in an order the log
+      # doesn't have. (The per-key sends above are per-subscriber lsn-0
+      # duplicates of these packed ops -- they must not be captured.)
+      if self.ctx.logs_ops:
+        for msg in msgs:
+          self.ctx.store.append(msg, self.ctx.epoch, self.flags)
 
       if self.ctx.is_authority:
         # Canonical ops originate from the authority. Re-origin the source to us

--- a/src/ed/types.nim
+++ b/src/ed/types.nim
@@ -307,6 +307,32 @@ type
     state*: FetchState
     obj*: ref EdBase
 
+  StoreDurability* = enum
+    ## When an appended op is considered committed (docs/persistence.md) -- the
+    ## durability-ladder rungs that exist today. Quorum replication is a future
+    ## rung on the same commit path.
+    FlushPerTick  ## buffered appends, flushed to the OS once per tick (default)
+    FsyncPerTick  ## flush + fsync once per tick
+    FsyncPerOp    ## flush + fsync after every append
+
+  EdStore* = ref object
+    ## The durable store attached to an authority context: append-only JSONL log
+    ## segments + snapshot directories under `path` (docs/persistence.md). The
+    ## layout is git-shaped on purpose -- rotated segments are immutable, a
+    ## snapshot is per-object files sealed by a manifest -- so a future "an ed
+    ## project is a git repo" layer commits the directory as-is.
+    path*: string
+    epoch*: int64            ## this session's epoch (max seen + 1 at open)
+    read_only*: bool         ## a replay view: no segment, appends forbidden
+    durability*: StoreDurability
+    snapshot_every*: int     ## appended entries between auto-snapshots (0 = manual)
+    retain_snapshots*: int   ## snapshot dirs kept; covered segments pruned with them
+    segment*: File           ## active append segment (nil when read_only)
+    segment_name*: string    ## relative to `path`
+    snapshot_name*: string   ## newest snapshot dir, relative to `path` ("" = none)
+    entries_since_snapshot*: int
+    dirty*: bool             ## unflushed buffered appends
+
   EdContext* = ref object
     ## Central coordination object managing `Ed` container lifecycle, subscriptions,
     ## and message passing between threads/network.
@@ -324,6 +350,19 @@ type
     applied_lsn*: int64   # highest global LSN applied (frontier)
     op_id_counter*: int64 # next op id to assign to a write we originate
     latest_op_id*: Table[string, int64]  # object_id -> our highest op id (own-op reconciliation)
+    # Phase 2: durable log + snapshots (docs/persistence.md)
+    store*: EdStore       # nil = no persistence
+    epoch*: int64         # authority epoch, stamped onto ordered ops; bumped on
+                          # every store open so a restarted authority's ops are
+                          # distinguishable from a stale incarnation's
+    seen_epoch*: int64    # follower: highest epoch observed on a stamped op. A
+                          # higher one resets the frontier -- the restarted
+                          # authority may legitimately reissue LSNs it never
+                          # made durable
+    replaying*: bool      # a restore/replay is feeding the log back through
+                          # process_message: bypass the loopback/own-op guards
+                          # (entries carry our own id) and suppress
+                          # publish/stamp/append (nothing new is happening)
     # Materialize-on-access (partial replicas). `materialize` is wired up at
     # subscribe time (it needs fetch/tick) and called by the read accessors when
     # they touch a placeholder. In PARTIAL the call pumps I/O until the object
@@ -483,6 +522,14 @@ type
     build_message: proc(
       body: ref EdBodyBase, change: BaseChange, id: string, trace: string
     ): Message {.gcsafe.}
+
+    # The canonical CREATE for this body right now. `contents = false` skips
+    # serializing `tracked` entirely (a handle -- the LAZY push; serializing a
+    # big table just to blank it is the cost LAZY exists to avoid); `true` is
+    # the full dump regardless of LAZY, shared by publish_create (wire) and
+    # the snapshot writer (disk).
+    build_create:
+      proc(body: ref EdBodyBase, contents: bool): Message {.gcsafe.}
 
     publish_create: proc(
       sub = Subscription(),

--- a/src/ed/utils/crc32.nim
+++ b/src/ed/utils/crc32.nim
@@ -1,0 +1,27 @@
+import std/strutils
+
+# CRC-32 (IEEE 802.3). Store integrity checks need a checksum that is stable
+# across Nim versions and builds -- std/hashes guarantees neither. The threat
+# model is torn/corrupted writes, not tampering.
+
+const crc32_table = block:
+  var table: array[256, uint32]
+  for i in 0 ..< 256:
+    var c = uint32(i)
+    for _ in 0 ..< 8:
+      c =
+        if (c and 1) != 0:
+          0xedb88320'u32 xor (c shr 1)
+        else:
+          c shr 1
+    table[i] = c
+  table
+
+proc crc32*(s: open_array[char]): uint32 =
+  result = 0xffffffff'u32
+  for ch in s:
+    result = crc32_table[(result xor uint32(ch)) and 0xff] xor (result shr 8)
+  result = not result
+
+proc crc32_hex*(s: open_array[char]): string =
+  crc32(s).to_hex(8).to_lower_ascii

--- a/src/ed/utils/logging.nim
+++ b/src/ed/utils/logging.nim
@@ -23,7 +23,10 @@ when chronicles_enabled == "on":
   template log_defaults*(log_topics = "ed") =
     log_scope:
       topics = log_topics
-      thread_ctx = active_ctx.id
+      # A thread that only uses explicit contexts never mints the implicit
+      # thread ctx -- an unguarded active_ctx.id turns the first emitted
+      # warn/notice on it into a nil deref.
+      thread_ctx = (if active_ctx == nil: "" else: active_ctx.id)
 
 else:
   # Don't include chronicles unless it's specifically enabled.

--- a/src/ed/utils/misc.nim
+++ b/src/ed/utils/misc.nim
@@ -55,6 +55,8 @@ type
 
   ConnectionError* = object of ZenError
 
+  StoreError* = object of ZenError
+
 # Exceptions
 
 template fail*(msg: string) =

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -13,6 +13,7 @@ import
 
 import ./private
 import ed/lifecycle
+import ed/components/store/log as store_log
 
 export EdContext
 
@@ -159,6 +160,14 @@ proc stamp_lsn*(self: EdContext, msg: var Message) =
   if self.is_authority and msg.lsn == 0 and
       msg.kind in {ASSIGN, UNASSIGN, TOUCH, DESTROY, PACKED}:
     msg.lsn = self.next_lsn
+    msg.epoch = self.epoch
+
+proc logs_ops*(self: EdContext): bool =
+  ## Whether this context appends canonical ops to a durable log right now.
+  ## Replay feeds logged ops back through the apply machinery, so it must never
+  ## publish/stamp/append -- nothing new is happening (docs/persistence.md).
+  self.is_authority and self.store != nil and not self.store.read_only and
+    not self.replaying
 
 proc `[]`*[T, O](self: EdContext, src: Ed[T, O]): Ed[T, O] =
   result = Ed[T, O](self.resolve_proxy(self.objects[src.id]))
@@ -237,14 +246,25 @@ proc tick_keepalives*(self: EdContext) {.gcsafe.} =
   self.harvest_reactor
 
 proc clear*(self: EdContext) =
-  ## Remove all objects from this context.
+  ## Remove all objects from this context. Raises `StoreError` on a
+  ## store-backed authority: a wiped registry with no messages would silently
+  ## desync the log from canonical state -- there is no CLEAR op.
+  if self.store != nil and not self.store.read_only:
+    raise StoreError.init(
+      "can't clear a store-backed authority; destroy objects instead"
+    )
   debug "Clearing EdContext"
   self.objects.clear
   self.latest_op_id.clear
   self.objects_need_packing = false
 
 proc close*(self: EdContext) =
-  ## Close network connections and cleanup resources.
+  ## Close network connections and cleanup resources. Detaches the store --
+  ## leaving it attached with its segment closed would make the next mutation
+  ## append to a nil File.
+  if ?self.store:
+    self.store.close_store
+    self.store = nil
   if ?self.reactor:
     private_access Reactor
     self.reactor.socket.close()

--- a/src/ed/zens/initializers.nim
+++ b/src/ed/zens/initializers.nim
@@ -4,6 +4,7 @@ import ed/components/private/global_state
 import ed/types {.all.}, ed/zens/[operations, contexts, private]
 import ed/lifecycle
 import ed/utils/misc # ZenError
+import ed/components/store/log as store_log
 
 # `quote do` (in create_initializer) expands to code referencing `new_ident_node`,
 # so it must be in scope here. Re-exported so it also resolves at `Ed.bootstrap`
@@ -47,6 +48,15 @@ proc relay_fill*[T, O](item: Ed[T, O], op_ctx: OperationContext) =
     item.owner_id = current_owner_id
     item.ctx.owned_by.mget_or_put(current_owner_id, init_hash_set[string]()).incl(
       item.id
+    )
+  # A fill is the one place a placeholder becomes a real object, so it's the
+  # log's creation event for objects whose CREATE arrived after something
+  # referenced them. The bin carries the just-filled contents, which also
+  # covers the fill's own ASSIGN having hit the log before this CREATE (replay
+  # drops ops for unknown ids; the CREATE bin restores the same state).
+  if item.ctx.logs_ops:
+    item.ctx.store.append(
+      item.body.build_create(item.body, true), item.ctx.epoch, item.flags
     )
   item.publish_create(broadcast = true, op_ctx = op_ctx)
 
@@ -246,6 +256,30 @@ proc defaults[T, O](
       self.owner_id = current_owner_id
       ctx.owned_by.mget_or_put(current_owner_id, init_hash_set[string]()).incl(self.id)
 
+  self.body.build_create = proc(
+      body: ref EdBodyBase, contents: bool
+  ): Message {.gcsafe.} =
+    # The canonical CREATE for this body right now. `contents = false` is a
+    # handle (empty-body CREATE; the LAZY push) and skips serialization
+    # entirely. Param-based like build_message -- captures nothing, needs no
+    # release.
+    let bin =
+      if contents:
+        let self = Ed[T, O](body.ctx.resolve_proxy(body))
+        {.gcsafe.}:
+          self.tracked.to_flatty
+      else:
+        ""
+    Message(
+      kind: CREATE,
+      obj: bin,
+      flags: body.flags,
+      type_id: Ed[T, O].tid,
+      object_id: body.id,
+      owner_id: body.owner_id, # synced ownership (see EdBase.owner_id)
+      # source is set by send() based on subscription type
+    )
+
   self.body.publish_create = proc(
       sub: Subscription,
       broadcast: bool,
@@ -255,31 +289,16 @@ proc defaults[T, O](
     log_defaults "ed publishing"
     trace "publish_create", sub
 
-    {.gcsafe.}:
-      # `contents = false` sends a handle: an empty-body CREATE (id + flags,
-      # no data). Used to push LAZY containers to partial subscribers -- the
-      # receiver registers a placeholder and pulls entries per-key.
-      let bin = if contents: body.tracked.to_flatty else: ""
-    let id = body.id
-    let owner_id = body.owner_id
-    let flags = body.flags
+    # `contents = false` sends a handle: an empty-body CREATE (id + flags,
+    # no data). Used to push LAZY containers to partial subscribers -- the
+    # receiver registers a placeholder and pulls entries per-key.
+    let create_msg = body.build_create(body, contents)
 
     template send_msg(src_ctx, sub) =
-      const ed_type_id = Ed[T, O].tid
-
       # Capability filter: don't send an object to a peer that can't materialize
       # its type. Empty `capabilities` = unfiltered (same-build / no handshake).
-      if sub.capabilities.len == 0 or ed_type_id in sub.capabilities:
-        var msg = Message(
-          kind: CREATE,
-          obj: bin,
-          flags: flags,
-          type_id: ed_type_id,
-          object_id: id,
-          owner_id: owner_id,  # synced ownership (see EdBase.owner_id)
-          # source is set by send() based on subscription type
-        )
-
+      if sub.capabilities.len == 0 or create_msg.type_id in sub.capabilities:
+        var msg = create_msg
         when defined(ed_trace):
           msg.trace = get_stack_trace()
 
@@ -292,7 +311,7 @@ proc defaults[T, O](
     if broadcast:
       for sub in ctx.subscribers:
         if sub.ctx_id notin op_ctx.source and
-            not (sub.partial and id notin sub.interest):
+            not (sub.partial and create_msg.object_id notin sub.interest):
           ctx.send_msg(sub)
     ctx.tick_reactor
 
@@ -530,6 +549,12 @@ proc defaults[T, O](
   self.ctx = ctx
 
   if broadcast:
+    # The log's creation event: once per object, here rather than in
+    # publish_create (which re-fires per subscriber and would duplicate). The
+    # bin is the default value -- Ed.init(tracked) mutates *after* defaults, so
+    # initial content reaches the log as the subsequent stamped ops.
+    if ctx.logs_ops:
+      ctx.store.append(body.build_create(body, true), ctx.epoch, body.flags)
     self.publish_create(broadcast = true, op_ctx = op_ctx)
   self
 

--- a/tests/persistence_tests.nim
+++ b/tests/persistence_tests.nim
@@ -485,6 +485,53 @@ proc run*() =
       check not dir_exists(path / "snapshots" / "tmp-000000000000009")
       a.destroy()
 
+    test "schema gate: matching version reopens with no false positive":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p24_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p24_value")
+      value.value = 1
+      a.snapshot()
+      a.destroy()
+      # Same build -> manifest.schema == ED_SCHEMA_VERSION -> opens cleanly.
+      var b = EdContext.init(id = "p24_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p24_value"]).value == 1
+      b.destroy()
+
+    test "schema gate: mismatched version refuses; override opens":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p25_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p25_value")
+      value.value = 1
+      let snap = a.snapshot()
+      a.destroy()
+
+      # Simulate a store written by a build with a different schema version:
+      # rewrite the manifest's schema field, re-sealed so its crc stays valid.
+      let manifest_path = snap / "manifest.json"
+      let (ok, m) = parse_manifest(read_file(manifest_path))
+      check ok
+      var bumped = m
+      bumped.schema = ED_SCHEMA_VERSION + 1
+      write_file(manifest_path, to_manifest(bumped) & "\n")
+
+      var b = EdContext.init(id = "p25_auth", is_authority = true)
+      expect StoreError:
+        b.open_store(path)
+      b.destroy()
+
+      # The override opens it anyway.
+      var c = EdContext.init(id = "p25_auth", is_authority = true)
+      c.open_store(path, allow_schema_mismatch = true)
+      check EdValue[int](c["p25_value"]).value == 1
+      c.destroy()
+
     test "entry format: roundtrip, crc rejection, forward compat":
       var msg = Message(
         kind: ASSIGN,

--- a/tests/persistence_tests.nim
+++ b/tests/persistence_tests.nim
@@ -1,0 +1,549 @@
+import std/[unittest, os, strutils, tables, sets]
+import ed
+import ed/types {.all.} # Message, for the entry-format tests
+import ed/utils/crc32
+import ed/zens/contexts
+import ed/components/subscriptions/core {.all.} # process_message, for the
+                                                # hostile-epoch test
+
+proc store_dir(): string =
+  result = get_temp_dir() / "ed_store_" & generate_id()
+
+proc read_log(path: string): string =
+  ## Concatenated content of every segment, for greppability assertions.
+  for kind, p in walk_dir(path / "log"):
+    if kind == pc_file:
+      result.add read_file(p)
+
+proc run*() =
+  suite "persistence":
+    test "append + restore roundtrip":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p1_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p1_value")
+      var s = EdSeq[string].init(ctx = a, id = "p1_seq")
+      var t = EdTable[string, int].init(ctx = a, id = "p1_table")
+      value.value = 42
+      s.add "one"
+      s.add "two"
+      t["k"] = 7
+      let lsn = a.lsn_counter
+      check lsn > 0
+      a.destroy()
+
+      var b = EdContext.init(id = "p1_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p1_value"]).value == 42
+      check EdSeq[string](b["p1_seq"]).len == 2
+      check "two" in EdSeq[string](b["p1_seq"])
+      check EdTable[string, int](b["p1_table"])["k"] == 7
+      # Counters continue: a new write stamps a strictly higher LSN.
+      check b.lsn_counter == lsn
+      EdValue[int](b["p1_value"]).value = 43
+      check b.lsn_counter > lsn
+      b.destroy()
+
+    test "own-origin collection ops survive replay (no delta-skip)":
+      # Regression for the own-op superseded rule: without the replaying
+      # bypass, every self-originated delta op is silently dropped on replay.
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p2_auth", is_authority = true)
+      a.open_store(path)
+      var s = EdSeq[int].init(ctx = a, id = "p2_seq")
+      s.add 1
+      s.add 2
+      s.add 3
+      a.destroy()
+
+      var b = EdContext.init(id = "p2_auth", is_authority = true)
+      b.open_store(path)
+      check EdSeq[int](b["p2_seq"]).len == 3
+      check EdSeq[int](b["p2_seq"])[2] == 3
+      b.destroy()
+
+    test "content created with zero subscribers is captured":
+      # The headless-authority case: publish_changes used to early-out with no
+      # subscribers, so nothing would be built/stamped/logged.
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p3_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[string].init(ctx = a, id = "p3_value")
+      value.value = "durable"
+      check a.lsn_counter > 0 # stamped despite zero subscribers
+      a.destroy()
+
+      var b = EdContext.init(id = "p3_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[string](b["p3_value"]).value == "durable"
+      b.destroy()
+
+    test "torn tail is dropped; state as of last valid entry":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p4_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p4_value")
+      value.value = 1
+      value.value = 2
+      let segment = path / a.store.segment_name
+      a.destroy()
+
+      # Simulate a mid-write crash: half a line at the end of the segment.
+      let f = open(segment, fm_append)
+      f.write("{\"v\":1,\"epo")
+      f.close
+
+      var b = EdContext.init(id = "p4_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p4_value"]).value == 2
+      EdValue[int](b["p4_value"]).value = 3 # appends still work
+      b.destroy()
+
+    test "mid-file corruption raises StoreError":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p5_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p5_value")
+      value.value = 1
+      value.value = 2
+      let segment = path / a.store.segment_name
+      a.destroy()
+
+      var lines = read_file(segment).strip(leading = false).split('\n')
+      check lines.len >= 3
+      lines[1] = "garbage line"
+      write_file(segment, lines.join("\n") & "\n")
+
+      var b = EdContext.init(id = "p5_auth", is_authority = true)
+      expect StoreError:
+        b.open_store(path)
+      b.destroy()
+
+    test "snapshot + tail restore (pre-snapshot segments not needed)":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p6_auth", is_authority = true)
+      a.open_store(path)
+      var s = EdSeq[int].init(ctx = a, id = "p6_seq")
+      s.add 1
+      s.add 2
+      let genesis_segment = path / a.store.segment_name
+      a.snapshot()
+      s.add 3 # tail, after the watermark
+      a.destroy()
+
+      # Prove restore uses the snapshot: the pre-snapshot segment (which holds
+      # the CREATE and the first two adds) is gone.
+      remove_file(genesis_segment)
+
+      var b = EdContext.init(id = "p6_auth", is_authority = true)
+      b.open_store(path)
+      check EdSeq[int](b["p6_seq"]).len == 3
+      check EdSeq[int](b["p6_seq"])[2] == 3
+      b.destroy()
+
+    test "snapshot_every auto-triggers; retention prunes":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p7_auth", is_authority = true)
+      a.open_store(path, snapshot_every = 5, retain_snapshots = 1)
+      var value = EdValue[int].init(ctx = a, id = "p7_value")
+      for i in 1 .. 12:
+        value.value = i
+        a.tick()
+      var snapshots: seq[string]
+      for kind, p in walk_dir(path / "snapshots"):
+        if kind == pc_dir:
+          snapshots.add p.extract_filename
+      check snapshots.len == 1 # retention pruned the older one
+      # Covered segments went with it: only segments at/after the retained
+      # watermark (plus the active one) remain.
+      var segments: seq[string]
+      for kind, p in walk_dir(path / "log"):
+        if kind == pc_file:
+          segments.add p.extract_filename
+      check segments.len <= 2
+      a.destroy()
+
+      var b = EdContext.init(id = "p7_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p7_value"]).value == 12
+      b.destroy()
+
+    test "replay_to materializes historical state; views never persist":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p8_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p8_value")
+      var lsns: seq[int64]
+      for i in 1 .. 5:
+        value.value = i * 10
+        lsns.add a.lsn_counter
+      a.destroy()
+
+      let view = EdContext.replay(path, to_lsn = lsns[2])
+      check EdValue[int](view["p8_value"]).value == 30
+      check not view.is_authority
+      # A write on the view is local-only.
+      EdValue[int](view["p8_value"]).value = 999
+      view.destroy()
+
+      var b = EdContext.init(id = "p8_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p8_value"]).value == 50 # 999 never persisted
+      b.destroy()
+
+    test "replay_to below retained history raises":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p9_auth", is_authority = true)
+      a.open_store(path, retain_snapshots = 1)
+      var value = EdValue[int].init(ctx = a, id = "p9_value")
+      value.value = 1
+      let early_lsn = a.lsn_counter
+      value.value = 2
+      a.snapshot()
+      value.value = 3
+      a.snapshot() # second snapshot; retention drops the first + its segments
+      a.destroy()
+
+      expect StoreError:
+        discard EdContext.replay(path, to_lsn = early_lsn)
+
+    test "epoch bumps per reopen and is stamped into entries":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p10_auth", is_authority = true)
+      let store_a = a.open_store(path)
+      check store_a.epoch == 1
+      var value = EdValue[int].init(ctx = a, id = "p10_value")
+      value.value = 1
+      a.destroy()
+
+      var b = EdContext.init(id = "p10_auth", is_authority = true)
+      let store_b = b.open_store(path)
+      check store_b.epoch == 2
+      EdValue[int](b["p10_value"]).value = 2
+      b.destroy()
+
+      let log = read_log(path)
+      check "\"epoch\":1" in log
+      check "\"epoch\":2" in log
+
+    test "follower adopts a restarted authority's timeline (epoch reset)":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p11_auth", is_authority = true)
+      a.open_store(path)
+      var follower = EdContext.init(id = "p11_follower")
+      follower.subscribe(a)
+      var value = EdValue[int].init(ctx = a, id = "p11_value")
+      for i in 1 .. 5:
+        value.value = i
+      follower.tick()
+      check follower.applied_lsn == 5
+      let last_segment = path / a.store.segment_name
+      a.destroy()
+
+      # Crash that loses the durable tail: the restarted authority legitimately
+      # reissues LSNs the follower already applied -- under a new epoch.
+      remove_file(last_segment)
+
+      var b = EdContext.init(id = "p11_auth", is_authority = true)
+      b.open_store(path)
+      check b.lsn_counter == 0 # tail lost; timeline restarts
+      follower.subscribe(b)
+      var value2 = EdValue[int].init(ctx = b, id = "p11_value2")
+      value2.value = 77 # stamps lsn 1/2, epoch 2 -- below the follower's old frontier
+      follower.tick()
+      # Without the epoch-aware frontier reset these would be stale-dropped
+      # forever (applied_lsn was 5).
+      check "p11_value2" in follower
+      check EdValue[int](follower["p11_value2"]).value == 77
+      b.destroy()
+      follower.destroy()
+
+    test "restore refuses truncated history (no snapshot, pruned genesis)":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p20_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p20_value")
+      value.value = 1
+      let genesis_segment = path / a.store.segment_name
+      a.snapshot()
+      value.value = 2
+      a.destroy()
+
+      # Damage the only snapshot AND remove pre-watermark history: restoring
+      # just the tail would silently canonize a near-empty world.
+      write_file(path / "snapshots" / "000000000000001" / "manifest.json", "x")
+      remove_file(genesis_segment)
+
+      var b = EdContext.init(id = "p20_auth", is_authority = true)
+      expect StoreError:
+        b.open_store(path)
+      b.destroy()
+
+    test "re-snapshot at an unchanged watermark keeps the existing snapshot":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p21_auth", is_authority = true)
+      a.open_store(path)
+      var value = EdValue[int].init(ctx = a, id = "p21_value")
+      value.value = 1
+      let first = a.snapshot()
+      # No stamped ops since (a CREATE-only append doesn't move the
+      # watermark): the second snapshot must not delete-and-rewrite the only
+      # retained snapshot -- a crash mid-replace would lose it.
+      discard EdValue[int].init(ctx = a, id = "p21_extra")
+      let second = a.snapshot()
+      check second == first
+      check file_exists(first / "manifest.json")
+      a.destroy()
+
+      var b = EdContext.init(id = "p21_auth", is_authority = true)
+      b.open_store(path)
+      check EdValue[int](b["p21_value"]).value == 1
+      check "p21_extra" in b # CREATE-only tail replays over the kept snapshot
+      b.destroy()
+
+    test "a non-upstream peer can't reset the frontier with a hostile epoch":
+      var leader = EdContext.init(id = "p22_auth", is_authority = true)
+      var follower = EdContext.init(id = "p22_follower")
+      follower.subscribe(leader)
+      var value = EdValue[int].init(ctx = leader, id = "p22_value")
+      for i in 1 .. 3:
+        value.value = i
+      follower.tick()
+      check follower.applied_lsn == 3
+
+      # A stamped op claiming a huge epoch, from a source that is not our
+      # upstream: the frontier must hold, or redelivered delta ops below it
+      # would re-apply (duplicated seq/set items).
+      var hostile = Message(
+        kind: ASSIGN,
+        object_id: "p22_value",
+        lsn: 1,
+        epoch: int64.high,
+        origin: "stranger",
+      )
+      hostile.source_set = ["stranger"].to_hash_set
+      follower.process_message(hostile)
+      check follower.applied_lsn == 3 # unchanged
+      check follower.seen_epoch < int64.high
+      leader.destroy()
+      follower.destroy()
+
+    test "clear raises on a store-backed authority":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p23_auth", is_authority = true)
+      a.open_store(path)
+      expect StoreError:
+        a.clear()
+      a.destroy()
+
+    test "destroy tombstone survives restore; same-id recreate replays":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p13_auth", is_authority = true)
+      a.open_store(path)
+      var doomed = EdValue[int].init(ctx = a, id = "p13_doomed")
+      doomed.value = 1
+      a.snapshot()
+      doomed.destroy() # tail op
+      var phoenix = EdValue[int].init(ctx = a, id = "p13_phoenix")
+      phoenix.value = 1
+      phoenix.destroy()
+      var phoenix2 = EdValue[int].init(ctx = a, id = "p13_phoenix")
+      phoenix2.value = 2
+      a.destroy()
+
+      var b = EdContext.init(id = "p13_auth", is_authority = true)
+      b.open_store(path)
+      check "p13_doomed" notin b
+      check "p13_phoenix" in b
+      check EdValue[int](b["p13_phoenix"]).value == 2
+      b.destroy()
+
+    test "nested + owned objects restore linked; new follower gets a working replica":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p14_auth", is_authority = true)
+      a.open_store(path)
+      var tbl = EdTable[string, EdSeq[int]].init(ctx = a, id = "p14_tbl")
+      var inner = EdSeq[int].init(ctx = a, id = "p14_inner")
+      tbl["k"] = inner
+      inner.add 42
+      "p14_owner".own:
+        discard EdValue[int].init(ctx = a, id = "p14_owned")
+      a.snapshot()
+      a.destroy()
+
+      var b = EdContext.init(id = "p14_auth", is_authority = true)
+      b.open_store(path)
+      let restored = EdTable[string, EdSeq[int]](b["p14_tbl"])
+      check restored["k"].id == "p14_inner"
+      check not restored["k"].body.placeholder # linked, not a husk
+      check restored["k"][0] == 42
+      check "p14_owner" in b.owned_by # ownership index rebuilt
+      check "p14_owned" in b.owned_by["p14_owner"]
+
+      # A fresh follower subscribing to the restored authority must receive a
+      # dependency-ordered push (exercises the registry re-order).
+      var follower = EdContext.init(id = "p14_follower")
+      follower.subscribe(b)
+      follower.tick()
+      let mirrored = EdTable[string, EdSeq[int]](follower["p14_tbl"])
+      check mirrored["k"][0] == 42
+      b.destroy()
+      follower.destroy()
+
+    test "packed multi-op changes log as one entry and restore":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p15_auth", is_authority = true)
+      a.open_store(path)
+      var t = EdTable[string, int].init(ctx = a, id = "p15_table")
+      t.value = {"a": 1, "b": 2, "c": 3}.to_table # one changeset, packed
+      a.destroy()
+
+      check "\"kind\":\"PACKED\"" in read_log(path)
+
+      var b = EdContext.init(id = "p15_auth", is_authority = true)
+      b.open_store(path)
+      check EdTable[string, int](b["p15_table"]).len == 3
+      check EdTable[string, int](b["p15_table"])["b"] == 2
+      b.destroy()
+
+    test "a follower-originated op is captured exactly once":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var a = EdContext.init(id = "p16_auth", is_authority = true)
+      a.open_store(path)
+      var follower = EdContext.init(id = "p16_follower")
+      follower.subscribe(a)
+      var s = EdSeq[int].init(ctx = a, id = "p16_seq")
+      follower.tick()
+      EdSeq[int](follower["p16_seq"]).add 42
+      a.tick() # authority orders + appends the follower's op
+      follower.tick()
+
+      check read_log(path).count("\"origin\":\"p16_follower\"") == 1
+      a.destroy()
+      follower.destroy()
+
+      var b = EdContext.init(id = "p16_auth", is_authority = true)
+      b.open_store(path)
+      check EdSeq[int](b["p16_seq"]).len == 1
+      b.destroy()
+
+    test "open_store guards: non-authority, non-empty, stale tmp dirs":
+      let path = store_dir()
+      defer:
+        remove_dir(path)
+      var follower = EdContext.init(id = "p17_follower")
+      expect AssertionDefect:
+        follower.open_store(path)
+
+      var busy = EdContext.init(id = "p17_busy", is_authority = true)
+      discard EdValue[int].init(ctx = busy, id = "p17_value")
+      expect AssertionDefect:
+        busy.open_store(path)
+      busy.destroy()
+
+      # A crashed-mid-snapshot tmp dir is deleted and ignored on open.
+      create_dir(path / "snapshots" / "tmp-000000000000009")
+      write_file(path / "snapshots" / "tmp-000000000000009" / "junk", "x")
+      var a = EdContext.init(id = "p17_auth", is_authority = true)
+      a.open_store(path)
+      check not dir_exists(path / "snapshots" / "tmp-000000000000009")
+      a.destroy()
+
+    test "entry format: roundtrip, crc rejection, forward compat":
+      var msg = Message(
+        kind: ASSIGN,
+        object_id: "obj-1",
+        type_id: 12345,
+        obj: "\x00\x01\xff binary \n bytes",
+        key_bin: "\xde\xad",
+        flags: {SYNC_LOCAL, SYNC_REMOTE},
+        epoch: 2,
+        lsn: 43,
+        op_id: 7,
+        origin: "ctx-a",
+        delta: true,
+      )
+      let line = msg.to_entry_line
+      let (ok, parsed) = parse_entry(line)
+      check ok
+      check parsed.kind == ASSIGN
+      check parsed.object_id == "obj-1"
+      check parsed.obj == msg.obj
+      check parsed.key_bin == msg.key_bin
+      check parsed.flags == msg.flags
+      check parsed.epoch == 2
+      check parsed.lsn == 43
+      check parsed.op_id == 7
+      check parsed.origin == "ctx-a"
+      check parsed.delta
+
+      # Any corrupted byte fails the crc.
+      var corrupt = line
+      corrupt[10] = if corrupt[10] == 'x': 'y' else: 'x'
+      check not parse_entry(corrupt).ok
+
+      # Unknown fields from a future writer are tolerated (crc intact).
+      let idx = line.rfind(",\"crc\":\"")
+      let extended = line[0 ..< idx] & ",\"future\":1"
+      let resealed =
+        extended & ",\"crc\":\"" & crc32_hex(extended) & "\"}"
+      check parse_entry(resealed).ok
+
+    test "manifest format: roundtrip + platform guard":
+      var m = Manifest.init(epoch = 2, lsn = 42, op_id_counter = 17)
+      m.objects.add ManifestEntry(
+        file: "obj-000001-x.json", oid: "x", tid: 99, crc: "deadbeef"
+      )
+      let (ok, parsed) = parse_manifest(m.to_manifest)
+      check ok
+      check parsed.lsn == 42
+      check parsed.op_id_counter == 17
+      check parsed.objects.len == 1
+      check parsed.objects[0].oid == "x"
+      check parsed.platform_ok
+
+      var alien = m
+      alien.endian = "mixed"
+      let (ok2, parsed2) = parse_manifest(alien.to_manifest)
+      check ok2
+      check not parsed2.platform_ok
+
+when is_main_module:
+  Ed.bootstrap
+  run()

--- a/tests/tests.nim
+++ b/tests/tests.nim
@@ -3,7 +3,7 @@ import
   object_tests, utils_tests, validation_tests, error_handling_tests, memory_tests,
   lsn_tests, client_tests, partial_tests, capability_tests, materialize_tests,
   lifetime_tests, ctx_teardown_tests, wire_hardening_tests,
-  seq_positional_tests
+  seq_positional_tests, persistence_tests
 
 Ed.bootstrap
 
@@ -25,3 +25,4 @@ lifetime_tests.run()
 ctx_teardown_tests.run()
 wire_hardening_tests.run()
 seq_positional_tests.run()
+persistence_tests.run()

--- a/tests/utils_tests.nim
+++ b/tests/utils_tests.nim
@@ -1,6 +1,6 @@
 import std/[unittest, monotimes, tables, strutils]
 import ed
-import ed/utils/[stats, misc, typeids]
+import ed/utils/[stats, misc, typeids, crc32]
 from std/times import seconds, init_duration
 
 proc run*() =
@@ -95,6 +95,13 @@ proc run*() =
 
     # Test maybe_dump_stats (won't actually dump in test)
     maybe_dump_stats()
+
+  test "crc32 known vectors":
+    check:
+      crc32("123456789") == 0xcbf43926'u32
+      crc32("") == 0'u32
+      crc32("The quick brown fox jumps over the lazy dog") == 0x414fa339'u32
+      crc32_hex("123456789") == "cbf43926"
 
   test "type IDs":
     type


### PR DESCRIPTION
Lands roadmap **Phase 2** (docs/consistency-and-partial-sync-plan.md): the authority appends its canonical op stream to a durable, git-shaped store — append-only JSONL log segments + per-object snapshot directories — restores from snapshot + tail on restart, and serves read-only historical views via `EdContext.replay(path, lsn)`. Design + rationale: **docs/persistence.md**.

## Highlights
- **Append at the stamp point**, between `stamp_lsn` and fanout; the store is a permanently-eligible subscriber, so a headless authority still captures its ops. CREATEs log once at the creation event, never in per-subscriber `publish_create`.
- **`ctx.replaying`** bypasses the loopback/own-op guards during restore (entries carry our own origin — the delta short-circuit would otherwise drop every self-originated collection op) and suppresses publish/stamp/append. The LSN frontier stays active, making double-covered segments idempotent.
- **`Message.epoch` is now real**: bumped per store open, stamped on ordered ops; a follower seeing a higher epoch *from an upstream* resets its frontier, closing the fanout-before-durable crash window under the default `FlushPerTick` durability.
- **Snapshot discipline**: tmp dir + fsync + atomic rename, manifest written last; a valid snapshot at the current watermark is kept, never delete-then-replaced; restore refuses truncated history (`StoreError`) instead of silently canonizing a near-empty world.
- Reserve-now slots baked into the format: entry `v`/`txn`/`commit`, manifest `schema`, `codec` seam for a future human-readable payload codec, platform (endian/int-width) guard.
- Incidental fix: `log_defaults` dereferenced a nil thread ctx on threads using only explicit contexts.

## Verification
- `nimble test` 195/195 (22 new persistence cases: torn-tail vs mid-file corruption, hostile-epoch trust gate, same-id recreate replay, nested/owned restore + fresh-follower push, exactly-once follower capture, ...)
- ASan build clean (194/194, zero errors)
- E2E: authority process `kill -9`'d mid-stream → committed ops survived, un-ticked tail correctly lost, epoch bumped, time-travel view correct, network follower re-synced from the restored authority
- A high-effort multi-agent review ran on the diff; all 9 code findings (2 data-loss, 1 hostile-input, 2 crash/perf regressions, 4 cleanups) are fixed with regression tests

## Deferred (deliberately)
Serving fetch misses from the log (lands with authority eviction), TypeSchema / structure-aware tids (slots reserved), the ack/commit callback, git integration itself. Known pre-existing gap documented in persistence.md: the single-subscriber return-to-source echo violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o1niF74BvbfxYU1oWEQ38