### PR TITLE
Give ed contexts globally-unique ids; EdClient uses the thread context

### DIFF
--- a/src/ed/client.nim
+++ b/src/ed/client.nim
@@ -48,8 +48,8 @@ type EdClient* = ref object
     ## wants units render-ready; a narrow utility fetches what it touches).
   on_connect*: proc()
     ## (Re)create this client's objects after each (re)connect. Runs with
-    ## `Ed.thread_ctx` set to the fresh context. Single-threaded -- runs on
-    ## the caller's thread, so it may touch the caller's globals.
+    ## `Ed.thread_ctx` set to this client's live context. Single-threaded --
+    ## runs on the caller's thread, so it may touch the caller's globals.
   ctx*: EdContext
   prev*: EdContext
     ## The session before the current one (one generation only). Each reconnect
@@ -63,33 +63,54 @@ type EdClient* = ref object
   last_attempt: MonoTime
 
 proc reconnect*(self: EdClient): EdClient {.discardable.} =
-  ## (Re)create the context with the stable `id`, subscribe to `address`,
-  ## and run `on_connect`. Resilient: if the peer is unreachable the new
-  ## context simply has no subscribers, so a later `tick` retries. Returns
-  ## `self` so it can be chained (`EdClient(...).reconnect`).
+  ## Establish (or re-establish) this client's context, subscribe to `address`,
+  ## and run `on_connect`. Resilient: if the peer is unreachable the context
+  ## simply has no subscribers, so a later `tick` retries. Returns `self` so it
+  ## can be chained (`EdClient(...).reconnect`).
   ##
   ## `connect` is an alias; both are plain procs callable anywhere (including
   ## inside a `unittest` `test` block). Type initializers self-register at
   ## program startup (see `create_initializer`), so there's no bootstrap step.
   ## The reconnect paths (`tick`/`online`) drive this.
   ##
-  ## The context is NOT reused across reconnects: an existing object's CREATE
-  ## never re-broadcasts, so a restarted peer would never learn about this
-  ## client's objects -- they'd survive locally as ghosts whose ops the peer
-  ## skips. Same-session resync is the body-persistence/revive work, not a
-  ## client-side trick.
+  ## First connect vs reconnect -- the context handling deliberately differs:
+  ##
+  ## * FIRST connect uses the thread's context (`Ed.thread_ctx`) rather than
+  ##   minting one and clobbering it, and inherits its `id` as this client's
+  ##   stable identity. The default thread context now carries a globally-unique
+  ##   id (see `EdContext.init`), so it's safe to adopt as a network identity. A
+  ##   caller that pins an explicit `id` still wins: if it differs from the
+  ##   thread context's, a context under that id is installed as the thread
+  ##   context (keeps id-driven callers -- e.g. the MCP server -- unchanged).
+  ##
+  ## * A genuine RECONNECT (this client already has a live context) is NOT
+  ##   allowed to reuse it: an existing object's CREATE never re-broadcasts, so
+  ##   a restarted peer would never learn about this client's objects -- they'd
+  ##   survive locally as ghosts whose ops the peer skips. So a reconnect always
+  ##   mints a FRESH context under the same stable `id`; the peer recognizes and
+  ##   supersedes the prior session by that id. Same-session resync is the
+  ##   body-persistence/revive work, not a client-side trick.
+  ##
+  ## Either way `Ed.thread_ctx` ends up pointing at this client's live context,
+  ## so `on_connect` and app helpers that read it see the right one.
   result = self
-  # Mint a stable id on first use if the caller didn't supply one, so it
-  # survives reconnects (the peer recognizes and supersedes the prior
-  # session by id).
-  if self.id == "":
-    self.id = generate_id()
   self.last_attempt = get_mono_time()
-  if not self.ctx.is_nil:
+  if self.ctx.is_nil:
+    # FIRST connect: use the thread context. Honor a caller-pinned id by
+    # installing a context under it; otherwise adopt whatever the thread has.
+    if self.id != "" and Ed.thread_ctx.id != self.id:
+      Ed.thread_ctx = EdContext.init(id = self.id)
+    self.ctx = Ed.thread_ctx
+  else:
+    # RECONNECT: retire the current context and mint a fresh one under the same
+    # stable id, then point the thread at it.
     self.ctx.close
     self.prev = self.ctx
-  self.ctx = EdContext.init(buffer = false, id = self.id)
-  Ed.thread_ctx = self.ctx
+    self.ctx = EdContext.init(id = self.id)
+    Ed.thread_ctx = self.ctx
+  # A stable id survives reconnects (the peer supersedes the prior session by
+  # id); align it with the context we settled on.
+  self.id = self.ctx.id
   try:
     # subscribe sets ctx.sync_mode from `mode` (PARTIAL => blocking reads)
     self.ctx.subscribe(

--- a/src/ed/zens/contexts.nim
+++ b/src/ed/zens/contexts.nim
@@ -63,7 +63,12 @@ proc len*(self: EdContext): int =
 
 proc init*(
     _: type EdContext,
-    id = "thread-" & $get_thread_id(),
+    # A context id doubles as this context's identity on the wire (see
+    # `subscribe`, which sends it as the subscriber's `ctx_id`), so the default
+    # must be globally unique -- a bare thread id collides across processes and
+    # isn't stable across runs. Keep the `thread-<id>` prefix for readable logs,
+    # then append a unique suffix.
+    id = "thread-" & $get_thread_id() & "-" & generate_id(),
     listen_address = "",
     blocking_recv = false,
     chan_size = 100,
@@ -117,7 +122,7 @@ proc init*(
 proc thread_ctx*(t: type Ed): EdContext =
   ## Get the current thread's `EdContext`. Creates one if it doesn't exist.
   if active_ctx == nil:
-    active_ctx = EdContext.init(id = "thread-" & $get_thread_id())
+    active_ctx = EdContext.init()
   active_ctx
 
 proc thread_ctx*(_: type EdBase): EdContext =

--- a/tests/client_tests.nim
+++ b/tests/client_tests.nim
@@ -1,5 +1,5 @@
 import test_util
-import std/[unittest, atomics, os]
+import std/[unittest, atomics, os, strutils]
 import ed
 import ed/types {.all.}
 
@@ -156,6 +156,63 @@ proc run*() =
     defer:
       stop_server()
     check client.tick_until(10.seconds, client.connected)
+
+  test "first connect adopts the thread default instead of clobbering it":
+    start_server()
+    defer:
+      stop_server()
+
+    # A context the caller set up as the thread default.
+    let default_ctx = EdContext.init(id = "adopt-me")
+    Ed.thread_ctx = default_ctx
+
+    # An id-agnostic client: no explicit id.
+    let client = EdClient(address: test_address)
+    client.reconnect
+
+    # It adopted the existing thread default rather than minting a new one, and
+    # took that context's id as its stable identity. The thread default is
+    # untouched (still the same object).
+    check client.ctx == default_ctx
+    check client.id == "adopt-me"
+    check Ed.thread_ctx == default_ctx
+
+    # A genuine reconnect still mints a FRESH context under the adopted id (the
+    # adopted context becomes `prev`).
+    client.reconnect
+    check client.ctx != default_ctx
+    check client.prev == default_ctx
+    check client.id == "adopt-me"
+    check Ed.thread_ctx == client.ctx
+
+  test "a caller-pinned id wins over the thread default and is installed as it":
+    start_server()
+    defer:
+      stop_server()
+
+    # A thread default with a different id must NOT be adopted when the caller
+    # pinned a specific id -- that stays backward-compatible with id-driven
+    # callers (e.g. the MCP server). The pinned context is promoted to the
+    # thread default so on_connect/app helpers read the right context.
+    let default_ctx = EdContext.init(id = "some-other-default")
+    Ed.thread_ctx = default_ctx
+
+    let client = EdClient(id: "pinned-id", address: test_address)
+    client.reconnect
+
+    check client.ctx != default_ctx
+    check client.ctx.id == "pinned-id"
+    check client.id == "pinned-id"
+    check Ed.thread_ctx == client.ctx
+
+  test "the default context id is globally unique, not a bare thread id":
+    # A context id doubles as its identity on the wire, so two default contexts
+    # (e.g. one per process) must not collide. The `thread-<id>` prefix stays for
+    # readable logs; a unique suffix makes the whole id distinct.
+    let a = EdContext.init()
+    let b = EdContext.init()
+    check a.id != b.id
+    check a.id.starts_with("thread-")
 
 when is_main_module:
   Ed.bootstrap


### PR DESCRIPTION
## Problem

A context's id doubles as its identity on the wire: `subscribe` sends it as the subscriber's `ctx_id`, and the peer keys sessions on it (dedup, eviction, paging, supersession). But the default context id was `thread-<thread_id>` — neither globally unique (two processes can share a thread id) nor stable across runs.

To avoid handing that thread-derived id to the peer as a network identity, `EdClient.reconnect` minted a fresh `generate_id()` context on **every** connect and overwrote `Ed.thread_ctx`, discarding whatever context the thread already had (orphaning any pre-connect objects).

## Fix (at the source)

Make the default context id globally unique: `thread-<thread_id>-<unique>`. The `thread-…` prefix stays for readable logs, but the id is now safe to put on the wire by construction — for `EdClient` and any future networked context alike.

With that, the client no longer needs to clobber:

- **First connect** uses `Ed.thread_ctx` (adopting its now-unique id) instead of minting-and-clobbering. A caller-pinned `id` still wins — a context under that id is installed as the thread context — so id-driven callers (e.g. the MCP server) are byte-for-byte unchanged.
- **Reconnect** still mints a **fresh** context under the same stable id. An existing object's CREATE never re-broadcasts, so reusing a context would strand this client's objects as ghosts a restarted peer never learns about; the peer supersedes the prior session by id.

Either way `Ed.thread_ctx` ends up pointing at the client's live context, so `on_connect` and app helpers that read it see the right one.

## Removed

- `EdClient.ctx_override` — a caller-supplied context can't survive a reconnect (which always mints fresh), so it went stale on the first dropped link. Speculative and unused.
- `EdContext.closed` and `Ed.thread_ctx_or_nil` — only existed to support the old adopt-or-mint branching.

## Compatibility

No caller changes. Enu already gives every context it creates a unique explicit id (`main-…`, `work-…`, `enu_mcp-…`); the thread-derived default was the only non-unique one. Nothing in ed or Enu parses or prefix-matches a context id — all id usage is equality / set-membership.

## Tests

`tests/client_tests.nim`: first connect adopts the thread default (reconnect still mints fresh); a caller-pinned id wins and is installed as the thread default; the default context id is globally unique. Full `tests/tests.nim` passes.